### PR TITLE
Fix excessive debug/trace logging

### DIFF
--- a/src/adapter/basic.ts
+++ b/src/adapter/basic.ts
@@ -304,7 +304,7 @@ export class Adapter<CustomSettings extends CustomAdapterSettings = SettingsMap>
 
     if (perSecRateLimit > highestTierValue) {
       logger.warn(
-        `The configured RATE_LIMIT_CAPACITY_SECOND value is higher than the highest tier value from limits.json ${highestTierValue}`,
+        `The configured RATE_LIMIT_CAPACITY_SECOND value is higher than the highest tier value in the adapter rate limiting configurations ${highestTierValue}`,
       )
     }
 
@@ -314,7 +314,7 @@ export class Adapter<CustomSettings extends CustomAdapterSettings = SettingsMap>
           ? 'RATE_LIMIT_CAPACITY_MINUTE'
           : 'RATE_LIMIT_CAPACITY'
       }
-      value is higher than the highest tier value from limits.json ${highestTierValue}`)
+      value is higher than the highest tier value the adapter rate limiting configurations ${highestTierValue}`)
     }
 
     if (!dependencies.rateLimiter) {

--- a/src/config/provider-limits.ts
+++ b/src/config/provider-limits.ts
@@ -61,14 +61,14 @@ const getProviderLimits = (
   const providerConfig = parseLimits(limits)
   if (!providerConfig) {
     throw new Error(
-      `Rate Limit: Provider: "${provider}" doesn't match any provider spec in limits.json`,
+      `Rate Limit: Provider: "${provider}" doesn't match any provider spec in the adapter rate limiting configurations`,
     )
   }
 
   const protocolConfig = providerConfig[protocol]
   if (!protocolConfig) {
     throw new Error(
-      `Rate Limit: "${provider}" doesn't have any configuration for ${protocol} in limits.json`,
+      `Rate Limit: "${provider}" doesn't have any configuration for ${protocol} in the adapter rate limiting configurations`,
     )
   }
 
@@ -83,7 +83,7 @@ const getProviderLimits = (
 
   if (!limitsConfig) {
     throw new Error(
-      `Rate Limit: Provider: "${provider}" has no tiers defined for ${protocol} in limits.json`,
+      `Rate Limit: Provider: "${provider}" has no tiers defined for ${protocol} in the adapter rate limiting configurations`,
     )
   }
 

--- a/src/transports/websocket.ts
+++ b/src/transports/websocket.ts
@@ -247,6 +247,7 @@ export class WebSocketTransport<
     // No new subs && connection -> unsubs only
     if (!subscriptions.new.length && !this.wsConnection) {
       logger.debug('No entries in subscription set and no established connection, skipping')
+      await sleep(context.adapterConfig.BACKGROUND_EXECUTE_MS_WS)
       return
     }
 

--- a/test/metrics/ws-metrics.test.ts
+++ b/test/metrics/ws-metrics.test.ts
@@ -217,7 +217,7 @@ test.serial('Test WS connection, subscription, and message metrics', async (t) =
   t.is(metricsMap.get(`ws_subscription_total{${feed},${basic}}`), 1)
   t.is(metricsMap.get(`ws_message_total{${feed},direction="sent",${basic}}`), 1)
   t.is(metricsMap.get(`ws_message_total{direction="received",${basic}}`), 1)
-  t.is(metricsMap.get(`bg_execute_total{${endpoint},${basic}}`), 3)
+  t.is(metricsMap.get(`bg_execute_total{${endpoint},${basic}}`), 2)
   t.is(metricsMap.get(`bg_execute_subscription_set_count{${endpoint},${transport},${basic}}`), 1)
 
   const responseTime = metricsMap.get(`bg_execute_duration_seconds{${endpoint},${basic}}`)
@@ -257,6 +257,6 @@ test.serial('Test WS connection, subscription, and message metrics', async (t) =
   metricsMap = parsePromMetrics(response.data)
 
   t.is(metricsMap.get(`ws_connection_active{${basic}}`), 0)
-  t.is(metricsMap.get(`bg_execute_total{${endpoint},${basic}}`), 7)
+  t.is(metricsMap.get(`bg_execute_total{${endpoint},${basic}}`), 6)
   t.is(metricsMap.get(`bg_execute_subscription_set_count{${endpoint},${transport},${basic}}`), 0)
 })

--- a/test/transports/http.test.ts
+++ b/test/transports/http.test.ts
@@ -355,7 +355,7 @@ test.serial(
 )
 
 test.serial(
-  'per second limit of 1 with two batch transports that make the same request results in a call every 1000ms for each, since the requests will coalesce',
+  'per second limit of 1 with two batch transports that make the same request results in a call every 2000ms for each',
   async (t) => {
     const rateLimit1s = 1
     const transportA = new MockHttpTransport(true)


### PR DESCRIPTION
The websocket background execute doesn't sleep when there are no new subs and there is no established connection. This causes the logs to get flooded with statements every 1ms making it hard to debug any issues.