### PR TITLE
Remove defaultTransport parameter from RoutingTransport

### DIFF
--- a/docs/v3-ea-components/transport-types/routing-transport.md
+++ b/docs/v3-ea-components/transport-types/routing-transport.md
@@ -28,14 +28,13 @@ export const routingTransport = new RoutingTransport<EndpointTypes>(
     ws: wsTransport,
     rest: httpTransport,
   },
-    customRouter: (req, adapterConfig) => {
-      // This code is not really a realistic use case, but does show the available context within the custom router
-      if (adapterConfig.SETTING === req.requestContext.data.base) {
-        return 'ws'
-      } else {
-        return 'rest'
-      }
-    },
+  (req, adapterConfig) => {
+    // This code is not really a realistic use case, but does show the available context within the custom router
+    if (adapterConfig.SETTING === req.requestContext.data.base) {
+      return 'ws'
+    } else {
+      return 'rest'
+    }
   },
 )
 ```

--- a/docs/v3-ea-components/transport-types/routing-transport.md
+++ b/docs/v3-ea-components/transport-types/routing-transport.md
@@ -14,7 +14,10 @@ export const routingTransport = new RoutingTransport<EndpointTypes>({
 })
 ```
 
-By default, the RoutingTransport expects a `transport` input parameter, that will be matched (case insensitive) to the keys of the transport map passed to the `RoutingTransport`'s constructor. You can optionally specify both a default transport to use if the parameter is not provided, as well as a custom router function that allows to implement different logic:
+> **Warning**
+> Be aware that for backwards compatibility, a default transport will likely be desired. This can be achieved by setting a default in the inputParameters.
+
+By default, the RoutingTransport expects a `transport` input parameter, that will be matched (case insensitive) to the keys of the transport map passed to the `RoutingTransport`'s constructor. You can optionally specify a custom router function that allows to implement different logic:
 
 ```typescript
 import { httpTransport } from './endpoint-http'
@@ -25,8 +28,6 @@ export const routingTransport = new RoutingTransport<EndpointTypes>(
     ws: wsTransport,
     rest: httpTransport,
   },
-  {
-    defaultTransport: 'rest',
     customRouter: (req, adapterConfig) => {
       // This code is not really a realistic use case, but does show the available context within the custom router
       if (adapterConfig.SETTING === req.requestContext.data.base) {

--- a/test/transports/routing.test.ts
+++ b/test/transports/routing.test.ts
@@ -403,10 +403,8 @@ test.serial('RoutingTransport can route to SSE transport', async (t) => {
 })
 
 test.serial('custom router is applied to get valid transport to route to', async (t) => {
-  const transport = new RoutingTransport<BaseEndpointTypes>(transports, {
-    customRouter: () => {
-      return 'batch'
-    },
+  const transport = new RoutingTransport<BaseEndpointTypes>(transports, () => {
+    return 'batch'
   })
   const endpoint = new AdapterEndpoint<BaseEndpointTypes>({
     inputParameters,
@@ -465,10 +463,8 @@ test.serial('custom router is applied to get valid transport to route to', async
 })
 
 test.serial('custom router returns invalid transport and request fails', async (t) => {
-  const transport = new RoutingTransport<BaseEndpointTypes>(transports, {
-    customRouter: () => {
-      return 'qweqwe'
-    },
+  const transport = new RoutingTransport<BaseEndpointTypes>(transports, () => {
+    return 'qweqwe'
   })
   const endpoint = new AdapterEndpoint<BaseEndpointTypes>({
     inputParameters,
@@ -589,14 +585,13 @@ test.serial('missing transport in input params with no default fails request', a
 })
 
 test.serial('missing transport in input params with default succeeds', async (t) => {
-  const transport = new RoutingTransport<BaseEndpointTypes>(transports, {
-    defaultTransport: 'batch',
-  })
+  const transport = new RoutingTransport<BaseEndpointTypes>(transports)
   const endpoint = new AdapterEndpoint<BaseEndpointTypes>({
     inputParameters: {
       ...inputParameters,
       transport: {
         ...inputParameters.transport,
+        default: 'batch',
         required: false,
       },
     },
@@ -664,13 +659,4 @@ test.serial('transport creation fails if transport names are not acceptable', as
         }),
     )
   }
-})
-
-test.serial('transport creation fails if default transport is not in transports map', async (t) => {
-  t.throws(
-    () =>
-      new RoutingTransport<BaseEndpointTypes>(transports, {
-        defaultTransport: 'asd',
-      }),
-  )
 })


### PR DESCRIPTION
The default transport shouldn't be set in the routing transport class, because it would cause problems with cache keys. The default should be set in the input parameters instead.