### PR TITLE
Fix/Handle circular references when censoring logs

### DIFF
--- a/src/util/logger.ts
+++ b/src/util/logger.ts
@@ -128,7 +128,14 @@ export const loggingContextMiddleware = (
 // Obj is typed as "any" because it could be a variety of structures in the logger
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function censor(obj: any, censorList: CensorKeyValue[]) {
-  let stringified = JSON.stringify(obj)
+  let stringified = ''
+  try {
+    // JSON.stringify(obj) will fail if obj contains a circular reference.
+    // If it fails, we fall back to replacing it with "[Unknown]".
+    stringified = JSON.stringify(obj)
+  } catch (e) {
+    return '[Unknown]'
+  }
   censorList.forEach((entry) => {
     stringified = stringified.replace(entry.value, `[${entry.key} REDACTED]`)
   })

--- a/test/logger.test.ts
+++ b/test/logger.test.ts
@@ -74,3 +74,12 @@ test('Test color factory', async (t) => {
   // Test that the colors cycle back
   t.is(nextColor(), COLORS[0])
 })
+
+test('properly handle circular references', async (t) => {
+  const a = {
+    b: {},
+  }
+  a.b = a
+  const log = censor(a, CensorList.getAll())
+  t.is(log, '[Unknown]')
+})


### PR DESCRIPTION
### Closes [PDI-182](https://smartcontract-it.atlassian.net/browse/PDI-182)

- Applies the same approach to handling circular references when censoring logs as monorepo