### PR TITLE
Initialize metrics earlier

### DIFF
--- a/src/adapter/basic.ts
+++ b/src/adapter/basic.ts
@@ -99,6 +99,9 @@ export class Adapter<CustomSettings extends CustomAdapterSettings = SettingsMap>
       throw new Error('This adapter has already been initialized!')
     }
 
+    // Initialize metrics to register them with the prom-client
+    metrics.initialize()
+
     // Building configs during initialization to avoid validation errors during construction
     validateAdapterConfig(this.config, this.customSettings)
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@ import { join } from 'path'
 import { Adapter, AdapterDependencies } from './adapter'
 import { callBackgroundExecutes } from './background-executor'
 import { AdapterConfig, SettingsMap } from './config'
-import { buildMetricsMiddleware, metrics, setupMetricsServer } from './metrics'
+import { buildMetricsMiddleware, setupMetricsServer } from './metrics'
 import { AdapterRouteGeneric, loggingContextMiddleware, makeLogger } from './util'
 import { loadTestPayload } from './util/test-payload-loader'
 import { errorCatchingMiddleware, validatorMiddleware } from './validation'
@@ -69,9 +69,6 @@ export const expose = async <T extends SettingsMap = SettingsMap>(
   await adapter.initialize(dependencies)
 
   let api: FastifyInstance | undefined = undefined
-
-  // Initialize metrics to register them with the prom-client
-  metrics.initialize()
 
   if (adapter.config.METRICS_ENABLED && adapter.config.EXPERIMENTAL_METRICS_ENABLED) {
     setupMetricsServer(adapter.name, adapter.config as AdapterConfig)


### PR DESCRIPTION
Metrics were getting initialized after Redis cache which uses metrics on open and retry connection. Moved metrics initialization before adapter dependency initialization.

Issue brought up [here](https://chainlink-core.slack.com/archives/C01URRHMM35/p1674174256335479?thread_ts=1674171364.273049&cid=C01URRHMM35)