### PR TITLE
Export ProviderRequestConfig & WebsocketTransportGenerics

### DIFF
--- a/src/transports/http.ts
+++ b/src/transports/http.ts
@@ -37,8 +37,8 @@ type HttpTransportGenerics = TransportGenerics & {
 /**
  * Structure containing the association between EA params and a provider request.
  */
-type ProviderRequestConfig<T extends HttpTransportGenerics> = {
-  /** The input paramters for requests that will get responses from the request in this struct */
+export type ProviderRequestConfig<T extends HttpTransportGenerics> = {
+  /** The input parameters for requests that will get responses from the request in this struct */
   params: T['Request']['Params'][]
 
   /** The request that will be sent to the data provider to fetch values for the params in this struct */

--- a/src/transports/websocket.ts
+++ b/src/transports/websocket.ts
@@ -92,7 +92,7 @@ export interface WebSocketTransportConfig<T extends WebsocketTransportGenerics> 
  * Helper struct type that will be used to pass types to the generic parameters of a Transport.
  * Extends the common TransportGenerics, adding Provider specific types for this WS endpoint.
  */
-type WebsocketTransportGenerics = TransportGenerics & {
+export type WebsocketTransportGenerics = TransportGenerics & {
   /**
    * Type details for any provider specific interfaces.
    */


### PR DESCRIPTION
We used to export ProviderRequestConfig previously, now we don't. This PR we don't don't export.

It helps typing EAs.