### PR TITLE
Mark priceMeta as optional

### DIFF
--- a/src/adapter/price.ts
+++ b/src/adapter/price.ts
@@ -155,7 +155,7 @@ export class PriceAdapter<CustomSettings extends SettingsMap> extends Adapter<Cu
   ): Promise<AdapterResponse> {
     const response = await super.handleRequest(req, replySent)
 
-    if (this.includesMap && req.requestContext.priceMeta.inverse) {
+    if (this.includesMap && req.requestContext.priceMeta?.inverse) {
       // We need to search in the reverse order (quote -> base) because the request transform will have inverted the pair
       const cloneResponse = { ...response }
       const inverseResult = 1 / (cloneResponse.result as number)


### PR DESCRIPTION
With the change in logic to move `requestTransforms` to endpoints, the includes transform was limited to just PriceEndpoints. Previously when it was at the adapter level, every requests were being transformed to include `priceMeta`. Now that only PriceEndpoints have this transformation, basic AdapterEndpoints do not meaning they would not have the `priceMeta` field. The current logic was throwing errors due to this so this change marks the field as optional.