### PR TITLE
Add test utilities, refactor

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -99,4 +99,12 @@ module.exports = {
     'symbol-description': 'error',
     yoda: 'error',
   },
+  overrides: [
+    {
+      files: ['./test/**/*.ts'],
+      rules: {
+        'require-atomic-updates': 'off',
+      },
+    },
+  ],
 }

--- a/package.json
+++ b/package.json
@@ -68,8 +68,7 @@
     ],
     "workerThreads": false,
     "environmentVariables": {
-      "METRICS_ENABLED": "false",
-      "FRAMEWORK_TESTING": "true"
+      "METRICS_ENABLED": "false"
     },
     "timeout": "20s"
   }

--- a/package.json
+++ b/package.json
@@ -68,7 +68,8 @@
     ],
     "workerThreads": false,
     "environmentVariables": {
-      "METRICS_ENABLED": "false"
+      "METRICS_ENABLED": "false",
+      "FRAMEWORK_TESTING": "true"
     },
     "timeout": "20s"
   }

--- a/src/background-executor.ts
+++ b/src/background-executor.ts
@@ -73,7 +73,7 @@ export async function callBackgroundExecutes(adapter: Adapter, apiShutdownPromis
           },
         )
       } catch (error) {
-        logger.error(error)
+        logger.error(error, (error as Error).stack)
       }
 
       // This background execute loop is no longer the one to determine the sleep between bg execute calls.

--- a/src/index.ts
+++ b/src/index.ts
@@ -86,18 +86,21 @@ export const expose = async <T extends SettingsMap = SettingsMap>(
       api?.addHook('onClose', async () => resolve())
     })
 
-    // Start listening for incoming requests
-    try {
-      await api.listen({
-        port: adapter.config.EA_PORT,
-        host: adapter.config.EA_HOST,
-      })
-    } catch (err) {
-      logger.fatal(`There was an error when starting the EA server: ${err}`)
-      process.exit()
-    }
+    // Tests will not use the port
+    if (!(process.env['FRAMEWORK_TESTING'] === 'true')) {
+      // Start listening for incoming requests
+      try {
+        await api.listen({
+          port: adapter.config.EA_PORT,
+          host: adapter.config.EA_HOST,
+        })
+      } catch (err) {
+        logger.fatal(`There was an error when starting the EA server: ${err}`)
+        process.exit()
+      }
 
-    logger.info(`Listening on port ${(api.server.address() as AddressInfo).port}`)
+      logger.info(`Listening on port ${(api.server.address() as AddressInfo).port}`)
+    }
   } else {
     logger.info('REST API is disabled; this instance will not process incoming requests.')
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -55,10 +55,13 @@ export const getMTLSOptions = (config: AdapterConfig) => {
  * @param dependencies - an optional object with adapter dependencies to inject
  * @returns a Promise that resolves to the http.Server listening for connections
  */
-export const expose = async <T extends SettingsMap = SettingsMap>(
+export const start = async <T extends SettingsMap = SettingsMap>(
   adapter: Adapter<T>,
   dependencies?: Partial<AdapterDependencies>,
-): Promise<FastifyInstance | undefined> => {
+): Promise<{
+  api: FastifyInstance | undefined
+  metricsApi: FastifyInstance | undefined
+}> => {
   if (!(adapter instanceof Adapter)) {
     throw new Error(
       'The adapter has not been initialized as an instance of the Adapter class, exiting.',
@@ -69,9 +72,10 @@ export const expose = async <T extends SettingsMap = SettingsMap>(
   await adapter.initialize(dependencies)
 
   let api: FastifyInstance | undefined = undefined
+  let metricsApi: FastifyInstance | undefined = undefined
 
   if (adapter.config.METRICS_ENABLED && adapter.config.EXPERIMENTAL_METRICS_ENABLED) {
-    setupMetricsServer(adapter.name, adapter.config as AdapterConfig)
+    metricsApi = setupMetricsServer(adapter.name, adapter.config as AdapterConfig)
   }
 
   // Optional Promise to indicate that the API is shutting down (for us to close background executors)
@@ -85,22 +89,6 @@ export const expose = async <T extends SettingsMap = SettingsMap>(
     apiShutdownPromise = new Promise<void>((resolve) => {
       api?.addHook('onClose', async () => resolve())
     })
-
-    // Tests will not use the port
-    if (!(process.env['FRAMEWORK_TESTING'] === 'true')) {
-      // Start listening for incoming requests
-      try {
-        await api.listen({
-          port: adapter.config.EA_PORT,
-          host: adapter.config.EA_HOST,
-        })
-      } catch (err) {
-        logger.fatal(`There was an error when starting the EA server: ${err}`)
-        process.exit()
-      }
-
-      logger.info(`Listening on port ${(api.server.address() as AddressInfo).port}`)
-    }
   } else {
     logger.info('REST API is disabled; this instance will not process incoming requests.')
   }
@@ -115,6 +103,37 @@ export const expose = async <T extends SettingsMap = SettingsMap>(
     )
   }
 
+  return { api, metricsApi }
+}
+
+export const expose = async <T extends SettingsMap = SettingsMap>(
+  adapter: Adapter<T>,
+  dependencies?: Partial<AdapterDependencies>,
+): Promise<FastifyInstance | undefined> => {
+  const { api, metricsApi } = await start(adapter, dependencies)
+
+  const exposeApp = async (app: FastifyInstance | undefined, host: string, port: number) => {
+    if (app) {
+      try {
+        await app.listen({ port, host })
+      } catch (err) {
+        logger.fatal(`There was an error when starting the server: ${err}`)
+        process.exit()
+      }
+
+      logger.info(`Listening on port ${(app.server.address() as AddressInfo).port}`)
+    }
+  }
+
+  const metricsUrl = adapter.config.METRICS_USE_BASE_URL
+    ? join(adapter.config.BASE_URL, 'metrics')
+    : '/metrics'
+
+  // Start listening for incoming requests
+  await exposeApp(api, adapter.config.EA_HOST, adapter.config.EA_PORT)
+  await exposeApp(metricsApi, metricsUrl, adapter.config.METRICS_PORT)
+
+  // We return only the main API to maintain backwards compatibility
   return api
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -112,10 +112,10 @@ export const expose = async <T extends SettingsMap = SettingsMap>(
 ): Promise<FastifyInstance | undefined> => {
   const { api, metricsApi } = await start(adapter, dependencies)
 
-  const exposeApp = async (app: FastifyInstance | undefined, host: string, port: number) => {
+  const exposeApp = async (app: FastifyInstance | undefined, port: number) => {
     if (app) {
       try {
-        await app.listen({ port, host })
+        await app.listen({ port, host: adapter.config.EA_HOST })
       } catch (err) {
         logger.fatal(`There was an error when starting the server: ${err}`)
         process.exit()
@@ -125,13 +125,9 @@ export const expose = async <T extends SettingsMap = SettingsMap>(
     }
   }
 
-  const metricsUrl = adapter.config.METRICS_USE_BASE_URL
-    ? join(adapter.config.BASE_URL, 'metrics')
-    : '/metrics'
-
   // Start listening for incoming requests
-  await exposeApp(api, adapter.config.EA_HOST, adapter.config.EA_PORT)
-  await exposeApp(metricsApi, metricsUrl, adapter.config.METRICS_PORT)
+  await exposeApp(api, adapter.config.EA_PORT)
+  await exposeApp(metricsApi, adapter.config.METRICS_PORT)
 
   // We return only the main API to maintain backwards compatibility
   return api

--- a/src/metrics/index.ts
+++ b/src/metrics/index.ts
@@ -27,10 +27,7 @@ export function setupMetricsServer(name: string, config: AdapterConfig) {
     res.send(await client.register.metrics())
   })
 
-  metricsApp.listen({
-    port: metricsPort,
-    host: eaHost,
-  })
+  return metricsApp
 }
 
 export const setupMetrics = (name: string): void => {

--- a/src/util/requester.ts
+++ b/src/util/requester.ts
@@ -144,9 +144,7 @@ export class Requester {
     if (overflowedRequest) {
       // If we have overflow, it means the oldest request needs to be rejected because the queue is at its limits
       logger.debug(
-        `Request (Key: ${key}, Retry #: ${0}) was removed from the queue to make room for a newer one (Size: ${
-          this.queue.length
-        })`,
+        `Request (Key: ${overflowedRequest.key}, Retry #: ${overflowedRequest.retries}) was removed from the queue to make room for a newer one (Size: ${this.queue.length})`,
       )
       metrics.get('requesterQueueOverflow').inc()
       overflowedRequest.reject(
@@ -154,6 +152,7 @@ export class Requester {
           message:
             'The EA was unable to execute the request to fetch the requested data from the DP because the request queue overflowed. This likely indicates that a higher API tier is needed.',
           statusCode: 429,
+          msUntilNextExecution: this.rateLimiter.msUntilNextExecution(),
         }),
       )
     }

--- a/src/validation/error.ts
+++ b/src/validation/error.ts
@@ -85,8 +85,15 @@ export class AdapterInputError extends AdapterError {
   }
 }
 export class AdapterRateLimitError extends AdapterError {
-  constructor(input: Partial<AdapterError>) {
+  msUntilNextExecution: number
+
+  constructor(
+    input: Partial<AdapterError> & {
+      msUntilNextExecution?: number
+    },
+  ) {
     super({ ...input, metricsLabel: HttpRequestType.RATE_LIMIT_ERROR })
+    this.msUntilNextExecution = input.msUntilNextExecution ?? 0
   }
 }
 export class AdapterTimeoutError extends AdapterError {

--- a/test/background-executor.test.ts
+++ b/test/background-executor.test.ts
@@ -1,7 +1,7 @@
-import test from 'ava'
 import FakeTimers from '@sinonjs/fake-timers'
-import { expose } from '../src'
-import { Adapter, EndpointContext, AdapterEndpoint } from '../src/adapter'
+import test from 'ava'
+import { start } from '../src'
+import { Adapter, AdapterEndpoint, EndpointContext } from '../src/adapter'
 import { deferredPromise, NopTransport, NopTransportTypes } from './util'
 
 test('background executor calls transport function with background context', async (t) => {
@@ -29,7 +29,7 @@ test('background executor calls transport function with background context', asy
     ],
   })
 
-  await expose(adapter)
+  await start(adapter)
   const context = await promise
   t.is(context.endpointName, 'test')
 })
@@ -55,12 +55,9 @@ test.serial('background executor ends recursive chain on server close', async (t
     ],
   })
 
-  const server = await expose(adapter)
-  if (!server) {
-    throw 'Server did not start'
-  }
+  const server = await start(adapter)
   t.is(timesCalled, 1)
-  server.close()
+  server.api?.close()
   await clock.tickAsync(999999)
   t.is(timesCalled, 1) // The background process closed, so this was never called again
 

--- a/test/cache/helper.ts
+++ b/test/cache/helper.ts
@@ -124,6 +124,6 @@ export const cacheTests = () => {
     const error = await t.context.testAdapter.request({
       endpoint: 'nowork',
     })
-    t.is(error?.statusCode, 504)
+    t.is(error.statusCode, 504)
   })
 }

--- a/test/cache/local.test.ts
+++ b/test/cache/local.test.ts
@@ -1,8 +1,6 @@
-import { AddressInfo } from 'ws'
-import { expose } from '../../src'
 import { Adapter, AdapterDependencies, AdapterEndpoint } from '../../src/adapter'
 import { CacheFactory, LocalCache } from '../../src/cache'
-import { NopTransport } from '../util'
+import { NopTransport, TestAdapter } from '../util'
 import { BasicCacheSetterTransport, cacheTests, test } from './helper'
 
 test.beforeEach(async (t) => {
@@ -42,11 +40,7 @@ test.beforeEach(async (t) => {
   }
 
   t.context.cache = cache
-  const api = await expose(adapter, dependencies)
-  if (!api) {
-    throw 'Server did not start'
-  }
-  t.context.serverAddress = `http://localhost:${(api.server.address() as AddressInfo).port}`
+  t.context.testAdapter = await TestAdapter.start(adapter, t.context, dependencies)
 })
 
 cacheTests()

--- a/test/cache/redis.test.ts
+++ b/test/cache/redis.test.ts
@@ -53,7 +53,7 @@ test.serial('running adapter throws on cache error', async (t) => {
   }
 
   const error = await t.context.testAdapter.request(data)
-  t.is(error?.statusCode, 500)
+  t.is(error.statusCode, 500)
 })
 
 test.serial('Test cache factory success (redis)', async (t) => {

--- a/test/cache/redis.test.ts
+++ b/test/cache/redis.test.ts
@@ -1,11 +1,8 @@
 import Redis from 'ioredis'
-import { AddressInfo } from 'ws'
-import { expose } from '../../src'
 import { Adapter, AdapterDependencies, AdapterEndpoint } from '../../src/adapter'
 import { CacheFactory, RedisCache } from '../../src/cache'
-import { NopTransport, RedisMock } from '../util'
+import { NopTransport, RedisMock, TestAdapter } from '../util'
 import { BasicCacheSetterTransport, buildDiffResultAdapter, cacheTests, test } from './helper'
-import axios, { AxiosError } from 'axios'
 
 test.beforeEach(async (t) => {
   const adapter = new Adapter({
@@ -44,11 +41,7 @@ test.beforeEach(async (t) => {
   }
 
   t.context.cache = cache
-  const api = await expose(adapter, dependencies)
-  if (!api) {
-    throw 'Server did not start'
-  }
-  t.context.serverAddress = `http://localhost:${(api.server.address() as AddressInfo).port}`
+  t.context.testAdapter = await TestAdapter.start(adapter, t.context, dependencies)
 })
 
 cacheTests()
@@ -59,10 +52,8 @@ test.serial('running adapter throws on cache error', async (t) => {
     factor: 123,
   }
 
-  const error: AxiosError | undefined = await t.throwsAsync(
-    axios.post(`${t.context.serverAddress}`, { data }),
-  )
-  t.is(error?.response?.status, 500)
+  const error = await t.context.testAdapter.request(data)
+  t.is(error?.statusCode, 500)
 })
 
 test.serial('Test cache factory success (redis)', async (t) => {
@@ -96,29 +87,20 @@ test.serial('Test cache key collision across adapters', async (t) => {
   }
 
   t.context.cache = cache
-  const apiA = await expose(adapterA, dependencies)
-  if (!apiA) {
-    throw 'Server did not start'
-  }
-  const addressA = `http://localhost:${(apiA.server.address() as AddressInfo).port}`
-
-  const apiB = await expose(adapterB, dependencies)
-  if (!apiB) {
-    throw 'Server did not start'
-  }
-  const addressB = `http://localhost:${(apiB.server.address() as AddressInfo).port}`
+  const testAdapterA = await TestAdapter.start(adapterA, t.context, dependencies)
+  const testAdapterB = await TestAdapter.start(adapterB, t.context, dependencies)
 
   const data = {
     base: 'eth',
   }
 
   // Populate cache
-  await axios.post(`${addressA}`, { data })
-  await axios.post(`${addressB}`, { data })
+  await testAdapterA.request(data)
+  await testAdapterB.request(data)
 
   // Get results from cache to ensure the cache key is not returning the same response for both adapters
-  const cacheResponseA = await axios.post(`${addressA}`, { data })
-  const cacheResponseB = await axios.post(`${addressB}`, { data })
+  const cacheResponseA = await testAdapterA.request(data)
+  const cacheResponseB = await testAdapterB.request(data)
 
-  t.not(cacheResponseA.data.result, cacheResponseB.data.result)
+  t.not(cacheResponseA.json().result, cacheResponseB.json().result)
 })

--- a/test/logger.test.ts
+++ b/test/logger.test.ts
@@ -1,10 +1,10 @@
 import test from 'ava'
-import { expose } from '../src'
+import { start } from '../src'
 import { Adapter, AdapterEndpoint } from '../src/adapter'
+import { SettingsMap } from '../src/config'
 import CensorList from '../src/util/censor/censor-list'
 import { censor, colorFactory, COLORS } from '../src/util/logger'
 import { NopTransport } from './util'
-import { SettingsMap } from '../src/config'
 
 test.before(async () => {
   const customSettings: SettingsMap = {
@@ -26,7 +26,7 @@ test.before(async () => {
       }),
     ],
   })
-  await expose(adapter)
+  await start(adapter)
 })
 
 test('properly builds censor list', async (t) => {

--- a/test/metrics/helper.ts
+++ b/test/metrics/helper.ts
@@ -4,21 +4,6 @@ import { SettingsMap } from '../../src/config'
 import { HttpTransport } from '../../src/transports'
 import { SingleNumberResultResponse } from '../../src/util'
 
-// Parse metrics scrape into object to use for tests
-export const parsePromMetrics = (data: string): Map<string, number> => {
-  const responseLines = data.split('\n')
-  const metricsMap = new Map<string, number>()
-  responseLines.forEach((line) => {
-    if (!line.startsWith('#') && line !== '') {
-      const metric = line.split(' ')
-      const nameLabel = metric[0]
-      const value = Number(metric[1])
-      metricsMap.set(nameLabel, value)
-    }
-  })
-  return metricsMap
-}
-
 export const buildHttpAdapter = (): Adapter => {
   return new Adapter({
     name: 'TEST',

--- a/test/metrics/metrics.test.ts
+++ b/test/metrics/metrics.test.ts
@@ -5,7 +5,6 @@ import { SettingsMap } from '../../src/config'
 import { retrieveCost } from '../../src/metrics'
 import { HttpTransport } from '../../src/transports'
 import { TestAdapter } from '../util'
-import { parsePromMetrics } from './helper'
 
 const test = untypedTest as TestFn<{
   testAdapter: TestAdapter
@@ -127,15 +126,13 @@ test.serial('Test http requests total metrics (data provider hit)', async (t) =>
 
   await t.context.testAdapter.request({ from, to })
 
-  const response = await t.context.testAdapter.getMetrics()
-  const metricsMap = parsePromMetrics(response)
+  const metricsMap = await t.context.testAdapter.getMetrics()
   const expectedLabel = `{method="POST",feed_id="{\\"from\\":\\"eth\\",\\"to\\":\\"usd\\"}",status_code="200",type="dataProviderHit",provider_status_code="200",app_name="TEST",app_version="${version}"}`
   t.is(metricsMap.get(`http_requests_total${expectedLabel}`), 1)
 })
 
 test.serial('Test http request duration metrics', async (t) => {
-  const response = await t.context.testAdapter.getMetrics()
-  const metricsMap = parsePromMetrics(response)
+  const metricsMap = await t.context.testAdapter.getMetrics()
   const expectedLabel = `{app_name="TEST",app_version="${version}"}`
   const responseTime = metricsMap.get(`http_request_duration_seconds_sum${expectedLabel}`)
   if (responseTime !== undefined) {
@@ -147,15 +144,13 @@ test.serial('Test http request duration metrics', async (t) => {
 })
 
 test.serial('Test data provider requests metrics', async (t) => {
-  const response = await t.context.testAdapter.getMetrics()
-  const metricsMap = parsePromMetrics(response)
+  const metricsMap = await t.context.testAdapter.getMetrics()
   const expectedLabel = `{provider_status_code="200",method="GET",app_name="TEST",app_version="${version}"}`
   t.is(metricsMap.get(`data_provider_requests${expectedLabel}`), 1)
 })
 
 test.serial('Test data provider request duration metrics', async (t) => {
-  const response = await t.context.testAdapter.getMetrics()
-  const metricsMap = parsePromMetrics(response)
+  const metricsMap = await t.context.testAdapter.getMetrics()
   const expectedLabel = `{app_name="TEST",app_version="${version}"}`
   const responseTime = metricsMap.get(`data_provider_request_duration_seconds_sum${expectedLabel}`)
   if (responseTime !== undefined) {
@@ -167,22 +162,19 @@ test.serial('Test data provider request duration metrics', async (t) => {
 })
 
 test.serial('Test cache set count metrics', async (t) => {
-  const response = await t.context.testAdapter.getMetrics()
-  const metricsMap = parsePromMetrics(response)
+  const metricsMap = await t.context.testAdapter.getMetrics()
   const expectedLabel = `{participant_id="TEST-test-{\\"from\\":\\"eth\\",\\"to\\":\\"usd\\"}",feed_id="{\\"from\\":\\"eth\\",\\"to\\":\\"usd\\"}",cache_type="local",app_name="TEST",app_version="${version}"}`
   t.is(metricsMap.get(`cache_data_set_count${expectedLabel}`), 1)
 })
 
 test.serial('Test cache max age metrics', async (t) => {
-  const response = await t.context.testAdapter.getMetrics()
-  const metricsMap = parsePromMetrics(response)
+  const metricsMap = await t.context.testAdapter.getMetrics()
   const expectedLabel = `{participant_id="TEST-test-{\\"from\\":\\"eth\\",\\"to\\":\\"usd\\"}",feed_id="{\\"from\\":\\"eth\\",\\"to\\":\\"usd\\"}",cache_type="local",app_name="TEST",app_version="${version}"}`
   t.is(metricsMap.get(`cache_data_max_age${expectedLabel}`), 90000)
 })
 
 test.serial('Test cache set staleness metrics', async (t) => {
-  const response = await t.context.testAdapter.getMetrics()
-  const metricsMap = parsePromMetrics(response)
+  const metricsMap = await t.context.testAdapter.getMetrics()
   const expectedLabel = `{participant_id="TEST-test-{\\"from\\":\\"eth\\",\\"to\\":\\"usd\\"}",feed_id="{\\"from\\":\\"eth\\",\\"to\\":\\"usd\\"}",cache_type="local",app_name="TEST",app_version="${version}"}`
   const staleness = metricsMap.get(`cache_data_staleness_seconds${expectedLabel}`)
   if (staleness !== undefined) {
@@ -194,15 +186,13 @@ test.serial('Test cache set staleness metrics', async (t) => {
 })
 
 test.serial('Test provider time delta metric', async (t) => {
-  const response = await t.context.testAdapter.getMetrics()
-  const metricsMap = parsePromMetrics(response)
+  const metricsMap = await t.context.testAdapter.getMetrics()
   const expectedLabel = `{participant_id="TEST-test-{\\"from\\":\\"eth\\",\\"to\\":\\"usd\\"}",feed_id="{\\"from\\":\\"eth\\",\\"to\\":\\"usd\\"}",cache_type="local",app_name="TEST",app_version="${version}"}`
   t.is(metricsMap.get(`cache_data_max_age${expectedLabel}`), 90000)
 })
 
 test.serial('Test credit spent metrics', async (t) => {
-  const response = await t.context.testAdapter.getMetrics()
-  const metricsMap = parsePromMetrics(response)
+  const metricsMap = await t.context.testAdapter.getMetrics()
   const expectedLabel = `{feed_id="N/A",participant_id="9002",app_name="TEST",app_version="${version}"}`
   t.is(metricsMap.get(`rate_limit_credits_spent_total${expectedLabel}`), 1)
 })
@@ -220,29 +210,25 @@ test.serial('Test http requests total metrics (cache hit)', async (t) => {
 
   await t.context.testAdapter.request({ from, to })
 
-  const response = await t.context.testAdapter.getMetrics()
-  const metricsMap = parsePromMetrics(response)
+  const metricsMap = await t.context.testAdapter.getMetrics()
   const expectedLabel = `{method="POST",feed_id="{\\"from\\":\\"eth\\",\\"to\\":\\"usd\\"}",status_code="200",type="cacheHit",app_name="TEST",app_version="${version}"}`
   t.is(metricsMap.get(`http_requests_total${expectedLabel}`), 1)
 })
 
 test.serial('Test cache get count metrics', async (t) => {
-  const response = await t.context.testAdapter.getMetrics()
-  const metricsMap = parsePromMetrics(response)
+  const metricsMap = await t.context.testAdapter.getMetrics()
   const expectedLabel = `{participant_id="TEST-test-{\\"from\\":\\"eth\\",\\"to\\":\\"usd\\"}",feed_id="{\\"from\\":\\"eth\\",\\"to\\":\\"usd\\"}",cache_type="local",app_name="TEST",app_version="${version}"}`
   t.is(metricsMap.get(`cache_data_get_count${expectedLabel}`), 1)
 })
 
 test.serial('Test cache get value metrics', async (t) => {
-  const response = await t.context.testAdapter.getMetrics()
-  const metricsMap = parsePromMetrics(response)
+  const metricsMap = await t.context.testAdapter.getMetrics()
   const expectedLabel = `{participant_id="TEST-test-{\\"from\\":\\"eth\\",\\"to\\":\\"usd\\"}",feed_id="{\\"from\\":\\"eth\\",\\"to\\":\\"usd\\"}",cache_type="local",app_name="TEST",app_version="${version}"}`
   t.is(metricsMap.get(`cache_data_get_values${expectedLabel}`), 1234)
 })
 
 test.serial('Test cache get staleness metrics', async (t) => {
-  const response = await t.context.testAdapter.getMetrics()
-  const metricsMap = parsePromMetrics(response)
+  const metricsMap = await t.context.testAdapter.getMetrics()
   const expectedLabel = `{participant_id="TEST-test-{\\"from\\":\\"eth\\",\\"to\\":\\"usd\\"}",feed_id="{\\"from\\":\\"eth\\",\\"to\\":\\"usd\\"}",cache_type="local",app_name="TEST",app_version="${version}"}`
   const staleness = metricsMap.get(`cache_data_staleness_seconds${expectedLabel}`)
   if (staleness !== undefined) {

--- a/test/metrics/polling-metrics.test.ts
+++ b/test/metrics/polling-metrics.test.ts
@@ -57,7 +57,7 @@ nock(URL)
 
 test.serial('Test cache warmer active metric', async (t) => {
   const error = await t.context.testAdapter.request({ from, to })
-  t.is(error?.statusCode, 504)
+  t.is(error.statusCode, 504)
 
   const metricsMap = await t.context.testAdapter.getMetrics()
 

--- a/test/metrics/polling-metrics.test.ts
+++ b/test/metrics/polling-metrics.test.ts
@@ -1,14 +1,11 @@
 import FakeTimers from '@sinonjs/fake-timers'
 import untypedTest, { TestFn } from 'ava'
-import axios, { AxiosError } from 'axios'
-import { AddressInfo } from 'net'
 import nock from 'nock'
-import { expose } from '../../src'
-import { MockCache } from '../util'
+import { MockCache, TestAdapter } from '../util'
 import { buildHttpAdapter, parsePromMetrics } from './helper'
 
 const test = untypedTest as TestFn<{
-  serverAddress: string
+  testAdapter: TestAdapter
   cache: MockCache
 }>
 
@@ -22,8 +19,6 @@ test.before(async (t) => {
   nock.disableNetConnect()
   nock.enableNetConnect('localhost')
   process.env['METRICS_ENABLED'] = 'true'
-  // Set unique port between metrics tests to avoid conflicts in metrics servers
-  process.env['METRICS_PORT'] = '9094'
   // Set higher retries for polling metrics testing
   process.env['CACHE_POLLING_MAX_RETRIES'] = '5'
 
@@ -34,10 +29,7 @@ test.before(async (t) => {
   const mockCache = new MockCache(adapter.config.CACHE_MAX_ITEMS)
 
   // Start the adapter
-  const api = await expose(adapter, {
-    cache: mockCache,
-  })
-  t.context.serverAddress = `http://localhost:${(api?.server.address() as AddressInfo)?.port}`
+  t.context.testAdapter = await TestAdapter.start(adapter, t.context, { cache: mockCache })
   t.context.cache = mockCache
 })
 
@@ -70,27 +62,11 @@ nock(URL)
   .persist()
 
 test.serial('Test cache warmer active metric', async (t) => {
-  const makeRequest = () =>
-    axios.post(t.context.serverAddress, {
-      data: {
-        from,
-        to,
-      },
-    })
+  const error = await t.context.testAdapter.request({ from, to })
+  t.is(error?.statusCode, 504)
 
-  // Expect the first response to time out
-  // The polling behavior is tested in the cache tests, so this is easier here.
-  // Start the request:
-  const errorPromise: Promise<AxiosError | undefined> = t.throwsAsync(makeRequest)
-  // Advance enough time for the initial request async flow
-  clock.tickAsync(10)
-  // Wait for the failed cache get -> instant 504
-  const error = await errorPromise
-  t.is(error?.response?.status, 504)
-
-  const metricsAddress = `http://localhost:${process.env['METRICS_PORT']}/metrics`
-  const response = await axios.get(metricsAddress)
-  const metricsMap = parsePromMetrics(response.data)
+  const response = await t.context.testAdapter.getMetrics()
+  const metricsMap = parsePromMetrics(response)
 
   let expectedLabel = `{endpoint="test",app_name="TEST",app_version="${version}"}`
   t.is(metricsMap.get(`transport_polling_failure_count${expectedLabel}`), 1)

--- a/test/metrics/redis-metrics.test.ts
+++ b/test/metrics/redis-metrics.test.ts
@@ -4,7 +4,6 @@ import { Adapter, AdapterDependencies, AdapterEndpoint, EndpointGenerics } from 
 import { Cache, LocalCache, RedisCache } from '../../src/cache'
 import { BasicCacheSetterTransport } from '../cache/helper'
 import { NopTransport, TestAdapter } from '../util'
-import { parsePromMetrics } from './helper'
 
 export const test = untypedTest as TestFn<{
   testAdapter: TestAdapter
@@ -98,8 +97,7 @@ test.serial('Test redis sent command metric', async (t) => {
   }
 
   await t.context.testAdapter.request(data)
-  const response = await t.context.testAdapter.getMetrics()
-  const metricsMap = parsePromMetrics(response)
+  const metricsMap = await t.context.testAdapter.getMetrics()
   const expectedLabel = `{status="SUCCESS",function_name="exec",app_name="TEST",app_version="${version}"}`
   t.is(metricsMap.get(`redis_commands_sent_count${expectedLabel}`), 1)
 })

--- a/test/metrics/warmer-metrics.test.ts
+++ b/test/metrics/warmer-metrics.test.ts
@@ -63,8 +63,10 @@ nock(URL)
 
 test.serial('Test cache warmer active metric', async (t) => {
   await t.context.testAdapter.startBackgroundExecuteThenGetResponse(t, {
-    from,
-    to,
+    requestData: {
+      from,
+      to,
+    },
   })
 
   const metricsMap = await t.context.testAdapter.getMetrics()

--- a/test/metrics/warmer-metrics.test.ts
+++ b/test/metrics/warmer-metrics.test.ts
@@ -1,29 +1,23 @@
-import FakeTimers from '@sinonjs/fake-timers'
+import FakeTimers, { InstalledClock } from '@sinonjs/fake-timers'
 import untypedTest, { TestFn } from 'ava'
-import axios, { AxiosError } from 'axios'
-import { AddressInfo } from 'net'
 import nock from 'nock'
-import { expose } from '../../src'
-import { MockCache, runAllUntilTime } from '../util'
+import { MockCache, runAllUntil, runAllUntilTime, TestAdapter } from '../util'
 import { buildHttpAdapter, parsePromMetrics } from './helper'
 
 const test = untypedTest as TestFn<{
-  serverAddress: string
+  testAdapter: TestAdapter
   cache: MockCache
+  clock: InstalledClock
 }>
 
 const URL = 'http://test-url.com'
 const endpoint = '/price'
 const version = process.env['npm_package_version']
 
-const clock = FakeTimers.install({ shouldAdvanceTime: true, advanceTimeDelta: 100 })
-
 test.before(async (t) => {
   nock.disableNetConnect()
   nock.enableNetConnect('localhost')
   process.env['METRICS_ENABLED'] = 'true'
-  // Set unique port between metrics tests to avoid conflicts in metrics servers
-  process.env['METRICS_PORT'] = '9092'
   // Disable retries to make the testing flow easier
   process.env['CACHE_POLLING_MAX_RETRIES'] = '0'
   // So that we don't have to wait that long in the test for the subscription to expire
@@ -40,16 +34,14 @@ test.before(async (t) => {
   const mockCache = new MockCache(adapter.config.CACHE_MAX_ITEMS)
 
   // Start the adapter
-  const api = await expose(adapter, {
-    cache: mockCache,
-  })
-  t.context.serverAddress = `http://localhost:${(api?.server.address() as AddressInfo)?.port}`
+  t.context.clock = FakeTimers.install()
+  t.context.testAdapter = await TestAdapter.start(adapter, t.context, { cache: mockCache })
   t.context.cache = mockCache
 })
 
-test.after(() => {
+test.after((t) => {
   nock.restore()
-  clock.uninstall()
+  t.context.clock.uninstall()
 })
 
 const from = 'ETH'
@@ -77,40 +69,32 @@ nock(URL)
 
 test.serial('Test cache warmer active metric', async (t) => {
   const makeRequest = () =>
-    axios.post(t.context.serverAddress, {
-      data: {
-        from,
-        to,
-      },
+    t.context.testAdapter.request({
+      from,
+      to,
     })
 
   // Expect the first response to time out
   // The polling behavior is tested in the cache tests, so this is easier here.
   // Start the request:
-  const errorPromise: Promise<AxiosError | undefined> = t.throwsAsync(makeRequest)
-  // Advance enough time for the initial request async flow
-  clock.tickAsync(10)
-  // Wait for the failed cache get -> instant 504
-  const error = await errorPromise
-  t.is(error?.response?.status, 504)
+  const error = await makeRequest()
+  t.is(error?.statusCode, 504)
 
   // Advance clock so that the batch warmer executes once again and wait for the cache to be set
-  const cacheValueSetPromise = t.context.cache.waitForNextSet()
-  await cacheValueSetPromise
+  await runAllUntil(t.context.clock, () => t.context.cache.cache.size > 0)
 
   // Second request should find the response in the cache
-  let response = await makeRequest()
+  const response = await makeRequest()
+  t.is(response.statusCode, 200)
 
-  t.is(response.status, 200)
-  const metricsAddress = `http://localhost:${process.env['METRICS_PORT']}/metrics`
-  response = await axios.get(metricsAddress)
-  let metricsMap = parsePromMetrics(response.data)
+  const metricsResponse = await t.context.testAdapter.getMetrics()
+  let metricsMap = parsePromMetrics(metricsResponse)
 
   let expectedLabel = `{isBatched="true",app_name="TEST",app_version="${version}"}`
   t.is(metricsMap.get(`cache_warmer_get_count${expectedLabel}`), 1)
 
   expectedLabel = `{endpoint="test",app_name="TEST",app_version="${version}"}`
-  t.is(metricsMap.get(`bg_execute_total${expectedLabel}`), 2)
+  t.is(metricsMap.get(`bg_execute_total${expectedLabel}`), 3)
 
   expectedLabel = `{endpoint="test",transport_type="MockHttpTransport",app_name="TEST",app_version="${version}"}`
   t.is(metricsMap.get(`bg_execute_subscription_set_count${expectedLabel}`), 1)
@@ -125,20 +109,20 @@ test.serial('Test cache warmer active metric', async (t) => {
   }
 
   // Wait until the cache expires, and the subscription is out
-  await runAllUntilTime(clock, 15000) // The provider response is slower
+  await runAllUntilTime(t.context.clock, 15000) // The provider response is slower
 
   // Now that the cache is out and the subscription no longer there, this should time out
-  const error2: AxiosError | undefined = await t.throwsAsync(makeRequest)
-  t.is(error2?.response?.status, 504)
+  const error2 = await makeRequest()
+  t.is(error2?.statusCode, 504)
 
-  response = await axios.get(metricsAddress)
-  metricsMap = parsePromMetrics(response.data)
+  const metricsResponse2 = await t.context.testAdapter.getMetrics()
+  metricsMap = parsePromMetrics(metricsResponse2)
 
   expectedLabel = `{isBatched="true",app_name="TEST",app_version="${version}"}`
   t.is(metricsMap.get(`cache_warmer_get_count${expectedLabel}`), 0)
 
   expectedLabel = `{endpoint="test",app_name="TEST",app_version="${version}"}`
-  t.is(metricsMap.get(`bg_execute_total${expectedLabel}`), 18)
+  t.is(metricsMap.get(`bg_execute_total${expectedLabel}`), 17)
 
   expectedLabel = `{endpoint="test",transport_type="MockHttpTransport",app_name="TEST",app_version="${version}"}`
   t.is(metricsMap.get(`bg_execute_subscription_set_count${expectedLabel}`), 0)

--- a/test/metrics/ws-metrics.test.ts
+++ b/test/metrics/ws-metrics.test.ts
@@ -1,21 +1,19 @@
-import FakeTimers from '@sinonjs/fake-timers'
+import FakeTimers, { InstalledClock } from '@sinonjs/fake-timers'
 import untypedTest, { TestFn } from 'ava'
-import axios, { AxiosError } from 'axios'
 import { Server, WebSocket } from 'mock-socket'
-import { AddressInfo } from 'net'
-import { expose } from '../../src'
 import { Adapter, AdapterEndpoint } from '../../src/adapter'
 import { SettingsMap } from '../../src/config'
 import { WebSocketClassProvider, WebSocketTransport } from '../../src/transports'
 import { InputParameters } from '../../src/validation'
-import { MockCache, runAllUntilTime } from '../util'
+import { MockCache, runAllUntil, TestAdapter } from '../util'
 import { parsePromMetrics } from './helper'
 
 export const test = untypedTest as TestFn<{
-  serverAddress: string
   cache: MockCache
   adapterEndpoint: AdapterEndpoint<WebSocketEndpointTypes>
+  testAdapter: TestAdapter
   server: Server
+  clock: InstalledClock
 }>
 
 interface AdapterRequestParams {
@@ -127,8 +125,6 @@ export const webSocketEndpoint = new AdapterEndpoint({
 const CACHE_MAX_AGE = 10000
 
 process.env['METRICS_ENABLED'] = 'true'
-// Set unique port between metrics tests to avoid conflicts in metrics servers
-process.env['METRICS_PORT'] = '9093'
 // Disable retries to make the testing flow easier
 process.env['CACHE_POLLING_MAX_RETRIES'] = '0'
 
@@ -143,8 +139,6 @@ const adapter = new Adapter({
     BACKGROUND_EXECUTE_MS_WS,
   },
 })
-
-const clock = FakeTimers.install()
 
 test.before(async (t) => {
   // Mock WS
@@ -169,43 +163,36 @@ test.before(async (t) => {
   // This is a more reliable method than expecting precise clock timings
   const mockCache = new MockCache(adapter.config.CACHE_MAX_ITEMS)
 
-  // Start up adapter
-  const api = await expose(adapter, {
-    cache: mockCache,
-  })
-  t.context.serverAddress = `http://localhost:${(api?.server.address() as AddressInfo)?.port}`
+  t.context.clock = FakeTimers.install()
+  t.context.testAdapter = await TestAdapter.start(adapter, t.context, { cache: mockCache })
   t.context.cache = mockCache
   t.context.server = mockWsServer
 })
 
-test.after(async () => {
-  clock.uninstall()
+test.after(async (t) => {
+  t.context.clock.uninstall()
 })
 
 test.serial('Test WS connection, subscription, and message metrics', async (t) => {
-  const makeRequest = () =>
-    axios.post(t.context.serverAddress, {
-      data: {
-        base,
-        quote,
-      },
-    })
+  const makeRequest = () => t.context.testAdapter.request({ base, quote })
 
   // Expect the first response to time out
-  const error = (await t.throwsAsync(makeRequest)) as AxiosError | undefined
-  t.is(error?.response?.status, 504)
+  // The polling behavior is tested in the cache tests, so this is easier here.
+  // Start the request:
+
+  const error = await makeRequest()
+  t.is(error?.statusCode, 504)
 
   // Advance clock so that the batch warmer executes once again and wait for the cache to be set
-  await runAllUntilTime(clock, BACKGROUND_EXECUTE_MS_WS + 10)
+  await runAllUntil(t.context.clock, () => t.context.cache.cache.size > 0)
 
   // Second request should find the response in the cache
-  let response = await makeRequest()
-  t.is(response.status, 200)
+  const response = await makeRequest()
+  t.is(response.statusCode, 200)
 
   // Check connection, subscription active, subscription total, and message total metrics when subscribed to feed
-  const metricsAddress = `http://localhost:${process.env['METRICS_PORT']}/metrics`
-  response = await axios.get(metricsAddress)
-  let metricsMap = parsePromMetrics(response.data)
+  const metricsResponse = await t.context.testAdapter.getMetrics()
+  let metricsMap = parsePromMetrics(metricsResponse)
 
   const basic = `app_name="TEST",app_version="${version}"`
   const feed = `feed_id="{\\"base\\":\\"eth\\",\\"quote\\":\\"usd\\"}",subscription_key="test-{\\"base\\":\\"eth\\",\\"quote\\":\\"usd\\"}"`
@@ -229,7 +216,7 @@ test.serial('Test WS connection, subscription, and message metrics', async (t) =
   }
 
   // Wait until the cache expires, and the subscription is out
-  await clock.tickAsync(
+  await t.context.clock.tickAsync(
     Math.ceil(CACHE_MAX_AGE / adapter.config.WS_SUBSCRIPTION_TTL) *
       adapter.config.WS_SUBSCRIPTION_TTL *
       2 +
@@ -237,12 +224,12 @@ test.serial('Test WS connection, subscription, and message metrics', async (t) =
   )
 
   // Now that the cache is out and the subscription no longer there, this should time out
-  const error2: AxiosError | undefined = await t.throwsAsync(makeRequest)
-  t.is(error2?.response?.status, 504)
+  const error2 = await makeRequest()
+  t.is(error2?.statusCode, 504)
 
   // Check connection, subscription active, subscription total, and message total metrics when unsubscribed from feed
-  response = await axios.get(metricsAddress)
-  metricsMap = parsePromMetrics(response.data)
+  const metricsResponse2 = await t.context.testAdapter.getMetrics()
+  metricsMap = parsePromMetrics(metricsResponse2)
 
   t.is(metricsMap.get(`ws_connection_active{${basic}}`), 1)
   t.is(metricsMap.get(`ws_subscription_active{${feed},${basic}}`), 0)
@@ -253,10 +240,10 @@ test.serial('Test WS connection, subscription, and message metrics', async (t) =
   t.context.server.close()
 
   // Check connection metric after connection closed
-  response = await axios.get(metricsAddress)
-  metricsMap = parsePromMetrics(response.data)
+  const metricsResponse3 = await t.context.testAdapter.getMetrics()
+  metricsMap = parsePromMetrics(metricsResponse3)
 
   t.is(metricsMap.get(`ws_connection_active{${basic}}`), 0)
-  t.is(metricsMap.get(`bg_execute_total{${endpoint},${basic}}`), 6)
+  t.is(metricsMap.get(`bg_execute_total{${endpoint},${basic}}`), 5)
   t.is(metricsMap.get(`bg_execute_subscription_set_count{${endpoint},${transport},${basic}}`), 0)
 })

--- a/test/metrics/ws-metrics.test.ts
+++ b/test/metrics/ws-metrics.test.ts
@@ -167,7 +167,12 @@ test.after(async (t) => {
 })
 
 test.serial('Test WS connection, subscription, and message metrics', async (t) => {
-  await t.context.testAdapter.startBackgroundExecuteThenGetResponse(t, { base, quote })
+  await t.context.testAdapter.startBackgroundExecuteThenGetResponse(t, {
+    requestData: {
+      base,
+      quote,
+    },
+  })
 
   // Check connection, subscription active, subscription total, and message total metrics when subscribed to feed
   const metricsMap = await t.context.testAdapter.getMetrics()

--- a/test/overrides.test.ts
+++ b/test/overrides.test.ts
@@ -1,14 +1,12 @@
 import untypedTest, { TestFn } from 'ava'
-import axios from 'axios'
-import { AddressInfo } from 'net'
-import { expose } from '../src'
 import { Adapter, AdapterEndpoint, EndpointGenerics } from '../src/adapter'
 import { ResponseCache } from '../src/cache/response'
 import { Transport, TransportGenerics } from '../src/transports'
 import { AdapterRequest } from '../src/util'
+import { TestAdapter } from './util'
 
 const test = untypedTest as TestFn<{
-  serverAddress: string
+  testAdapter: TestAdapter
   adapterEndpoint: AdapterEndpoint<EndpointGenerics>
 }>
 
@@ -77,117 +75,101 @@ test.beforeEach(async (t) => {
   })
 
   t.context.adapterEndpoint = adapter.endpoints[0]
-  const api = await expose(adapter)
-  if (!api) {
-    throw 'Server did not start'
-  }
-  t.context.serverAddress = `http://localhost:${(api.server.address() as AddressInfo).port}`
+  t.context.testAdapter = await TestAdapter.start(adapter, t.context)
 })
 
 test('adapter hardcoded overrides are respected', async (t) => {
-  const response = await axios.post(`${t.context.serverAddress}`, {
-    data: {
-      base: 'OVER1',
-      quote: 'USD',
-    },
+  const response = await t.context.testAdapter.request({
+    base: 'OVER1',
+    quote: 'USD',
   })
 
-  t.deepEqual(response.data.data, {
+  t.deepEqual(response.json().data, {
     base: 'overriden_1',
     quote: 'USD',
   })
 })
 
 test('request overrides are respected', async (t) => {
-  const response = await axios.post(`${t.context.serverAddress}`, {
-    data: {
-      base: 'OVER2',
-      quote: 'USD',
-      overrides: {
-        test: {
-          OVER2: 'qweqwe',
-        },
+  const response = await t.context.testAdapter.request({
+    base: 'OVER2',
+    quote: 'USD',
+    overrides: {
+      test: {
+        OVER2: 'qweqwe',
       },
     },
   })
 
-  t.deepEqual(response.data.data, {
+  t.deepEqual(response.json().data, {
     base: 'qweqwe',
     quote: 'USD',
   })
 })
 
 test('not overriden field is kept as is', async (t) => {
-  const response = await axios.post(`${t.context.serverAddress}`, {
-    data: {
-      base: 'NO-OVER',
-      quote: 'USD',
-      overrides: {
-        test: {
-          OVER2: 'qweqwe',
-        },
+  const response = await t.context.testAdapter.request({
+    base: 'NO-OVER',
+    quote: 'USD',
+    overrides: {
+      test: {
+        OVER2: 'qweqwe',
       },
     },
   })
 
-  t.deepEqual(response.data.data, {
+  t.deepEqual(response.json().data, {
     base: 'NO-OVER',
     quote: 'USD',
   })
 })
 
 test('request overrides take precedence over adapter hardcoded ones', async (t) => {
-  const response = await axios.post(`${t.context.serverAddress}`, {
-    data: {
-      base: 'OVER1',
-      quote: 'USD',
-      overrides: {
-        test: {
-          OVER1: 'priority',
-        },
+  const response = await t.context.testAdapter.request({
+    base: 'OVER1',
+    quote: 'USD',
+    overrides: {
+      test: {
+        OVER1: 'priority',
       },
     },
   })
 
-  t.deepEqual(response.data.data, {
+  t.deepEqual(response.json().data, {
     base: 'priority',
     quote: 'USD',
   })
 })
 
 test('request overrides that resolve field to overridable symbol are not overriden from adapter overrides', async (t) => {
-  const response = await axios.post(`${t.context.serverAddress}`, {
-    data: {
-      base: 'OVER2',
-      quote: 'USD',
-      overrides: {
-        test: {
-          OVER2: 'OVER1',
-        },
+  const response = await t.context.testAdapter.request({
+    base: 'OVER2',
+    quote: 'USD',
+    overrides: {
+      test: {
+        OVER2: 'OVER1',
       },
     },
   })
 
-  t.deepEqual(response.data.data, {
+  t.deepEqual(response.json().data, {
     base: 'OVER1', // Want to check that it's not been overriden twice, which would be 'overriden_1'
     quote: 'USD',
   })
 })
 
 test('adapter overrides that resolve field to overridable symbol are not overriden from request overrides', async (t) => {
-  const response = await axios.post(`${t.context.serverAddress}`, {
-    data: {
-      base: 'OVER1',
-      quote: 'USD',
-      overrides: {
-        test: {
-          overriden_1: 'twice',
-        },
+  const response = await t.context.testAdapter.request({
+    base: 'OVER1',
+    quote: 'USD',
+    overrides: {
+      test: {
+        overriden_1: 'twice',
       },
     },
   })
 
-  t.deepEqual(response.data.data, {
+  t.deepEqual(response.json().data, {
     base: 'overriden_1', // Want to check that it's not been overriden twice, which would be 'twice'
     quote: 'USD',
   })

--- a/test/rate-limit-config.test.ts
+++ b/test/rate-limit-config.test.ts
@@ -1,5 +1,5 @@
 import test from 'ava'
-import { expose } from '../src'
+import { start } from '../src'
 import { Adapter, AdapterDependencies, AdapterEndpoint } from '../src/adapter'
 import {
   buildRateLimitTiersFromConfig,
@@ -24,7 +24,7 @@ test('empty tiers in rate limiting fails on startup', async (t) => {
     },
   })
 
-  await t.throwsAsync(async () => expose(adapter), {
+  await t.throwsAsync(async () => start(adapter), {
     message: 'The tiers object is defined, but has no entries',
   })
 })
@@ -54,7 +54,7 @@ test('selected tier is not a valid option', async (t) => {
     },
   })
 
-  await t.throwsAsync(async () => expose(adapter), {
+  await t.throwsAsync(async () => start(adapter), {
     message: 'The selected rate limit tier "asdasdasd" is not valid (can be one of "free", "pro")',
   })
 })
@@ -178,7 +178,7 @@ test('uses most restrictive tier if none is specified in settings', async (t) =>
     },
   })
 
-  await expose(adapter)
+  await start(adapter)
 })
 
 test('uses unlimited tier if none is specified in settings', async (t) => {
@@ -201,7 +201,7 @@ test('uses unlimited tier if none is specified in settings', async (t) => {
     ],
   })
 
-  await expose(adapter)
+  await start(adapter)
 })
 
 test('uses specified tier if present in settings', async (t) => {
@@ -242,7 +242,7 @@ test('uses specified tier if present in settings', async (t) => {
     },
   })
 
-  await expose(adapter)
+  await start(adapter)
 })
 
 test('test build rate limits from env vars (second, minute)', async (t) => {

--- a/test/subscription-set/redis-subscription-set.test.ts
+++ b/test/subscription-set/redis-subscription-set.test.ts
@@ -205,5 +205,5 @@ test.serial('Test redis subscription set (add and getAll)', async (t) => {
 
   // Now that the cache is out and the subscription no longer there, this should time out
   const error = await t.context.testAdapter.request({ from, to })
-  t.is(error?.statusCode, 504)
+  t.is(error.statusCode, 504)
 })

--- a/test/subscription-set/redis-subscription-set.test.ts
+++ b/test/subscription-set/redis-subscription-set.test.ts
@@ -189,8 +189,10 @@ test.serial('Test redis subscription set (add and getAll)', async (t) => {
   t.context.testAdapter = await TestAdapter.startWithMockedCache(adapter, t.context, dependencies)
 
   const response = await t.context.testAdapter.startBackgroundExecuteThenGetResponse(t, {
-    from,
-    to,
+    requestData: {
+      from,
+      to,
+    },
   })
   assertEqualResponses(t, response.json(), {
     data: {

--- a/test/transports/http.test.ts
+++ b/test/transports/http.test.ts
@@ -134,7 +134,6 @@ process.env['CACHE_POLLING_MAX_RETRIES'] = '0'
 process.env['RETRY'] = '0'
 process.env['BACKGROUND_EXECUTE_MS_HTTP'] = BACKGROUND_EXECUTE_MS_HTTP.toString()
 process.env['API_TIMEOUT'] = '0'
-process.env['FRAMEWORK_TESTING'] = 'true'
 
 const from = 'ETH'
 const to = 'USD'

--- a/test/transports/http.test.ts
+++ b/test/transports/http.test.ts
@@ -195,13 +195,15 @@ test.serial('sends request to DP and returns response', async (t) => {
 
   // Start the adapter
   const testAdapter = await TestAdapter.startWithMockedCache(adapter, t.context)
-  const response = await testAdapter.startBackgroundExecuteThenGetResponse(t, { from, to })
-  assertEqualResponses(t, response.json(), {
-    data: {
+  await testAdapter.startBackgroundExecuteThenGetResponse(t, {
+    requestData: { from, to },
+    expectedResponse: {
+      data: {
+        result: price,
+      },
       result: price,
+      statusCode: 200,
     },
-    result: price,
-    statusCode: 200,
   })
 })
 
@@ -462,18 +464,17 @@ test.serial('DP request fails, EA returns 502 cached error', async (t) => {
     cache: mockCache,
   })
 
-  await testAdapter.startBackgroundExecuteThenGetResponse(
-    t,
-    {
+  await testAdapter.startBackgroundExecuteThenGetResponse(t, {
+    requestData: {
       from: 'ERR',
       to,
     },
-    {
+    expectedResponse: {
       errorMessage:
         'Provider request failed with status undefined: "There was an unexpected issue"',
       statusCode: 502,
     },
-  )
+  })
 })
 
 test.serial('requests from different transports are NOT coalesced', async (t) => {
@@ -636,8 +637,10 @@ test.serial('requests for the same transport are coalesced', async (t) => {
   const testAdapter = await TestAdapter.startWithMockedCache(adapter, t.context)
 
   await testAdapter.startBackgroundExecuteThenGetResponse(t, {
-    from: 'COALESCE2',
-    to,
+    requestData: {
+      from: 'COALESCE2',
+      to,
+    },
   })
 })
 

--- a/test/transports/http.test.ts
+++ b/test/transports/http.test.ts
@@ -222,7 +222,7 @@ test.serial('sends request to DP and returns response', async (t) => {
   const response = await makeRequest()
 
   t.is(response.statusCode, 200)
-  assertEqualResponses(t, JSON.parse(response.body), {
+  assertEqualResponses(t, response.json(), {
     data: {
       result: price,
     },
@@ -517,7 +517,7 @@ test.serial('DP request fails, EA returns 502 cached error', async (t) => {
   const response = await makeRequest()
 
   t.is(response.statusCode, 502)
-  assertEqualResponses(t, JSON.parse(response.body), {
+  assertEqualResponses(t, response.json(), {
     errorMessage: 'Provider request failed with status undefined: "There was an unexpected issue"',
     statusCode: 502,
   })
@@ -635,7 +635,7 @@ test.serial('requests from different transports are NOT coalesced', async (t) =>
   const responseB = await makeRequest('testB')
 
   t.is(responseA.statusCode, 200)
-  assertEqualResponses(t, JSON.parse(responseA.body), {
+  assertEqualResponses(t, responseA.json(), {
     data: {
       result: price,
     },
@@ -643,7 +643,7 @@ test.serial('requests from different transports are NOT coalesced', async (t) =>
     statusCode: 200,
   })
   t.is(responseB.statusCode, 200)
-  assertEqualResponses(t, JSON.parse(responseB.body), {
+  assertEqualResponses(t, responseB.json(), {
     data: {
       result: volume,
     },
@@ -798,7 +798,7 @@ test.serial(
     // Request for the last 2 requests should be fulfilled, since the first one will have been kicked off the queue
     const error3 = await makeRequest(3)
     t.is(error3?.statusCode, 429)
-    assertEqualResponses(t, JSON.parse(error3.body), {
+    assertEqualResponses(t, error3.json(), {
       errorMessage:
         'The EA was unable to execute the request to fetch the requested data from the DP because the request queue overflowed. This likely indicates that a higher API tier is needed.',
       statusCode: 429,

--- a/test/transports/sse.test.ts
+++ b/test/transports/sse.test.ts
@@ -162,15 +162,14 @@ test('connects to EventSource, subscribes, gets message, unsubscribes and handle
     eventSource: EventSource,
   })
 
-  await testAdapter.startBackgroundExecuteThenGetResponse(
-    t,
-    { base, quote },
-    {
+  await testAdapter.startBackgroundExecuteThenGetResponse(t, {
+    requestData: { base, quote },
+    expectedResponse: {
       data: { result: 111 },
       result: price,
       statusCode: 200,
     },
-  )
+  })
 
   // Make a request for an unsupported ticker symbol
   const error = await testAdapter.request({

--- a/test/transports/websocket.test.ts
+++ b/test/transports/websocket.test.ts
@@ -170,17 +170,16 @@ test.serial('connects to websocket, subscribes, gets message, unsubscribes', asy
 
   const testAdapter = await TestAdapter.startWithMockedCache(adapter, t.context)
 
-  await testAdapter.startBackgroundExecuteThenGetResponse(
-    t,
-    { base, quote },
-    {
+  await testAdapter.startBackgroundExecuteThenGetResponse(t, {
+    requestData: { base, quote },
+    expectedResponse: {
       data: {
         result: price,
       },
       result: price,
       statusCode: 200,
     },
-  )
+  })
 
   // Wait until the cache expires, and the subscription is out
   const duration =
@@ -274,18 +273,17 @@ test.serial('reconnects when url changed', async (t) => {
   const testAdapter = await TestAdapter.startWithMockedCache(adapter, t.context)
 
   const testResponse = async (base: string, count: number) => {
-    await testAdapter.startBackgroundExecuteThenGetResponse(
-      t,
-      { base, quote: 'USD' },
-      {
+    await testAdapter.startBackgroundExecuteThenGetResponse(t, {
+      requestData: { base, quote: 'USD' },
+      expectedCacheSize: count,
+      expectedResponse: {
         data: {
           result: price,
         },
         result: price,
         statusCode: 200,
       },
-      count,
-    )
+    })
     t.is(connectionCounter, count)
   }
 
@@ -417,17 +415,16 @@ test.serial(
 
     const testAdapter = await TestAdapter.startWithMockedCache(adapter, t.context)
 
-    await testAdapter.startBackgroundExecuteThenGetResponse(
-      t,
-      { base, quote },
-      {
+    await testAdapter.startBackgroundExecuteThenGetResponse(t, {
+      requestData: { base, quote },
+      expectedResponse: {
         data: {
           result: price,
         },
         result: price,
         statusCode: 200,
       },
-    )
+    })
 
     // Wait until the cache expires, and the subscription is out
     const duration =
@@ -540,15 +537,14 @@ test.serial('can set reverse mapping and read from it', async (t) => {
   })
 
   const testAdapter = await TestAdapter.startWithMockedCache(adapter, t.context)
-  await testAdapter.startBackgroundExecuteThenGetResponse(
-    t,
-    { base, quote },
-    {
+  await testAdapter.startBackgroundExecuteThenGetResponse(t, {
+    requestData: { base, quote },
+    expectedResponse: {
       data: {
         result: price,
       },
       result: price,
       statusCode: 200,
     },
-  )
+  })
 })

--- a/test/util.ts
+++ b/test/util.ts
@@ -65,7 +65,6 @@ export class MockCache extends LocalCache {
 
   override async set(key: string, value: Readonly<unknown>, ttl: number): Promise<void> {
     super.set(key, value, ttl)
-    console.log('setting value')
     if (this.awaitingPromiseResolve) {
       this.awaitingPromiseResolve(value)
     }
@@ -223,10 +222,8 @@ export async function waitUntilResolved<T>(
   execute()
   // eslint-disable-next-line no-unmodified-loop-condition
   while (result === undefined) {
-    // Console.log('executing next', result)
     await clock.nextAsync()
   }
-  console.log('done')
 
   return result
 }

--- a/test/util.ts
+++ b/test/util.ts
@@ -240,13 +240,14 @@ export class TestAdapter {
     return context.testAdapter
   }
 
-  async request(data: object) {
+  async request(data: object, headers?: Record<string, string>) {
     const makeRequest = async () =>
       this.api.inject({
         method: 'post',
         url: '/',
         headers: {
           'content-type': 'application/json',
+          ...headers,
         },
         payload: {
           data,
@@ -317,6 +318,10 @@ export class TestAdapter {
     }
     const response = await this.metricsApi.inject('/metrics')
     return parsePromMetrics(response.body)
+  }
+
+  async getHealth() {
+    return this.api.inject('/health')
   }
 }
 


### PR DESCRIPTION
This is quite a loaded PR. Changes:
- Change default background execute sleep from 1ms to 10ms
- Add stacktrace logging on background execute errors
- Add transport name and endpoint to logs written in a background execute context
- Separate port listening on the rest APIs to a separate function `expose` to maintain backwards compat, while leaving a `start` function to build the APIs and start background executes as necessary
- Make HTTP transport sleep upon hitting a requester queue overflow
- Add more logging for provider errors in HTTP transport
- Add 1s time to wait since a WS connection was opened to avoid problems like messages never being sent
- Add check to send messages only if the WS connection is open
- Add TestAdapter utility class, to start an adapter and provide methods for common patterns (sending a request to the EA, sending one + waiting for bg execute + sending again for result, getting metrics, etc.)
- Refactor and clean up _all_ test suites