### PR TITLE
Update max key length logic

### DIFF
--- a/test/cache/cache-key.test.ts
+++ b/test/cache/cache-key.test.ts
@@ -136,7 +136,7 @@ test.serial('cache key is truncated if over max size', async (t) => {
       .map((s, i) => `----------${i}`)
       .join('|'),
   })
-  t.is(response.json().result.length, 4 + 1 + 4 + 1 + 150) // Adapter Name + separator + Endpoint Name + separator + Max common key
+  t.is(response.json().result.length, 4 + 1 + 4 + 1 + 28) // Adapter Name + separator + Endpoint Name + separator + Hash
 })
 
 test.serial('custom cache key', async (t) => {


### PR DESCRIPTION
Changing max key length logic from truncating string to hashing it. Now that the requester is using the same logic to generate keys for the request queue, keys were regularly exceeding the max due to batch requests.