### PR TITLE
Refactor Settings

### DIFF
--- a/src/adapter/basic.ts
+++ b/src/adapter/basic.ts
@@ -56,7 +56,7 @@ export class Adapter<T extends ProcessedConfig = ProcessedConfig>
     this.name = params.name
     this.defaultEndpoint = params.defaultEndpoint?.toLowerCase()
     this.endpoints = params.endpoints
-    this.processedConfig = params.processedConfig
+    this.processedConfig = params.processedConfig || (new ProcessedConfig({}) as T)
     this.rateLimiting = params.rateLimiting
     this.bootstrap = params.bootstrap
 

--- a/src/adapter/basic.ts
+++ b/src/adapter/basic.ts
@@ -1,14 +1,7 @@
 import Redis from 'ioredis'
 import { Cache, CacheFactory, pollResponseFromCache } from '../cache'
 import { cacheGet, cacheMetricsLabel } from '../cache/metrics'
-import {
-  AdapterConfig,
-  BaseAdapterConfig,
-  BaseSettings,
-  buildAdapterConfig,
-  SettingsMap,
-  validateAdapterConfig,
-} from '../config'
+import { BaseAdapterConfig, BaseSettings, ProcessedConfig } from '../config'
 import { metrics } from '../metrics'
 import {
   buildRateLimitTiersFromConfig,
@@ -16,8 +9,7 @@ import {
   highestRateLimitTiers,
   SimpleCountingRateLimiter,
 } from '../rate-limiting'
-import { AdapterRequest, AdapterResponse, makeLogger, Merge, SubscriptionSetFactory } from '../util'
-import CensorList, { CensorKeyValue } from '../util/censor/censor-list'
+import { AdapterRequest, AdapterResponse, makeLogger, SubscriptionSetFactory } from '../util'
 import { Requester } from '../util/requester'
 import { AdapterTimeoutError } from '../validation/error'
 import { AdapterEndpoint } from './endpoint'
@@ -25,7 +17,6 @@ import {
   AdapterDependencies,
   AdapterParams,
   AdapterRateLimitingConfig,
-  CustomAdapterSettings,
   EndpointGenerics,
 } from './types'
 
@@ -34,15 +25,14 @@ const logger = makeLogger('Adapter')
 /**
  * Main class to represent an External Adapter
  */
-export class Adapter<CustomSettings extends CustomAdapterSettings = SettingsMap>
-  implements Omit<AdapterParams<CustomSettings>, 'bootstrap'>
+export class Adapter<T extends ProcessedConfig = ProcessedConfig>
+  implements Omit<AdapterParams<T>, 'bootstrap'>
 {
   // Adapter params
   name: Uppercase<string>
   defaultEndpoint?: string | undefined
-  endpoints: AdapterEndpoint<Merge<EndpointGenerics, { CustomSettings: CustomSettings }>>[]
+  endpoints: AdapterEndpoint<EndpointGenerics>[]
   envDefaultOverrides?: Partial<BaseAdapterConfig> | undefined
-  customSettings?: SettingsMap | undefined
   rateLimiting?: AdapterRateLimitingConfig | undefined
   envVarsPrefix?: string
 
@@ -50,35 +40,25 @@ export class Adapter<CustomSettings extends CustomAdapterSettings = SettingsMap>
   initialized = false
 
   /** Object containing alias translations for all endpoints */
-  endpointsMap: Record<
-    string,
-    AdapterEndpoint<Merge<EndpointGenerics, { CustomSettings: CustomSettings }>>
-  > = {}
+  endpointsMap: Record<string, AdapterEndpoint<EndpointGenerics>> = {}
 
   /** Initialized dependencies that the adapter will use */
   dependencies!: AdapterDependencies
 
   /** Configuration params for various adapter properties */
-  config: AdapterConfig<CustomSettings>
+  processedConfig: T
 
   /** Bootstrap function that will run when initializing the adapter */
-  private readonly bootstrap?: (adapter: Adapter<CustomSettings>) => Promise<void>
+  private readonly bootstrap?: (adapter: Adapter<T>) => Promise<void>
 
-  constructor(params: AdapterParams<CustomSettings>) {
+  constructor(params: AdapterParams<T>) {
     // Copy over params
     this.name = params.name
     this.defaultEndpoint = params.defaultEndpoint?.toLowerCase()
     this.endpoints = params.endpoints
-    this.envDefaultOverrides = params.envDefaultOverrides
-    this.customSettings = params.customSettings
+    this.processedConfig = params.processedConfig
     this.rateLimiting = params.rateLimiting
     this.bootstrap = params.bootstrap
-
-    this.config = buildAdapterConfig({
-      overrides: this.envDefaultOverrides,
-      customSettings: this.customSettings,
-      envVarsPrefix: this.envVarsPrefix,
-    })
 
     this.normalizeEndpointNames()
     this.calculateRateLimitAllocations()
@@ -97,7 +77,7 @@ export class Adapter<CustomSettings extends CustomAdapterSettings = SettingsMap>
     metrics.initialize()
 
     // Building configs during initialization to avoid validation errors during construction
-    validateAdapterConfig(this.config, this.customSettings)
+    this.processedConfig.validate()
 
     // Log warnings for risks associated with certain configs and values
     this.logConfigWarnings()
@@ -119,12 +99,12 @@ export class Adapter<CustomSettings extends CustomAdapterSettings = SettingsMap>
       }
 
       logger.debug(`Initializing endpoint "${endpoint.name}"...`)
-      await endpoint.initialize(this.name, this.dependencies, this.config)
+      await endpoint.initialize(this.name, this.dependencies, this.processedConfig.config)
     }
 
     // Build list of key/values that need to be redacted in logs
     // Populates the static array in CensorList to use in censor-transport
-    this.buildCensorList()
+    this.processedConfig.buildCensorList()
 
     logger.debug('Adapter initialization complete.')
     this.initialized = true
@@ -183,58 +163,32 @@ export class Adapter<CustomSettings extends CustomAdapterSettings = SettingsMap>
   }
 
   /**
-   * Creates a list of key/value pairs that need to be censored in the logs
-   * using the sensitive flag in the adapter config
-   */
-  private buildCensorList() {
-    const censorList: CensorKeyValue[] = Object.entries(BaseSettings as SettingsMap)
-      .concat(Object.entries((this.customSettings as SettingsMap) || {}))
-      .filter(
-        ([name, setting]) =>
-          setting &&
-          setting.type === 'string' &&
-          setting.sensitive &&
-          this.config[name as keyof AdapterConfig<CustomSettings>],
-      )
-      .map(([name]) => ({
-        key: name,
-        // Escaping potential special characters in values before creating regex
-        value: new RegExp(
-          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-          ((this.config as AdapterConfig)[name]! as string).replace(
-            /[-[\]{}()*+?.,\\^$|#\s]/g,
-            '\\$&',
-          ),
-          'gi',
-        ),
-      }))
-    CensorList.set(censorList)
-  }
-
-  /**
    * Logs a warning for certain configs if set to particular values.
    * Used to warn stakeholders of potential risks.
    */
   private logConfigWarnings() {
     if (
-      this.config.LOG_LEVEL.toUpperCase() === 'DEBUG' ||
-      this.config.LOG_LEVEL.toUpperCase() === 'TRACE'
+      this.processedConfig.config.LOG_LEVEL.toUpperCase() === 'DEBUG' ||
+      this.processedConfig.config.LOG_LEVEL.toUpperCase() === 'TRACE'
     ) {
       logger.warn(
-        `LOG_LEVEL has been set to ${this.config.LOG_LEVEL.toUpperCase()}. Setting higher log levels results in increased memory usage and potentially slower performance.`,
+        `LOG_LEVEL has been set to ${this.processedConfig.config.LOG_LEVEL.toUpperCase()}. Setting higher log levels results in increased memory usage and potentially slower performance.`,
       )
     }
-    if (this.config.DEBUG === true) {
+    if (this.processedConfig.config.DEBUG === true) {
       logger.warn(`The adapter is running with DEBUG mode on.`)
     }
-    if (this.config.METRICS_ENABLED === false) {
+    if (this.processedConfig.config.METRICS_ENABLED === false) {
       logger.warn(
         `METRICS_ENABLED has been set to false. Metrics should not be disabled in a production environment.`,
       )
     }
-    if (this.config.MAX_PAYLOAD_SIZE_LIMIT !== BaseSettings.MAX_PAYLOAD_SIZE_LIMIT.default) {
+    if (
+      this.processedConfig.config.MAX_PAYLOAD_SIZE_LIMIT !==
+      BaseSettings.MAX_PAYLOAD_SIZE_LIMIT.default
+    ) {
       logger.warn(
-        `MAX_PAYLOAD_SIZE_LIMIT has been set to ${this.config.MAX_PAYLOAD_SIZE_LIMIT}. This setting should only be set when absolutely necessary.`,
+        `MAX_PAYLOAD_SIZE_LIMIT has been set to ${this.processedConfig.config.MAX_PAYLOAD_SIZE_LIMIT}. This setting should only be set when absolutely necessary.`,
       )
     }
   }
@@ -250,25 +204,28 @@ export class Adapter<CustomSettings extends CustomAdapterSettings = SettingsMap>
     const dependencies = inputDependencies || {}
 
     if (!dependencies.redisClient) {
-      if (this.config.CACHE_TYPE === 'redis') {
-        const maxCooldown = this.config.CACHE_REDIS_MAX_RECONNECT_COOLDOWN
+      if (this.processedConfig.config.CACHE_TYPE === 'redis') {
+        const maxCooldown = this.processedConfig.config.CACHE_REDIS_MAX_RECONNECT_COOLDOWN
         const redisOptions = {
           enableAutoPipelining: true, // This will make multiple commands be batch automatically
-          host: this.config.CACHE_REDIS_HOST,
-          port: this.config.CACHE_REDIS_PORT,
-          password: this.config.CACHE_REDIS_PASSWORD,
-          path: this.config.CACHE_REDIS_PATH, // If set, port and host are ignored
-          timeout: this.config.CACHE_REDIS_TIMEOUT,
+          host: this.processedConfig.config.CACHE_REDIS_HOST,
+          port: this.processedConfig.config.CACHE_REDIS_PORT,
+          password: this.processedConfig.config.CACHE_REDIS_PASSWORD,
+          path: this.processedConfig.config.CACHE_REDIS_PATH, // If set, port and host are ignored
+          timeout: this.processedConfig.config.CACHE_REDIS_TIMEOUT,
           retryStrategy(times: number): number {
             metrics.get('redisRetriesCount').inc()
             logger.warn(`Redis reconnect attempt #${times}`)
             return Math.min(times * 100, maxCooldown) // Next reconnect attempt time
           },
-          connectTimeout: this.config.CACHE_REDIS_CONNECTION_TIMEOUT,
+          connectTimeout: this.processedConfig.config.CACHE_REDIS_CONNECTION_TIMEOUT,
           maxRetriesPerRequest: 30, // Limits the number of retries before the adapter shuts down
         }
-        if (this.config.CACHE_REDIS_URL) {
-          dependencies.redisClient = new Redis(this.config.CACHE_REDIS_URL, redisOptions)
+        if (this.processedConfig.config.CACHE_REDIS_URL) {
+          dependencies.redisClient = new Redis(
+            this.processedConfig.config.CACHE_REDIS_URL,
+            redisOptions,
+          )
         } else {
           dependencies.redisClient = new Redis(redisOptions)
         }
@@ -281,18 +238,21 @@ export class Adapter<CustomSettings extends CustomAdapterSettings = SettingsMap>
 
     if (!dependencies.cache) {
       dependencies.cache = CacheFactory.buildCache(
-        { cacheType: this.config.CACHE_TYPE, maxSizeForLocalCache: this.config.CACHE_MAX_ITEMS },
+        {
+          cacheType: this.processedConfig.config.CACHE_TYPE,
+          maxSizeForLocalCache: this.processedConfig.config.CACHE_MAX_ITEMS,
+        },
         dependencies.redisClient,
       )
     }
 
     const rateLimitingTier = getRateLimitingTier(
-      this.config as AdapterConfig,
+      this.processedConfig.config,
       this.rateLimiting?.tiers,
     )
 
     const highestTierValue = highestRateLimitTiers(this.rateLimiting?.tiers)
-    const rateLimitTierFromConfig = buildRateLimitTiersFromConfig(this.config as AdapterConfig)
+    const rateLimitTierFromConfig = buildRateLimitTiersFromConfig(this.processedConfig.config)
     const perSecRateLimit = rateLimitTierFromConfig?.rateLimit1s || 0
     const perMinuteRateLimit = (rateLimitTierFromConfig?.rateLimit1m || 0) * 60
 
@@ -304,7 +264,7 @@ export class Adapter<CustomSettings extends CustomAdapterSettings = SettingsMap>
 
     if (perMinuteRateLimit > highestTierValue) {
       logger.warn(`The configured ${
-        this.config.RATE_LIMIT_CAPACITY_MINUTE
+        this.processedConfig.config.RATE_LIMIT_CAPACITY_MINUTE
           ? 'RATE_LIMIT_CAPACITY_MINUTE'
           : 'RATE_LIMIT_CAPACITY'
       }
@@ -319,13 +279,13 @@ export class Adapter<CustomSettings extends CustomAdapterSettings = SettingsMap>
     }
     if (!dependencies.subscriptionSetFactory) {
       dependencies.subscriptionSetFactory = new SubscriptionSetFactory(
-        this.config as AdapterConfig,
+        this.processedConfig.config,
         this.name,
         dependencies.redisClient,
       )
     }
     if (!dependencies.requester) {
-      dependencies.requester = new Requester(dependencies.rateLimiter, this.config as AdapterConfig)
+      dependencies.requester = new Requester(dependencies.rateLimiter, this.processedConfig.config)
     }
 
     return dependencies as AdapterDependencies
@@ -343,11 +303,14 @@ export class Adapter<CustomSettings extends CustomAdapterSettings = SettingsMap>
     )
 
     if (response) {
-      if (this.config.METRICS_ENABLED && this.config.EXPERIMENTAL_METRICS_ENABLED) {
+      if (
+        this.processedConfig.config.METRICS_ENABLED &&
+        this.processedConfig.config.EXPERIMENTAL_METRICS_ENABLED
+      ) {
         const label = cacheMetricsLabel(
           req.requestContext.cacheKey,
           req.requestContext.meta?.metrics?.feedId || 'N/A',
-          this.config.CACHE_TYPE,
+          this.processedConfig.config.CACHE_TYPE,
         )
 
         // Record cache staleness and cache get count and value
@@ -402,7 +365,7 @@ export class Adapter<CustomSettings extends CustomAdapterSettings = SettingsMap>
           // `await` is required to catch the error, you'll get an unhandled promise rejection otherwise
           // Disable non-null assertion operator because we already checked for the existence of registerRequest
           // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-          return await transport.registerRequest!(req, this.config)
+          return await transport.registerRequest!(req, this.processedConfig.config)
         } catch (err) {
           logger.error(`Error registering request: ${err}`)
           requestRegistrationError = err as Error
@@ -427,7 +390,8 @@ export class Adapter<CustomSettings extends CustomAdapterSettings = SettingsMap>
 
     // If there was no cached response, execute the foregroundExecute if defined
     const immediateResponse =
-      transport.foregroundExecute && (await transport.foregroundExecute(req, this.config))
+      transport.foregroundExecute &&
+      (await transport.foregroundExecute(req, this.processedConfig.config))
     if (immediateResponse) {
       logger.debug('Got immediate response from transport, sending as response')
       return immediateResponse
@@ -453,8 +417,8 @@ export class Adapter<CustomSettings extends CustomAdapterSettings = SettingsMap>
       this.dependencies.cache as Cache<AdapterResponse>,
       req.requestContext.cacheKey,
       {
-        maxRetries: this.config.CACHE_POLLING_MAX_RETRIES,
-        sleep: this.config.CACHE_POLLING_SLEEP_MS,
+        maxRetries: this.processedConfig.config.CACHE_POLLING_MAX_RETRIES,
+        sleep: this.processedConfig.config.CACHE_POLLING_SLEEP_MS,
       },
     )
 

--- a/src/adapter/basic.ts
+++ b/src/adapter/basic.ts
@@ -1,7 +1,7 @@
 import Redis from 'ioredis'
 import { Cache, CacheFactory, pollResponseFromCache } from '../cache'
 import { cacheGet, cacheMetricsLabel } from '../cache/metrics'
-import { BaseAdapterConfig, BaseSettings, ProcessedConfig } from '../config'
+import { BaseAdapterSettings, BaseSettingsDefinition, ProcessedConfig } from '../config'
 import { metrics } from '../metrics'
 import {
   buildRateLimitTiersFromConfig,
@@ -32,7 +32,7 @@ export class Adapter<T extends ProcessedConfig = ProcessedConfig>
   name: Uppercase<string>
   defaultEndpoint?: string | undefined
   endpoints: AdapterEndpoint<EndpointGenerics>[]
-  envDefaultOverrides?: Partial<BaseAdapterConfig> | undefined
+  envDefaultOverrides?: Partial<BaseAdapterSettings> | undefined
   rateLimiting?: AdapterRateLimitingConfig | undefined
   envVarsPrefix?: string
 
@@ -100,7 +100,7 @@ export class Adapter<T extends ProcessedConfig = ProcessedConfig>
       }
 
       logger.debug(`Initializing endpoint "${endpoint.name}"...`)
-      await endpoint.initialize(this.name, this.dependencies, this.processedConfig.config)
+      await endpoint.initialize(this.name, this.dependencies, this.processedConfig.settings)
     }
 
     // Build list of key/values that need to be redacted in logs
@@ -169,27 +169,27 @@ export class Adapter<T extends ProcessedConfig = ProcessedConfig>
    */
   private logConfigWarnings() {
     if (
-      this.processedConfig.config.LOG_LEVEL.toUpperCase() === 'DEBUG' ||
-      this.processedConfig.config.LOG_LEVEL.toUpperCase() === 'TRACE'
+      this.processedConfig.settings.LOG_LEVEL.toUpperCase() === 'DEBUG' ||
+      this.processedConfig.settings.LOG_LEVEL.toUpperCase() === 'TRACE'
     ) {
       logger.warn(
-        `LOG_LEVEL has been set to ${this.processedConfig.config.LOG_LEVEL.toUpperCase()}. Setting higher log levels results in increased memory usage and potentially slower performance.`,
+        `LOG_LEVEL has been set to ${this.processedConfig.settings.LOG_LEVEL.toUpperCase()}. Setting higher log levels results in increased memory usage and potentially slower performance.`,
       )
     }
-    if (this.processedConfig.config.DEBUG === true) {
+    if (this.processedConfig.settings.DEBUG === true) {
       logger.warn(`The adapter is running with DEBUG mode on.`)
     }
-    if (this.processedConfig.config.METRICS_ENABLED === false) {
+    if (this.processedConfig.settings.METRICS_ENABLED === false) {
       logger.warn(
         `METRICS_ENABLED has been set to false. Metrics should not be disabled in a production environment.`,
       )
     }
     if (
-      this.processedConfig.config.MAX_PAYLOAD_SIZE_LIMIT !==
-      BaseSettings.MAX_PAYLOAD_SIZE_LIMIT.default
+      this.processedConfig.settings.MAX_PAYLOAD_SIZE_LIMIT !==
+      BaseSettingsDefinition.MAX_PAYLOAD_SIZE_LIMIT.default
     ) {
       logger.warn(
-        `MAX_PAYLOAD_SIZE_LIMIT has been set to ${this.processedConfig.config.MAX_PAYLOAD_SIZE_LIMIT}. This setting should only be set when absolutely necessary.`,
+        `MAX_PAYLOAD_SIZE_LIMIT has been set to ${this.processedConfig.settings.MAX_PAYLOAD_SIZE_LIMIT}. This setting should only be set when absolutely necessary.`,
       )
     }
   }
@@ -205,26 +205,26 @@ export class Adapter<T extends ProcessedConfig = ProcessedConfig>
     const dependencies = inputDependencies || {}
 
     if (!dependencies.redisClient) {
-      if (this.processedConfig.config.CACHE_TYPE === 'redis') {
-        const maxCooldown = this.processedConfig.config.CACHE_REDIS_MAX_RECONNECT_COOLDOWN
+      if (this.processedConfig.settings.CACHE_TYPE === 'redis') {
+        const maxCooldown = this.processedConfig.settings.CACHE_REDIS_MAX_RECONNECT_COOLDOWN
         const redisOptions = {
           enableAutoPipelining: true, // This will make multiple commands be batch automatically
-          host: this.processedConfig.config.CACHE_REDIS_HOST,
-          port: this.processedConfig.config.CACHE_REDIS_PORT,
-          password: this.processedConfig.config.CACHE_REDIS_PASSWORD,
-          path: this.processedConfig.config.CACHE_REDIS_PATH, // If set, port and host are ignored
-          timeout: this.processedConfig.config.CACHE_REDIS_TIMEOUT,
+          host: this.processedConfig.settings.CACHE_REDIS_HOST,
+          port: this.processedConfig.settings.CACHE_REDIS_PORT,
+          password: this.processedConfig.settings.CACHE_REDIS_PASSWORD,
+          path: this.processedConfig.settings.CACHE_REDIS_PATH, // If set, port and host are ignored
+          timeout: this.processedConfig.settings.CACHE_REDIS_TIMEOUT,
           retryStrategy(times: number): number {
             metrics.get('redisRetriesCount').inc()
             logger.warn(`Redis reconnect attempt #${times}`)
             return Math.min(times * 100, maxCooldown) // Next reconnect attempt time
           },
-          connectTimeout: this.processedConfig.config.CACHE_REDIS_CONNECTION_TIMEOUT,
+          connectTimeout: this.processedConfig.settings.CACHE_REDIS_CONNECTION_TIMEOUT,
           maxRetriesPerRequest: 30, // Limits the number of retries before the adapter shuts down
         }
-        if (this.processedConfig.config.CACHE_REDIS_URL) {
+        if (this.processedConfig.settings.CACHE_REDIS_URL) {
           dependencies.redisClient = new Redis(
-            this.processedConfig.config.CACHE_REDIS_URL,
+            this.processedConfig.settings.CACHE_REDIS_URL,
             redisOptions,
           )
         } else {
@@ -240,20 +240,20 @@ export class Adapter<T extends ProcessedConfig = ProcessedConfig>
     if (!dependencies.cache) {
       dependencies.cache = CacheFactory.buildCache(
         {
-          cacheType: this.processedConfig.config.CACHE_TYPE,
-          maxSizeForLocalCache: this.processedConfig.config.CACHE_MAX_ITEMS,
+          cacheType: this.processedConfig.settings.CACHE_TYPE,
+          maxSizeForLocalCache: this.processedConfig.settings.CACHE_MAX_ITEMS,
         },
         dependencies.redisClient,
       )
     }
 
     const rateLimitingTier = getRateLimitingTier(
-      this.processedConfig.config,
+      this.processedConfig.settings,
       this.rateLimiting?.tiers,
     )
 
     const highestTierValue = highestRateLimitTiers(this.rateLimiting?.tiers)
-    const rateLimitTierFromConfig = buildRateLimitTiersFromConfig(this.processedConfig.config)
+    const rateLimitTierFromConfig = buildRateLimitTiersFromConfig(this.processedConfig.settings)
     const perSecRateLimit = rateLimitTierFromConfig?.rateLimit1s || 0
     const perMinuteRateLimit = (rateLimitTierFromConfig?.rateLimit1m || 0) * 60
 
@@ -265,7 +265,7 @@ export class Adapter<T extends ProcessedConfig = ProcessedConfig>
 
     if (perMinuteRateLimit > highestTierValue) {
       logger.warn(`The configured ${
-        this.processedConfig.config.RATE_LIMIT_CAPACITY_MINUTE
+        this.processedConfig.settings.RATE_LIMIT_CAPACITY_MINUTE
           ? 'RATE_LIMIT_CAPACITY_MINUTE'
           : 'RATE_LIMIT_CAPACITY'
       }
@@ -280,13 +280,16 @@ export class Adapter<T extends ProcessedConfig = ProcessedConfig>
     }
     if (!dependencies.subscriptionSetFactory) {
       dependencies.subscriptionSetFactory = new SubscriptionSetFactory(
-        this.processedConfig.config,
+        this.processedConfig.settings,
         this.name,
         dependencies.redisClient,
       )
     }
     if (!dependencies.requester) {
-      dependencies.requester = new Requester(dependencies.rateLimiter, this.processedConfig.config)
+      dependencies.requester = new Requester(
+        dependencies.rateLimiter,
+        this.processedConfig.settings,
+      )
     }
 
     return dependencies as AdapterDependencies
@@ -305,13 +308,13 @@ export class Adapter<T extends ProcessedConfig = ProcessedConfig>
 
     if (response) {
       if (
-        this.processedConfig.config.METRICS_ENABLED &&
-        this.processedConfig.config.EXPERIMENTAL_METRICS_ENABLED
+        this.processedConfig.settings.METRICS_ENABLED &&
+        this.processedConfig.settings.EXPERIMENTAL_METRICS_ENABLED
       ) {
         const label = cacheMetricsLabel(
           req.requestContext.cacheKey,
           req.requestContext.meta?.metrics?.feedId || 'N/A',
-          this.processedConfig.config.CACHE_TYPE,
+          this.processedConfig.settings.CACHE_TYPE,
         )
 
         // Record cache staleness and cache get count and value
@@ -366,7 +369,7 @@ export class Adapter<T extends ProcessedConfig = ProcessedConfig>
           // `await` is required to catch the error, you'll get an unhandled promise rejection otherwise
           // Disable non-null assertion operator because we already checked for the existence of registerRequest
           // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-          return await transport.registerRequest!(req, this.processedConfig.config)
+          return await transport.registerRequest!(req, this.processedConfig.settings)
         } catch (err) {
           logger.error(`Error registering request: ${err}`)
           requestRegistrationError = err as Error
@@ -392,7 +395,7 @@ export class Adapter<T extends ProcessedConfig = ProcessedConfig>
     // If there was no cached response, execute the foregroundExecute if defined
     const immediateResponse =
       transport.foregroundExecute &&
-      (await transport.foregroundExecute(req, this.processedConfig.config))
+      (await transport.foregroundExecute(req, this.processedConfig.settings))
     if (immediateResponse) {
       logger.debug('Got immediate response from transport, sending as response')
       return immediateResponse
@@ -418,8 +421,8 @@ export class Adapter<T extends ProcessedConfig = ProcessedConfig>
       this.dependencies.cache as Cache<AdapterResponse>,
       req.requestContext.cacheKey,
       {
-        maxRetries: this.processedConfig.config.CACHE_POLLING_MAX_RETRIES,
-        sleep: this.processedConfig.config.CACHE_POLLING_SLEEP_MS,
+        maxRetries: this.processedConfig.settings.CACHE_POLLING_MAX_RETRIES,
+        sleep: this.processedConfig.settings.CACHE_POLLING_SLEEP_MS,
       },
     )
 

--- a/src/adapter/basic.ts
+++ b/src/adapter/basic.ts
@@ -56,10 +56,11 @@ export class Adapter<T extends ProcessedConfig = ProcessedConfig>
     this.name = params.name
     this.defaultEndpoint = params.defaultEndpoint?.toLowerCase()
     this.endpoints = params.endpoints
-    this.processedConfig = params.processedConfig || (new ProcessedConfig({}) as T)
     this.rateLimiting = params.rateLimiting
     this.bootstrap = params.bootstrap
+    this.processedConfig = params.processedConfig || (new ProcessedConfig({}) as T)
 
+    this.processedConfig.initialize()
     this.normalizeEndpointNames()
     this.calculateRateLimitAllocations()
   }

--- a/src/adapter/basic.ts
+++ b/src/adapter/basic.ts
@@ -403,7 +403,7 @@ export class Adapter<T extends AdapterConfig = AdapterConfig>
     // Observe the idle time taken for polling response
     const metricsTimer = metrics
       .get('transportPollingDurationSeconds')
-      .labels({ endpoint: req.requestContext.endpointName })
+      .labels({ adapter_endpoint: req.requestContext.endpointName })
       .startTimer()
 
     logger.debug('Transport is set up, polling cache for response...')
@@ -426,7 +426,7 @@ export class Adapter<T extends AdapterConfig = AdapterConfig>
     // Record polling mechanism failure to return response
     metrics
       .get('transportPollingFailureCount')
-      .labels({ endpoint: req.requestContext.endpointName })
+      .labels({ adapter_endpoint: req.requestContext.endpointName })
       .inc()
 
     logger.debug('Ran out of polling attempts, returning timeout')

--- a/src/adapter/endpoint.ts
+++ b/src/adapter/endpoint.ts
@@ -33,10 +33,7 @@ export class AdapterEndpoint<T extends EndpointGenerics> implements AdapterEndpo
   customInputValidation?: CustomInputValidator<T>
   requestTransforms?: RequestTransform<T>[]
   overrides?: Record<string, string> | undefined
-  customRouter?: (
-    req: AdapterRequest<T['Request']>,
-    adapterConfig: AdapterConfig<T['CustomSettings']>,
-  ) => string
+  customRouter?: (req: AdapterRequest<T['Request']>, adapterConfig: T['Config']) => string
   defaultTransport?: string
 
   constructor(params: AdapterEndpointParams<T>) {
@@ -81,7 +78,7 @@ export class AdapterEndpoint<T extends EndpointGenerics> implements AdapterEndpo
   async initialize(
     adapterName: string,
     dependencies: AdapterDependencies,
-    config: AdapterConfig<T['CustomSettings']>,
+    config: T['Config'],
   ): Promise<void> {
     const responseCache = new ResponseCache({
       dependencies,
@@ -143,7 +140,7 @@ export class AdapterEndpoint<T extends EndpointGenerics> implements AdapterEndpo
 
   getTransportNameForRequest(
     req: AdapterRequest<T['Request']>,
-    adapterConfig: AdapterConfig<T['CustomSettings']>,
+    adapterConfig: T['Config'],
   ): string {
     // If there's only one transport, return it
     if (this.transports[DEFAULT_TRANSPORT_NAME]) {

--- a/src/adapter/endpoint.ts
+++ b/src/adapter/endpoint.ts
@@ -1,5 +1,5 @@
 import { ResponseCache } from '../cache/response'
-import { AdapterConfig } from '../config'
+import { AdapterSettings } from '../config'
 import { Transport } from '../transports'
 import { AdapterRequest, AdapterRequestData, makeLogger } from '../util'
 import { SpecificInputParameters } from '../validation'
@@ -33,7 +33,7 @@ export class AdapterEndpoint<T extends EndpointGenerics> implements AdapterEndpo
   customInputValidation?: CustomInputValidator<T>
   requestTransforms?: RequestTransform<T>[]
   overrides?: Record<string, string> | undefined
-  customRouter?: (req: AdapterRequest<T['Request']>, adapterConfig: T['Config']) => string
+  customRouter?: (req: AdapterRequest<T['Request']>, settings: T['Settings']) => string
   defaultTransport?: string
 
   constructor(params: AdapterEndpointParams<T>) {
@@ -73,16 +73,16 @@ export class AdapterEndpoint<T extends EndpointGenerics> implements AdapterEndpo
    * Performs all necessary initialization processes that are async or need async initialized dependencies
    *
    * @param dependencies - all dependencies initialized at the adapter level
-   * @param config - configuration for the adapter
+   * @param adapterSettings - configuration for the adapter
    */
   async initialize(
     adapterName: string,
     dependencies: AdapterDependencies,
-    config: T['Config'],
+    adapterSettings: T['Settings'],
   ): Promise<void> {
     const responseCache = new ResponseCache({
       dependencies,
-      config: config as AdapterConfig,
+      adapterSettings: adapterSettings as AdapterSettings,
       adapterName,
       endpointName: this.name,
       inputParameters: this.inputParameters,
@@ -95,7 +95,7 @@ export class AdapterEndpoint<T extends EndpointGenerics> implements AdapterEndpo
 
     logger.debug(`Initializing transports for endpoint "${this.name}"...`)
     for (const [transportName, transport] of Object.entries(this.transports)) {
-      await transport.initialize(transportDependencies, config, this.name, transportName)
+      await transport.initialize(transportDependencies, adapterSettings, this.name, transportName)
     }
   }
 
@@ -138,10 +138,7 @@ export class AdapterEndpoint<T extends EndpointGenerics> implements AdapterEndpo
     return req
   }
 
-  getTransportNameForRequest(
-    req: AdapterRequest<T['Request']>,
-    adapterConfig: T['Config'],
-  ): string {
+  getTransportNameForRequest(req: AdapterRequest<T['Request']>, settings: T['Settings']): string {
     // If there's only one transport, return it
     if (this.transports[DEFAULT_TRANSPORT_NAME]) {
       return DEFAULT_TRANSPORT_NAME
@@ -152,7 +149,7 @@ export class AdapterEndpoint<T extends EndpointGenerics> implements AdapterEndpo
     //   2. Default router (try to get it from the input params)
     //   3. Default transport (if it was specified in the instance params)
     const rawTransportName =
-      (this.customRouter && this.customRouter(req, adapterConfig)) ||
+      (this.customRouter && this.customRouter(req, settings)) ||
       this.defaultRouter(req) ||
       this.defaultTransport
 

--- a/src/adapter/price.ts
+++ b/src/adapter/price.ts
@@ -1,4 +1,4 @@
-import { ProcessedConfig } from '../config'
+import { AdapterConfig } from '../config'
 import { AdapterRequest, AdapterRequestContext, AdapterResponse, RequestGenerics } from '../util'
 import { AdapterEndpoint } from './endpoint'
 import { Adapter, AdapterEndpointParams, AdapterParams, PriceEndpointGenerics } from './index'
@@ -102,7 +102,7 @@ type PriceAdapterRequest<T extends RequestGenerics> = AdapterRequest<T> & {
 /**
  * A PriceAdapter is a specific kind of Adapter that includes at least one PriceEnpoint.
  */
-export class PriceAdapter<T extends ProcessedConfig> extends Adapter<T> {
+export class PriceAdapter<T extends AdapterConfig> extends Adapter<T> {
   includesMap?: IncludesMap
 
   constructor(

--- a/src/adapter/price.ts
+++ b/src/adapter/price.ts
@@ -1,4 +1,4 @@
-import { SettingsMap } from '../config'
+import { ProcessedConfig } from '../config'
 import { AdapterRequest, AdapterRequestContext, AdapterResponse, RequestGenerics } from '../util'
 import { AdapterEndpoint } from './endpoint'
 import { Adapter, AdapterEndpointParams, AdapterParams, PriceEndpointGenerics } from './index'
@@ -102,11 +102,11 @@ type PriceAdapterRequest<T extends RequestGenerics> = AdapterRequest<T> & {
 /**
  * A PriceAdapter is a specific kind of Adapter that includes at least one PriceEnpoint.
  */
-export class PriceAdapter<CustomSettings extends SettingsMap> extends Adapter<CustomSettings> {
+export class PriceAdapter<T extends ProcessedConfig> extends Adapter<T> {
   includesMap?: IncludesMap
 
   constructor(
-    params: AdapterParams<CustomSettings> & {
+    params: AdapterParams<T> & {
       includes?: IncludesFile
     },
   ) {

--- a/src/adapter/types.ts
+++ b/src/adapter/types.ts
@@ -105,7 +105,7 @@ export interface AdapterParams<T extends AdapterConfig = AdapterConfig> {
   /** Bootstrap function that will run when initializing the adapter */
   bootstrap?: (adapter: Adapter<T>) => Promise<void>
 
-  /** TODO: complete */
+  /** The custom [[AdapterConfig]] to use. If not provided, the default configuration will be used instead */
   config?: T
 }
 

--- a/src/adapter/types.ts
+++ b/src/adapter/types.ts
@@ -1,7 +1,7 @@
 import type EventSource from 'eventsource'
 import Redis from 'ioredis'
 import { Cache } from '../cache'
-import { BaseAdapterConfig, ProcessedConfig, SettingsMap } from '../config'
+import { BaseAdapterSettings, ProcessedConfig, SettingsDefinitionMap } from '../config'
 import { AdapterRateLimitTier, RateLimiter } from '../rate-limiting'
 import { Transport, TransportGenerics } from '../transports'
 import { AdapterRequest, SingleNumberResultResponse, SubscriptionSetFactory } from '../util'
@@ -11,9 +11,9 @@ import { AdapterError } from '../validation/error'
 import { Adapter } from './basic'
 import { AdapterEndpoint } from './endpoint'
 
-export type CustomAdapterSettings = SettingsMap & NegatedAdapterSettings
+export type CustomAdapterSettings = SettingsDefinitionMap & NegatedAdapterSettings
 type NegatedAdapterSettings = {
-  [K in keyof BaseAdapterConfig]?: never
+  [K in keyof BaseAdapterSettings]?: never
 }
 
 /**
@@ -51,7 +51,7 @@ export interface EndpointContext<T extends EndpointGenerics> {
   inputParameters: InputParameters
 
   /** Initialized config for the adapter that the Transport can access */
-  adapterConfig: T['Config']
+  adapterSettings: T['Settings']
 }
 
 /**
@@ -133,7 +133,7 @@ export type PriceEndpointGenerics = TransportGenerics & { Response: SingleNumber
 
 export type CustomInputValidator<T extends EndpointGenerics> = (
   input: AdapterRequest<T['Request']>,
-  config: T['Config'],
+  adapterSettings: T['Settings'],
 ) => AdapterError | undefined
 
 /**
@@ -176,7 +176,7 @@ type MultiTransportAdapterEndpointParams<T extends EndpointGenerics> = {
   transports: Record<string, Transport<T>>
 
   /** Custom function to direct an incoming request to the appropriate transport from the transports map */
-  customRouter?: (req: AdapterRequest<T['Request']>, adapterConfig: T['Config']) => string
+  customRouter?: (req: AdapterRequest<T['Request']>, settings: T['Settings']) => string
 
   /** If no value is returned from the custom router or the default (transport param), which transport to use */
   defaultTransport?: string

--- a/src/adapter/types.ts
+++ b/src/adapter/types.ts
@@ -1,7 +1,7 @@
 import type EventSource from 'eventsource'
 import Redis from 'ioredis'
 import { Cache } from '../cache'
-import { BaseAdapterSettings, ProcessedConfig, SettingsDefinitionMap } from '../config'
+import { BaseAdapterSettings, AdapterConfig, SettingsDefinitionMap } from '../config'
 import { AdapterRateLimitTier, RateLimiter } from '../rate-limiting'
 import { Transport, TransportGenerics } from '../transports'
 import { AdapterRequest, SingleNumberResultResponse, SubscriptionSetFactory } from '../util'
@@ -81,7 +81,7 @@ export type Overrides = {
 /**
  * Main structure of an External Adapter
  */
-export interface AdapterParams<T extends ProcessedConfig = ProcessedConfig> {
+export interface AdapterParams<T extends AdapterConfig = AdapterConfig> {
   /** Name of the adapter */
   name: Uppercase<string>
 
@@ -106,7 +106,7 @@ export interface AdapterParams<T extends ProcessedConfig = ProcessedConfig> {
   bootstrap?: (adapter: Adapter<T>) => Promise<void>
 
   /** TODO: complete */
-  processedConfig?: T
+  config?: T
 }
 
 /**

--- a/src/adapter/types.ts
+++ b/src/adapter/types.ts
@@ -106,7 +106,7 @@ export interface AdapterParams<T extends ProcessedConfig = ProcessedConfig> {
   bootstrap?: (adapter: Adapter<T>) => Promise<void>
 
   /** TODO: complete */
-  processedConfig: T
+  processedConfig?: T
 }
 
 /**

--- a/src/background-executor.ts
+++ b/src/background-executor.ts
@@ -45,7 +45,7 @@ export async function callBackgroundExecutes(adapter: Adapter, apiShutdownPromis
     const context: EndpointContext<EndpointGenerics> = {
       endpointName: endpoint.name,
       inputParameters: endpoint.inputParameters,
-      adapterConfig: adapter.config,
+      adapterConfig: adapter.processedConfig.config,
     }
 
     const handler = async () => {

--- a/src/background-executor.ts
+++ b/src/background-executor.ts
@@ -45,7 +45,7 @@ export async function callBackgroundExecutes(adapter: Adapter, apiShutdownPromis
     const context: EndpointContext<EndpointGenerics> = {
       endpointName: endpoint.name,
       inputParameters: endpoint.inputParameters,
-      adapterConfig: adapter.processedConfig.config,
+      adapterSettings: adapter.processedConfig.settings,
     }
 
     const handler = async () => {

--- a/src/background-executor.ts
+++ b/src/background-executor.ts
@@ -56,13 +56,13 @@ export async function callBackgroundExecutes(adapter: Adapter, apiShutdownPromis
       // Count number of background executions per endpoint
       metrics
         .get('bgExecuteTotal')
-        .labels({ endpoint: endpoint.name, transport: transportName })
+        .labels({ adapter_endpoint: endpoint.name, transport: transportName })
         .inc()
 
       // Time the duration of the background execute process excluding sleep time
       const metricsTimer = metrics
         .get('bgExecuteDurationSeconds')
-        .labels({ endpoint: endpoint.name, transport: transportName })
+        .labels({ adapter_endpoint: endpoint.name, transport: transportName })
         .startTimer()
 
       logger.debug(`Calling background execute for endpoint "${endpoint.name}"`)
@@ -80,7 +80,7 @@ export async function callBackgroundExecutes(adapter: Adapter, apiShutdownPromis
         logger.error(error, (error as Error).stack)
         metrics
           .get('bgExecuteErrors')
-          .labels({ endpoint: endpoint.name, transport: transportName })
+          .labels({ adapter_endpoint: endpoint.name, transport: transportName })
           .inc()
       }
 

--- a/src/background-executor.ts
+++ b/src/background-executor.ts
@@ -45,7 +45,7 @@ export async function callBackgroundExecutes(adapter: Adapter, apiShutdownPromis
     const context: EndpointContext<EndpointGenerics> = {
       endpointName: endpoint.name,
       inputParameters: endpoint.inputParameters,
-      adapterSettings: adapter.processedConfig.settings,
+      adapterSettings: adapter.config.settings,
     }
 
     const handler = async () => {

--- a/src/cache/index.ts
+++ b/src/cache/index.ts
@@ -1,6 +1,5 @@
 import crypto from 'crypto'
 import { EndpointContext, EndpointGenerics } from '../adapter'
-import { AdapterConfig } from '../config'
 import { AdapterResponse, makeLogger, sleep } from '../util'
 import { InputParameters } from '../validation'
 import { CacheTypes as CacheType } from './metrics'
@@ -76,7 +75,7 @@ export const calculateCacheKey = <T extends EndpointGenerics>({
   inputParameters: InputParameters
   adapterName: string
   endpointName: string
-  adapterConfig: AdapterConfig<T['CustomSettings']>
+  adapterConfig: T['Config']
   transportName: string
 }): string => {
   const calculatedKey = calculateKey({
@@ -122,7 +121,7 @@ const calculateKey = <T extends EndpointGenerics>({
   data: unknown
   endpointName: string
   transportName: string
-  adapterConfig: AdapterConfig<T['CustomSettings']>
+  adapterConfig: T['Config']
   inputParameters: InputParameters
 }) => {
   const paramsKey = Object.keys(inputParameters).length
@@ -137,7 +136,7 @@ export const calculateFeedId = <T extends EndpointGenerics>(
     adapterConfig,
   }: {
     inputParameters: InputParameters
-    adapterConfig: AdapterConfig<T['CustomSettings']>
+    adapterConfig: T['Config']
   },
   data: unknown,
 ): string => {

--- a/src/cache/index.ts
+++ b/src/cache/index.ts
@@ -68,19 +68,19 @@ export const calculateCacheKey = <T extends EndpointGenerics>({
   inputParameters,
   adapterName,
   endpointName,
-  adapterConfig,
+  adapterSettings,
   transportName,
 }: {
   data: unknown
   inputParameters: InputParameters
   adapterName: string
   endpointName: string
-  adapterConfig: T['Config']
+  adapterSettings: T['Settings']
   transportName: string
 }): string => {
   const calculatedKey = calculateKey({
     data,
-    adapterConfig,
+    adapterSettings,
     endpointName,
     transportName,
     inputParameters,
@@ -103,7 +103,7 @@ export const calculateHttpRequestKey = <T extends EndpointGenerics>({
   const key = calculateKey({
     data,
     transportName,
-    adapterConfig: context.adapterConfig,
+    adapterSettings: context.adapterSettings,
     endpointName: context.endpointName,
     inputParameters: context.inputParameters,
   })
@@ -115,28 +115,28 @@ const calculateKey = <T extends EndpointGenerics>({
   data,
   endpointName,
   transportName,
-  adapterConfig,
+  adapterSettings,
   inputParameters,
 }: {
   data: unknown
   endpointName: string
   transportName: string
-  adapterConfig: T['Config']
+  adapterSettings: T['Settings']
   inputParameters: InputParameters
 }) => {
   const paramsKey = Object.keys(inputParameters).length
-    ? calculateParamsKey(data, adapterConfig.MAX_COMMON_KEY_SIZE)
-    : adapterConfig.DEFAULT_CACHE_KEY
+    ? calculateParamsKey(data, adapterSettings.MAX_COMMON_KEY_SIZE)
+    : adapterSettings.DEFAULT_CACHE_KEY
   return `${endpointName}-${transportName}-${paramsKey}`
 }
 
 export const calculateFeedId = <T extends EndpointGenerics>(
   {
     inputParameters,
-    adapterConfig,
+    adapterSettings,
   }: {
     inputParameters: InputParameters
-    adapterConfig: T['Config']
+    adapterSettings: T['Settings']
   },
   data: unknown,
 ): string => {
@@ -144,7 +144,7 @@ export const calculateFeedId = <T extends EndpointGenerics>(
     logger.trace(`Cannot generate Feed ID without input parameters`)
     return 'N/A'
   }
-  return calculateParamsKey(data, adapterConfig.MAX_COMMON_KEY_SIZE)
+  return calculateParamsKey(data, adapterSettings.MAX_COMMON_KEY_SIZE)
 }
 
 /**

--- a/src/cache/response.ts
+++ b/src/cache/response.ts
@@ -1,5 +1,5 @@
 import { AdapterDependencies } from '../adapter'
-import { AdapterConfig } from '../config'
+import { AdapterSettings } from '../config'
 import {
   AdapterResponse,
   RequestGenerics,
@@ -24,17 +24,17 @@ export class ResponseCache<
   inputParameters: InputParameters
   adapterName: string
   endpointName: string
-  config: AdapterConfig
+  adapterSettings: AdapterSettings
 
   constructor({
     inputParameters,
     adapterName,
     endpointName,
-    config,
+    adapterSettings,
     dependencies,
   }: {
     dependencies: AdapterDependencies
-    config: AdapterConfig
+    adapterSettings: AdapterSettings
     adapterName: string
     endpointName: string
     inputParameters: InputParameters
@@ -43,7 +43,7 @@ export class ResponseCache<
     this.inputParameters = inputParameters
     this.adapterName = adapterName
     this.endpointName = endpointName
-    this.config = config
+    this.adapterSettings = adapterSettings
   }
 
   /**
@@ -58,13 +58,16 @@ export class ResponseCache<
         statusCode: (r.response as TimestampedProviderErrorResponse).statusCode || 200,
       }
 
-      if (this.config.METRICS_ENABLED && this.config.EXPERIMENTAL_METRICS_ENABLED) {
+      if (
+        this.adapterSettings.METRICS_ENABLED &&
+        this.adapterSettings.EXPERIMENTAL_METRICS_ENABLED
+      ) {
         response.meta = {
           metrics: {
             feedId: calculateFeedId(
               {
                 inputParameters: this.inputParameters,
-                adapterConfig: this.config,
+                adapterSettings: this.adapterSettings,
               },
               r.params,
             ),
@@ -79,13 +82,13 @@ export class ResponseCache<
           inputParameters: this.inputParameters,
           adapterName: this.adapterName,
           endpointName: this.endpointName,
-          adapterConfig: this.config,
+          adapterSettings: this.adapterSettings,
         }),
         value: response,
       } as const
     })
 
-    const ttl = this.config.CACHE_MAX_AGE
+    const ttl = this.adapterSettings.CACHE_MAX_AGE
     await this.cache.setMany(entries, ttl)
 
     const now = Date.now()

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -522,7 +522,7 @@ export type ValidationErrorMessage = string | undefined
  * Then in the generics we can simply pass the type of this, and it will hopefully allow for simpler generics
  * name is placeholder
  */
-export class ProcessedConfig<T extends SettingsDefinitionMap = SettingsDefinitionMap> {
+export class AdapterConfig<T extends SettingsDefinitionMap = SettingsDefinitionMap> {
   settings!: AdapterSettings<T>
 
   constructor(

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -526,7 +526,7 @@ export class ProcessedConfig<T extends SettingsMap = SettingsMap> {
       envDefaultOverrides?: Partial<BaseAdapterConfig>
 
       /** TODO: complete */
-      envVarsPrefix: string
+      envVarsPrefix?: string
     },
   ) {}
 

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,7 +1,7 @@
 import CensorList, { CensorKeyValue } from '../util/censor/censor-list'
 import { validator } from '../validation/utils'
 
-export const BaseSettings = {
+export const BaseSettingsDefinition = {
   // V2 compat
   // ADAPTER_URL: {
   //   description: 'The URL of another adapter from which data needs to be retrieved',
@@ -312,28 +312,30 @@ export const BaseSettings = {
     default: 1000,
     validate: validator.integer({ min: 1, max: 10000 }),
   },
-} as const satisfies SettingsMap
+} as const satisfies SettingsDefinitionMap
 
-export const buildAdapterConfig = <
-  CustomSettings extends CustomSettingsType<CustomSettings> = EmptySettings,
+export const buildAdapterSettings = <
+  CustomSettings extends CustomSettingsDefinition<CustomSettings> = EmptySettingsDefinitionMap,
 >({
-  overrides = {} as Partial<BaseAdapterConfig>,
-  customSettings = {} as SettingsMap,
+  overrides = {} as Partial<BaseAdapterSettings>,
+  customSettings = {} as SettingsDefinitionMap,
   envVarsPrefix = '' as string,
-}): AdapterConfig<CustomSettings> => {
+}): AdapterSettings<CustomSettings> => {
   const vars = {} as Record<string, SettingValueType | undefined>
 
   // Iterate base adapter env vars
-  for (const [key, config] of Object.entries(BaseSettings) as Array<
-    [keyof BaseAdapterConfig, Setting]
+  for (const [key, config] of Object.entries(BaseSettingsDefinition) as Array<
+    [keyof BaseAdapterSettings, SettingDefinition]
   >) {
     const value = getEnv(key as string, config, envVarsPrefix) ?? overrides?.[key] ?? config.default
     vars[key] = value
   }
 
   // Iterate custom vars
-  for (const [key, config] of Object.entries(customSettings) as Array<[string, Setting]>) {
-    if ((BaseSettings as Record<string, unknown>)[key as string]) {
+  for (const [key, config] of Object.entries(customSettings) as Array<
+    [string, SettingDefinition]
+  >) {
+    if ((BaseSettingsDefinition as Record<string, unknown>)[key as string]) {
       throw new Error(
         `Custom env var "${key}" declared, but a base framework env var with that name already exists.`,
       )
@@ -342,22 +344,22 @@ export const buildAdapterConfig = <
     vars[key] = value
   }
 
-  return vars as AdapterConfig<CustomSettings>
+  return vars as AdapterSettings<CustomSettings>
 }
 
 const validateSetting = (
   key: string,
   value: SettingValueType | undefined,
-  config: Setting,
+  settingsDefinition: SettingDefinition,
   validationErrors: string[],
 ) => {
   // Check if a required setting has been provided
-  if (config.required && (value === null || value === undefined)) {
+  if (settingsDefinition.required && (value === null || value === undefined)) {
     validationErrors.push(`${key}: Value is required, but none was provided`)
-  } else if (value && config.validate) {
+  } else if (value && settingsDefinition.validate) {
     // Cast validate to unknown because TS can't select one of multiple variants of the validate function signature
     const validationRes = (
-      config.validate as unknown as (value?: SettingValueType) => ValidationErrorMessage
+      settingsDefinition.validate as unknown as (value?: SettingValueType) => ValidationErrorMessage
     )(value)
     if (validationRes) {
       validationErrors.push(`${key}: ${validationRes}`)
@@ -377,14 +379,18 @@ const getEnvName = (name: string, prefix = ''): string => {
 
 const isEnvNameValid = (name: string) => /^[_a-z0-9]+$/i.test(name)
 
-export const getEnv = (name: string, config: Setting, prefix = ''): SettingValueType | null => {
+export const getEnv = (
+  name: string,
+  settingsDefinition: SettingDefinition,
+  prefix = '',
+): SettingValueType | null => {
   const value = process.env[getEnvName(name, prefix)]
 
   if (!value || value === '' || value === '""') {
     return null
   }
 
-  switch (config.type) {
+  switch (settingsDefinition.type) {
     case 'string':
       return value
     case 'number':
@@ -392,9 +398,9 @@ export const getEnv = (name: string, config: Setting, prefix = ''): SettingValue
     case 'boolean':
       return value === 'true'
     case 'enum':
-      if (!config.options?.includes(value)) {
+      if (!settingsDefinition.options?.includes(value)) {
         throw new Error(
-          `Env var "${name}" has value "${value}" which is not included in the valid options (${config.options})`,
+          `Env var "${name}" has value "${value}" which is not included in the valid options (${settingsDefinition.options})`,
         )
       }
       return value
@@ -402,7 +408,7 @@ export const getEnv = (name: string, config: Setting, prefix = ''): SettingValue
 }
 
 type SettingValueType = string | number | boolean
-type SettingType<C extends Setting> = C['type'] extends 'string'
+type SettingType<C extends SettingDefinition> = C['type'] extends 'string'
   ? string
   : C['type'] extends 'number'
   ? number
@@ -413,8 +419,8 @@ type SettingType<C extends Setting> = C['type'] extends 'string'
     ? C['options'][number]
     : never
   : never
-type BaseSettingsType = typeof BaseSettings
-export type Setting =
+type BaseSettingsDefinitionType = typeof BaseSettingsDefinition
+export type SettingDefinition =
   | {
       type: 'string'
       description: string
@@ -482,7 +488,7 @@ export type Setting =
       required: true
     }
 
-export type AdapterConfigFromSettings<T extends SettingsMap> = {
+export type Settings<T extends SettingsDefinitionMap> = {
   -readonly [K in keyof T as T[K] extends {
     default: SettingValueType
   }
@@ -500,13 +506,13 @@ export type AdapterConfigFromSettings<T extends SettingsMap> = {
     : K]?: SettingType<T[K]> | undefined
 }
 
-export type BaseAdapterConfig = AdapterConfigFromSettings<BaseSettingsType>
-export type AdapterConfig<T extends CustomSettingsType<T> = SettingsMap> =
-  AdapterConfigFromSettings<T> & BaseAdapterConfig & ConfigObjectSpecifier
+export type BaseAdapterSettings = Settings<BaseSettingsDefinitionType>
+export type AdapterSettings<T extends CustomSettingsDefinition<T> = SettingsDefinitionMap> =
+  Settings<T> & BaseAdapterSettings & SettingsObjectSpecifier
 
-export type CustomSettingsType<T = SettingsMap> = Record<keyof T, Setting>
-export type EmptySettings = Record<string, never>
-export type SettingsMap = Record<string, Setting>
+export type CustomSettingsDefinition<T = SettingsDefinitionMap> = Record<keyof T, SettingDefinition>
+export type EmptySettingsDefinitionMap = Record<string, never>
+export type SettingsDefinitionMap = Record<string, SettingDefinition>
 export type ValidationErrorMessage = string | undefined
 
 /**
@@ -516,14 +522,14 @@ export type ValidationErrorMessage = string | undefined
  * Then in the generics we can simply pass the type of this, and it will hopefully allow for simpler generics
  * name is placeholder
  */
-export class ProcessedConfig<T extends SettingsMap = SettingsMap> {
-  config!: AdapterConfig<T>
+export class ProcessedConfig<T extends SettingsDefinitionMap = SettingsDefinitionMap> {
+  settings!: AdapterSettings<T>
 
   constructor(
-    private settings: T,
+    private settingsDefinition: T,
     private options?: {
       /** Map of overrides to the default config values for an Adapter */
-      envDefaultOverrides?: Partial<BaseAdapterConfig>
+      envDefaultOverrides?: Partial<BaseAdapterSettings>
 
       /** TODO: complete */
       envVarsPrefix?: string
@@ -531,8 +537,8 @@ export class ProcessedConfig<T extends SettingsMap = SettingsMap> {
   ) {}
 
   initialize() {
-    this.config = buildAdapterConfig({
-      customSettings: this.settings,
+    this.settings = buildAdapterSettings({
+      customSettings: this.settingsDefinition,
       overrides: this.options?.envDefaultOverrides,
       envVarsPrefix: this.options?.envVarsPrefix,
     })
@@ -540,12 +546,12 @@ export class ProcessedConfig<T extends SettingsMap = SettingsMap> {
 
   validate(): void {
     const validationErrors: string[] = []
-    Object.entries(BaseSettings as SettingsMap)
-      .concat(Object.entries(this.settings || {}))
+    Object.entries(BaseSettingsDefinition as SettingsDefinitionMap)
+      .concat(Object.entries(this.settingsDefinition || {}))
       .forEach(([name, setting]) => {
         validateSetting(
           name,
-          (this.config as Record<string, ValidSettingValue>)[name],
+          (this.settings as Record<string, ValidSettingValue>)[name],
           setting,
           validationErrors,
         )
@@ -563,21 +569,23 @@ export class ProcessedConfig<T extends SettingsMap = SettingsMap> {
    * using the sensitive flag in the adapter config
    */
   buildCensorList() {
-    const censorList: CensorKeyValue[] = Object.entries(BaseSettings as SettingsMap)
-      .concat(Object.entries((this.settings as SettingsMap) || {}))
+    const censorList: CensorKeyValue[] = Object.entries(
+      BaseSettingsDefinition as SettingsDefinitionMap,
+    )
+      .concat(Object.entries((this.settingsDefinition as SettingsDefinitionMap) || {}))
       .filter(
         ([name, setting]) =>
           setting &&
           setting.type === 'string' &&
           setting.sensitive &&
-          (this.config as Record<string, ValidSettingValue>)[name],
+          (this.settings as Record<string, ValidSettingValue>)[name],
       )
       .map(([name]) => ({
         key: name,
         // Escaping potential special characters in values before creating regex
         value: new RegExp(
           // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-          ((this.config as AdapterConfig)[name]! as string).replace(
+          ((this.settings as AdapterSettings)[name]! as string).replace(
             /[-[\]{}()*+?.,\\^$|#\s]/g,
             '\\$&',
           ),
@@ -588,8 +596,8 @@ export class ProcessedConfig<T extends SettingsMap = SettingsMap> {
   }
 }
 
-type ConfigObjectSpecifier = {
+type SettingsObjectSpecifier = {
   __reserved_settings: never
 }
 type ValidSettingValue = string | number | boolean
-export type GenericConfigStructure = BaseAdapterConfig & ConfigObjectSpecifier
+export type GenericConfigStructure = BaseAdapterSettings & SettingsObjectSpecifier

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -516,26 +516,28 @@ export type SettingsDefinitionMap = Record<string, SettingDefinition>
 export type ValidationErrorMessage = string | undefined
 
 /**
- * TODO: Improve docs
- * This class will hold the processed config type, and the basic settings
- * The idea is that you can no longer use a straight object, but have to build a config
- * Then in the generics we can simply pass the type of this, and it will hopefully allow for simpler generics
- * name is placeholder
+ * This class will hold the processed config type, and the basic settings.
+ * The idea is that you can no longer use a straight object, but have to build a config,
+ * then in the generics we can simply pass the type of this, and it will hopefully allow for simpler generics
  */
 export class AdapterConfig<T extends SettingsDefinitionMap = SettingsDefinitionMap> {
   settings!: AdapterSettings<T>
 
   constructor(
+    /** Map of setting definitions to validate and use to get setting values */
     private settingsDefinition: T,
     private options?: {
       /** Map of overrides to the default config values for an Adapter */
       envDefaultOverrides?: Partial<BaseAdapterSettings>
 
-      /** TODO: complete */
+      /** Optional prefix that all adapter variables will be expected to have */
       envVarsPrefix?: string
     },
   ) {}
 
+  /**
+   * Performs some basic validation of the definition structure, and pull data from environment variables
+   */
   initialize() {
     this.settings = buildAdapterSettings({
       customSettings: this.settingsDefinition,
@@ -544,6 +546,9 @@ export class AdapterConfig<T extends SettingsDefinitionMap = SettingsDefinitionM
     })
   }
 
+  /**
+   * Performs validation of each setting, checking to see that they match their definition
+   */
   validate(): void {
     const validationErrors: string[] = []
     Object.entries(BaseSettingsDefinition as SettingsDefinitionMap)

--- a/src/metrics/index.ts
+++ b/src/metrics/index.ts
@@ -1,7 +1,7 @@
 import * as client from 'prom-client'
 import { HttpRequestType, requestDurationBuckets } from './constants'
 import { AdapterRequest, makeLogger } from '../util'
-import { AdapterConfig } from '../config'
+import { AdapterSettings } from '../config'
 import fastify, { FastifyReply, HookHandlerDoneFunction } from 'fastify'
 import { join } from 'path'
 import { AdapterError } from '../validation/error'
@@ -9,15 +9,17 @@ import { getMTLSOptions, httpsOptions } from '../index'
 
 const logger = makeLogger('Metrics')
 
-export function setupMetricsServer(name: string, config: AdapterConfig) {
-  const mTLSOptions: httpsOptions | Record<string, unknown> = getMTLSOptions(config)
+export function setupMetricsServer(name: string, adapterSettings: AdapterSettings) {
+  const mTLSOptions: httpsOptions | Record<string, unknown> = getMTLSOptions(adapterSettings)
   const metricsApp = fastify({
     ...mTLSOptions,
     logger: false,
   })
-  const metricsPort = config.METRICS_PORT
-  const endpoint = config.METRICS_USE_BASE_URL ? join(config.BASE_URL, 'metrics') : '/metrics'
-  const eaHost = config.EA_HOST
+  const metricsPort = adapterSettings.METRICS_PORT
+  const endpoint = adapterSettings.METRICS_USE_BASE_URL
+    ? join(adapterSettings.BASE_URL, 'metrics')
+    : '/metrics'
+  const eaHost = adapterSettings.EA_HOST
   logger.info(`Metrics endpoint: http://${eaHost}:${metricsPort}${endpoint}`)
 
   setupMetrics(name)

--- a/src/metrics/index.ts
+++ b/src/metrics/index.ts
@@ -192,22 +192,22 @@ export const metrics = new Metrics(() => ({
   bgExecuteSubscriptionSetCount: new client.Gauge({
     name: 'bg_execute_subscription_set_count',
     help: 'The number of active subscriptions in background execute',
-    labelNames: ['endpoint', 'transport_type'] as const,
+    labelNames: ['adapter_endpoint', 'transport_type'] as const,
   }),
   bgExecuteTotal: new client.Counter({
     name: 'bg_execute_total',
     help: 'The number of background executes performed per endpoint',
-    labelNames: ['endpoint', 'transport'] as const,
+    labelNames: ['adapter_endpoint', 'transport'] as const,
   }),
   bgExecuteErrors: new client.Counter({
     name: 'bg_execute_errors',
     help: 'The number of background execute errors per endpoint x transport',
-    labelNames: ['endpoint', 'transport'] as const,
+    labelNames: ['adapter_endpoint', 'transport'] as const,
   }),
   bgExecuteDurationSeconds: new client.Gauge({
     name: 'bg_execute_duration_seconds',
     help: 'A histogram bucket of the distribution of background execute durations',
-    labelNames: ['endpoint', 'transport'] as const,
+    labelNames: ['adapter_endpoint', 'transport'] as const,
   }),
   cacheDataGetCount: new client.Counter({
     name: 'cache_data_get_count',
@@ -290,12 +290,12 @@ export const metrics = new Metrics(() => ({
   transportPollingFailureCount: new client.Counter({
     name: 'transport_polling_failure_count',
     help: 'The number of times the polling mechanism ran out of attempts and failed to return a response',
-    labelNames: ['endpoint'] as const,
+    labelNames: ['adapter_endpoint'] as const,
   }),
   transportPollingDurationSeconds: new client.Gauge({
     name: 'transport_polling_duration_seconds',
     help: 'A histogram bucket of the distribution of transport polling idle time durations',
-    labelNames: ['endpoint', 'succeeded'] as const,
+    labelNames: ['adapter_endpoint', 'succeeded'] as const,
   }),
   rateLimitCreditsSpentTotal: new client.Counter({
     name: 'rate_limit_credits_spent_total',

--- a/src/metrics/util.ts
+++ b/src/metrics/util.ts
@@ -1,13 +1,12 @@
 import { EndpointGenerics } from '../adapter'
 import { calculateFeedId } from '../cache'
-import { AdapterConfig } from '../config'
 import { AdapterMetricsMeta, AdapterRequestData } from '../util'
 import { InputParameters } from '../validation'
 
 export const getMetricsMeta = <T extends EndpointGenerics>(
   args: {
     inputParameters: InputParameters
-    adapterConfig: AdapterConfig<T['CustomSettings']>
+    adapterConfig: T['Config']
   },
   data: AdapterRequestData,
 ): AdapterMetricsMeta => {

--- a/src/metrics/util.ts
+++ b/src/metrics/util.ts
@@ -6,7 +6,7 @@ import { InputParameters } from '../validation'
 export const getMetricsMeta = <T extends EndpointGenerics>(
   args: {
     inputParameters: InputParameters
-    adapterConfig: T['Config']
+    adapterSettings: T['Settings']
   },
   data: AdapterRequestData,
 ): AdapterMetricsMeta => {

--- a/src/rate-limiting/index.ts
+++ b/src/rate-limiting/index.ts
@@ -1,5 +1,5 @@
 import { AdapterEndpoint, EndpointGenerics } from '../adapter'
-import { AdapterConfig } from '../config'
+import { AdapterSettings } from '../config'
 import { makeLogger } from '../util'
 
 export * from './simple-counting'
@@ -80,20 +80,20 @@ export const lowestTierLimit = (limits?: AdapterRateLimitTier) => {
 /**
  * Validates rate limiting tiers specified for the adapter, and returns the one to use.
  *
- * @param config - the adapter config containing the env vars
+ * @param adapterSettings - the adapter config containing the env vars
  * @param tiers - the adapter config listing the different available API tiers
  * @returns the specified API tier, or a default one if none are specified
  */
 export const getRateLimitingTier = (
-  config: AdapterConfig,
+  adapterSettings: AdapterSettings,
   tiers?: Record<string, AdapterRateLimitTier>,
 ): AdapterRateLimitTier | undefined => {
   if (
-    config.RATE_LIMIT_CAPACITY ||
-    config.RATE_LIMIT_CAPACITY_MINUTE ||
-    config.RATE_LIMIT_CAPACITY_SECOND
+    adapterSettings.RATE_LIMIT_CAPACITY ||
+    adapterSettings.RATE_LIMIT_CAPACITY_MINUTE ||
+    adapterSettings.RATE_LIMIT_CAPACITY_SECOND
   ) {
-    return buildRateLimitTiersFromConfig(config)
+    return buildRateLimitTiersFromConfig(adapterSettings)
   }
   if (!tiers) {
     return
@@ -105,7 +105,7 @@ export const getRateLimitingTier = (
   }
 
   // Check that the tier set in the AdapterConfig is a valid one
-  const selectedTier = config.RATE_LIMIT_API_TIER
+  const selectedTier = adapterSettings.RATE_LIMIT_API_TIER
   if (selectedTier && !tiers[selectedTier]) {
     const validTiersString = Object.keys(tiers)
       .map((t) => `"${t}"`)
@@ -133,14 +133,14 @@ export const getRateLimitingTier = (
 
 // Creates adapter rate limit tier using the configs specified in env vars
 export const buildRateLimitTiersFromConfig = (
-  config: AdapterConfig,
+  adapterSettings: AdapterSettings,
 ): AdapterRateLimitTier | undefined => {
-  const rateLimit1s = config.RATE_LIMIT_CAPACITY_SECOND
+  const rateLimit1s = adapterSettings.RATE_LIMIT_CAPACITY_SECOND
   let rateLimit1m
-  if (config.RATE_LIMIT_CAPACITY_MINUTE) {
-    rateLimit1m = config.RATE_LIMIT_CAPACITY_MINUTE
-  } else if (config.RATE_LIMIT_CAPACITY) {
-    rateLimit1m = config.RATE_LIMIT_CAPACITY
+  if (adapterSettings.RATE_LIMIT_CAPACITY_MINUTE) {
+    rateLimit1m = adapterSettings.RATE_LIMIT_CAPACITY_MINUTE
+  } else if (adapterSettings.RATE_LIMIT_CAPACITY) {
+    rateLimit1m = adapterSettings.RATE_LIMIT_CAPACITY
   }
   return {
     rateLimit1s,

--- a/src/transports/abstract/subscription.ts
+++ b/src/transports/abstract/subscription.ts
@@ -56,7 +56,7 @@ export abstract class SubscriptionTransport<T extends TransportGenerics> impleme
     // this.constructor.name will resolve to the instance name, not the class one (i.e., will use the implementing class' name)
     metrics
       .get('bgExecuteSubscriptionSetCount')
-      .labels({ endpoint: context.endpointName, transport_type: this.constructor.name })
+      .labels({ adapter_endpoint: context.endpointName, transport_type: this.constructor.name })
       .set(entries.length)
 
     await this.backgroundHandler(context, entries)

--- a/src/transports/abstract/subscription.ts
+++ b/src/transports/abstract/subscription.ts
@@ -1,10 +1,9 @@
+import { Transport, TransportDependencies, TransportGenerics } from '..'
 import { EndpointContext } from '../../adapter'
 import { ResponseCache } from '../../cache/response'
-import { AdapterConfig } from '../../config'
+import { metrics } from '../../metrics'
 import { makeLogger, SubscriptionSet } from '../../util'
 import { AdapterRequest } from '../../util/types'
-import { Transport, TransportDependencies, TransportGenerics } from '..'
-import { metrics } from '../../metrics'
 
 const logger = makeLogger('SubscriptionTransport')
 
@@ -25,7 +24,7 @@ export abstract class SubscriptionTransport<T extends TransportGenerics> impleme
 
   async initialize(
     dependencies: TransportDependencies<T>,
-    config: AdapterConfig<T['CustomSettings']>,
+    config: T['Config'],
     endpointName: string,
     name: string,
   ): Promise<void> {
@@ -35,10 +34,7 @@ export abstract class SubscriptionTransport<T extends TransportGenerics> impleme
     this.name = name
   }
 
-  async registerRequest(
-    req: AdapterRequest<T['Request']>,
-    _: AdapterConfig<T['CustomSettings']>,
-  ): Promise<void> {
+  async registerRequest(req: AdapterRequest<T['Request']>, _: T['Config']): Promise<void> {
     logger.debug(
       `Adding entry to subscription set (ttl ${this.subscriptionTtl}): [${req.requestContext.cacheKey}] = ${req.requestContext.data}`,
     )
@@ -82,5 +78,5 @@ export abstract class SubscriptionTransport<T extends TransportGenerics> impleme
    *
    * @param config - the config for this adapter
    */
-  abstract getSubscriptionTtlFromConfig(config: AdapterConfig<T['CustomSettings']>): number
+  abstract getSubscriptionTtlFromConfig(config: T['Config']): number
 }

--- a/src/transports/abstract/subscription.ts
+++ b/src/transports/abstract/subscription.ts
@@ -24,17 +24,17 @@ export abstract class SubscriptionTransport<T extends TransportGenerics> impleme
 
   async initialize(
     dependencies: TransportDependencies<T>,
-    config: T['Config'],
+    adapterSettings: T['Settings'],
     endpointName: string,
     name: string,
   ): Promise<void> {
     this.responseCache = dependencies.responseCache
     this.subscriptionSet = dependencies.subscriptionSetFactory.buildSet(endpointName)
-    this.subscriptionTtl = this.getSubscriptionTtlFromConfig(config) // Will be implemented by subclasses
+    this.subscriptionTtl = this.getSubscriptionTtlFromConfig(adapterSettings) // Will be implemented by subclasses
     this.name = name
   }
 
-  async registerRequest(req: AdapterRequest<T['Request']>, _: T['Config']): Promise<void> {
+  async registerRequest(req: AdapterRequest<T['Request']>, _: T['Settings']): Promise<void> {
     logger.debug(
       `Adding entry to subscription set (ttl ${this.subscriptionTtl}): [${req.requestContext.cacheKey}] = ${req.requestContext.data}`,
     )
@@ -76,7 +76,7 @@ export abstract class SubscriptionTransport<T extends TransportGenerics> impleme
   /**
    * Helper method to be defined in subclasses, for each of them to carry their own TTL definition in the EA config.
    *
-   * @param config - the config for this adapter
+   * @param adapterSettings - the config for this adapter
    */
-  abstract getSubscriptionTtlFromConfig(config: T['Config']): number
+  abstract getSubscriptionTtlFromConfig(adapterSettings: T['Settings']): number
 }

--- a/src/transports/http.ts
+++ b/src/transports/http.ts
@@ -1,14 +1,13 @@
 import { AxiosError, AxiosRequestConfig, AxiosResponse } from 'axios'
-import { EndpointContext } from '../adapter'
-import { AdapterConfig } from '../config'
-import { makeLogger, sleep } from '../util'
-import { PartialSuccessfulResponse, ProviderResult, TimestampedProviderResult } from '../util/types'
-import { Requester } from '../util/requester'
-import { AdapterDataProviderError, AdapterRateLimitError } from '../validation/error'
 import { TransportDependencies, TransportGenerics } from '.'
-import { SubscriptionTransport } from './abstract/subscription'
-import { metrics, retrieveCost } from '../metrics'
+import { EndpointContext } from '../adapter'
 import { calculateHttpRequestKey } from '../cache'
+import { metrics, retrieveCost } from '../metrics'
+import { makeLogger, sleep } from '../util'
+import { Requester } from '../util/requester'
+import { PartialSuccessfulResponse, ProviderResult, TimestampedProviderResult } from '../util/types'
+import { AdapterDataProviderError, AdapterRateLimitError } from '../validation/error'
+import { SubscriptionTransport } from './abstract/subscription'
 
 const WARMUP_BATCH_REQUEST_ID = '9002'
 
@@ -64,7 +63,7 @@ export interface HttpTransportConfig<T extends HttpTransportGenerics> {
    */
   prepareRequests: (
     params: T['Request']['Params'][],
-    config: AdapterConfig<T['CustomSettings']>,
+    config: T['Config'],
   ) => ProviderRequestConfig<T> | ProviderRequestConfig<T>[]
 
   /**
@@ -84,7 +83,7 @@ export interface HttpTransportConfig<T extends HttpTransportGenerics> {
   parseResponse: (
     params: T['Request']['Params'][],
     res: AxiosResponse<T['Provider']['ResponseBody']>,
-    config: AdapterConfig<T['CustomSettings']>,
+    config: T['Config'],
   ) => ProviderResult<T>[]
 }
 
@@ -110,7 +109,7 @@ export class HttpTransport<T extends HttpTransportGenerics> extends Subscription
 
   override async initialize(
     dependencies: TransportDependencies<T>,
-    config: AdapterConfig<T['CustomSettings']>,
+    config: T['Config'],
     endpointName: string,
     transportName: string,
   ): Promise<void> {
@@ -118,7 +117,7 @@ export class HttpTransport<T extends HttpTransportGenerics> extends Subscription
     this.requester = dependencies.requester
   }
 
-  getSubscriptionTtlFromConfig(config: AdapterConfig<T['CustomSettings']>): number {
+  getSubscriptionTtlFromConfig(config: T['Config']): number {
     return config.WARMUP_SUBSCRIPTION_TTL
   }
 

--- a/src/transports/http.ts
+++ b/src/transports/http.ts
@@ -58,12 +58,12 @@ export interface HttpTransportConfig<T extends HttpTransportGenerics> {
    *     to consolidate many of them since the parseResponse method is called independently for each of them.
    *
    * @param params - the list of non-expired input parameters sent to this Adapter
-   * @param config - the config for this Adapter
+   * @param adapterSettings - the config for this Adapter
    * @returns one or multiple request configs
    */
   prepareRequests: (
     params: T['Request']['Params'][],
-    config: T['Config'],
+    adapterSettings: T['Settings'],
   ) => ProviderRequestConfig<T> | ProviderRequestConfig<T>[]
 
   /**
@@ -77,13 +77,13 @@ export interface HttpTransportConfig<T extends HttpTransportGenerics> {
    *
    * @param params - the list of input parameters that should be fulfilled by this incoming provider response
    * @param res - the response from the data provider
-   * @param config - the config for this Adapter
+   * @param adapterSettings - the config for this Adapter
    * @returns a list of ProviderResults
    */
   parseResponse: (
     params: T['Request']['Params'][],
     res: AxiosResponse<T['Provider']['ResponseBody']>,
-    config: T['Config'],
+    adapterSettings: T['Settings'],
   ) => ProviderResult<T>[]
 }
 
@@ -109,16 +109,16 @@ export class HttpTransport<T extends HttpTransportGenerics> extends Subscription
 
   override async initialize(
     dependencies: TransportDependencies<T>,
-    config: T['Config'],
+    adapterSettings: T['Settings'],
     endpointName: string,
     transportName: string,
   ): Promise<void> {
-    await super.initialize(dependencies, config, endpointName, transportName)
+    await super.initialize(dependencies, adapterSettings, endpointName, transportName)
     this.requester = dependencies.requester
   }
 
-  getSubscriptionTtlFromConfig(config: T['Config']): number {
-    return config.WARMUP_SUBSCRIPTION_TTL
+  getSubscriptionTtlFromConfig(adapterSettings: T['Settings']): number {
+    return adapterSettings.WARMUP_SUBSCRIPTION_TTL
   }
 
   async backgroundHandler(
@@ -127,14 +127,14 @@ export class HttpTransport<T extends HttpTransportGenerics> extends Subscription
   ): Promise<void> {
     if (!entries.length) {
       logger.debug(
-        `No entries in subscription set, sleeping for ${context.adapterConfig.BACKGROUND_EXECUTE_MS_HTTP}ms...`,
+        `No entries in subscription set, sleeping for ${context.adapterSettings.BACKGROUND_EXECUTE_MS_HTTP}ms...`,
       )
       if (this.WARMER_ACTIVE) {
         // Decrement count when warmer changed from having entries to having none
         metrics.get('cacheWarmerCount').labels({ isBatched: 'true' }).dec()
         this.WARMER_ACTIVE = false
       }
-      await sleep(context.adapterConfig.BACKGROUND_EXECUTE_MS_HTTP)
+      await sleep(context.adapterSettings.BACKGROUND_EXECUTE_MS_HTTP)
       return
     } else if (this.WARMER_ACTIVE === false) {
       // Increment count when warmer changed from having no entries to having some
@@ -143,7 +143,7 @@ export class HttpTransport<T extends HttpTransportGenerics> extends Subscription
     }
 
     logger.trace(`Have ${entries.length} entries in batch, preparing requests...`)
-    const rawRequests = this.config.prepareRequests(entries, context.adapterConfig)
+    const rawRequests = this.config.prepareRequests(entries, context.adapterSettings)
     const requests = Array.isArray(rawRequests) ? rawRequests : [rawRequests]
 
     // We're awaiting these promises because although we have request coalescing, new entries
@@ -158,17 +158,17 @@ export class HttpTransport<T extends HttpTransportGenerics> extends Subscription
 
     // These logs will surface warnings that operators should take action on, in case the execution of all
     // requests is taking too long so that entries could have expired within this timeframe
-    if (duration > context.adapterConfig.WARMUP_SUBSCRIPTION_TTL) {
+    if (duration > context.adapterSettings.WARMUP_SUBSCRIPTION_TTL) {
       logger.warn(
         `Background execution of all HTTP requests in a batch took ${duration},\
-         which is longer than the subscription TTL (${context.adapterConfig.WARMUP_SUBSCRIPTION_TTL}).\
+         which is longer than the subscription TTL (${context.adapterSettings.WARMUP_SUBSCRIPTION_TTL}).\
          This might be due to insufficient speed on the selected API tier, please check metrics and logs to confirm and consider moving to a faster tier.`,
       )
     }
-    if (duration > context.adapterConfig.CACHE_MAX_AGE) {
+    if (duration > context.adapterSettings.CACHE_MAX_AGE) {
       logger.warn(
         `Background execution of all HTTP requests in a batch took ${duration},\
-         which is longer than the max cache age (${context.adapterConfig.CACHE_MAX_AGE}).\
+         which is longer than the max cache age (${context.adapterSettings.CACHE_MAX_AGE}).\
          This might be due to insufficient speed on the selected API tier, please check metrics and logs to confirm and consider moving to a faster tier.`,
       )
     }
@@ -227,7 +227,7 @@ export class HttpTransport<T extends HttpTransportGenerics> extends Subscription
 
       // Parse responses and apply timestamps
       const results = this.config
-        .parseResponse(requestConfig.params, requesterResult.response, context.adapterConfig)
+        .parseResponse(requestConfig.params, requesterResult.response, context.adapterSettings)
         .map((r) => {
           const result = r as TimestampedProviderResult<T>
           const partialResponse = r.response as PartialSuccessfulResponse<T['Response']>

--- a/src/transports/index.ts
+++ b/src/transports/index.ts
@@ -1,6 +1,6 @@
 import { AdapterDependencies, EndpointContext } from '../adapter'
 import { ResponseCache } from '../cache/response'
-import { BaseAdapterConfig } from '../config'
+import { BaseAdapterSettings } from '../config'
 import { AdapterRequest, AdapterResponse, RequestGenerics, ResponseGenerics } from '../util/types'
 
 export * from './http'
@@ -29,7 +29,7 @@ export type TransportGenerics = {
   /**
    * Type for any custom settings used for this Transport
    */
-  Config: BaseAdapterConfig
+  Settings: BaseAdapterSettings
 }
 
 /**
@@ -66,12 +66,12 @@ export interface Transport<T extends TransportGenerics> {
    * Initializes the transport in the Adapter context.
    *
    * @param dependencies - Adapter dependencies (e.g. cache instance)
-   * @param config - Adapter config containing env vars
+   * @param adapterSettings - Adapter config containing env vars
    * @returns an empty Promise
    */
   initialize: (
     dependencies: TransportDependencies<T>,
-    config: T['Config'],
+    adapterSettings: T['Settings'],
     endpointName: string,
     transportName: string,
   ) => Promise<void>
@@ -81,10 +81,13 @@ export interface Transport<T extends TransportGenerics> {
    * This means things like adding the request to a subscription set.
    *
    * @param req - the incoming AdapterRequest
-   * @param config - common configuration for the Adapter as a whole
+   * @param adapterSettings - common configuration for the Adapter as a whole
    * @returns an empty Promise
    */
-  registerRequest?: (req: AdapterRequest<T['Request']>, config: T['Config']) => Promise<void>
+  registerRequest?: (
+    req: AdapterRequest<T['Request']>,
+    adapterSettings: T['Settings'],
+  ) => Promise<void>
 
   /**
    * Performs a synchronous fetch/processing of information within the lifecycle of an incoming request.
@@ -94,13 +97,13 @@ export interface Transport<T extends TransportGenerics> {
    * to perform as much of the work as possible (or all of it) in the backgroundExecute method.
    *
    * @param req - the incoming AdapterRequest
-   * @param config - common configuration for the Adapter as a whole
+   * @param adapterSettings - common configuration for the Adapter as a whole
    * @returns a Promise that _optionally_ returns an AdapterResponse, if the Transport has the capability of
    *   immediately fetching data and returning it without the background process.
    */
   foregroundExecute?: (
     req: AdapterRequest<T['Request']>,
-    config: T['Config'],
+    adapterSettings: T['Settings'],
   ) => Promise<AdapterResponse<{
     Data: T['Response']['Data']
     Result: T['Response']['Result']

--- a/src/transports/index.ts
+++ b/src/transports/index.ts
@@ -1,6 +1,6 @@
 import { AdapterDependencies, EndpointContext } from '../adapter'
 import { ResponseCache } from '../cache/response'
-import { AdapterConfig, SettingsMap } from '../config'
+import { BaseAdapterConfig } from '../config'
 import { AdapterRequest, AdapterResponse, RequestGenerics, ResponseGenerics } from '../util/types'
 
 export * from './http'
@@ -29,7 +29,7 @@ export type TransportGenerics = {
   /**
    * Type for any custom settings used for this Transport
    */
-  CustomSettings: SettingsMap
+  Config: BaseAdapterConfig
 }
 
 /**
@@ -71,7 +71,7 @@ export interface Transport<T extends TransportGenerics> {
    */
   initialize: (
     dependencies: TransportDependencies<T>,
-    config: AdapterConfig<T['CustomSettings']>,
+    config: T['Config'],
     endpointName: string,
     transportName: string,
   ) => Promise<void>
@@ -84,10 +84,7 @@ export interface Transport<T extends TransportGenerics> {
    * @param config - common configuration for the Adapter as a whole
    * @returns an empty Promise
    */
-  registerRequest?: (
-    req: AdapterRequest<T['Request']>,
-    config: AdapterConfig<T['CustomSettings']>,
-  ) => Promise<void>
+  registerRequest?: (req: AdapterRequest<T['Request']>, config: T['Config']) => Promise<void>
 
   /**
    * Performs a synchronous fetch/processing of information within the lifecycle of an incoming request.
@@ -103,7 +100,7 @@ export interface Transport<T extends TransportGenerics> {
    */
   foregroundExecute?: (
     req: AdapterRequest<T['Request']>,
-    config: AdapterConfig<T['CustomSettings']>,
+    config: T['Config'],
   ) => Promise<AdapterResponse<{
     Data: T['Response']['Data']
     Result: T['Response']['Result']

--- a/src/transports/metrics.ts
+++ b/src/transports/metrics.ts
@@ -16,7 +16,7 @@ export const messageSubsLabels = <T extends TransportGenerics>(
   context: {
     inputParameters: InputParameters
     endpointName: string
-    adapterConfig: T['Config']
+    adapterSettings: T['Settings']
   },
   params: T['Request']['Params'],
 ) => {

--- a/src/transports/metrics.ts
+++ b/src/transports/metrics.ts
@@ -1,7 +1,6 @@
 import { TransportGenerics } from '.'
 import { EndpointContext } from '../adapter'
 import { calculateFeedId } from '../cache'
-import { AdapterConfig } from '../config'
 import { metrics } from '../metrics'
 import { InputParameters } from '../validation'
 
@@ -17,7 +16,7 @@ export const messageSubsLabels = <T extends TransportGenerics>(
   context: {
     inputParameters: InputParameters
     endpointName: string
-    adapterConfig: AdapterConfig<T['CustomSettings']>
+    adapterConfig: T['Config']
   },
   params: T['Request']['Params'],
 ) => {

--- a/src/transports/sse.ts
+++ b/src/transports/sse.ts
@@ -1,13 +1,12 @@
 import { AxiosRequestConfig } from 'axios'
 import EventSource from 'eventsource'
 import { EndpointContext } from '../adapter'
-import { AdapterConfig } from '../config'
+import { calculateHttpRequestKey } from '../cache'
 import { makeLogger, sleep } from '../util'
+import { Requester } from '../util/requester'
 import { PartialSuccessfulResponse, ProviderResult, TimestampedProviderResult } from '../util/types'
 import { TransportDependencies, TransportGenerics } from './'
 import { StreamingTransport, SubscriptionDeltas } from './abstract/streaming'
-import { Requester } from '../util/requester'
-import { calculateHttpRequestKey } from '../cache'
 
 const logger = makeLogger('SSETransport')
 
@@ -75,13 +74,13 @@ export class SseTransport<T extends SSETransportGenerics> extends StreamingTrans
     super()
   }
 
-  getSubscriptionTtlFromConfig(config: AdapterConfig<T['CustomSettings']>): number {
+  getSubscriptionTtlFromConfig(config: T['Config']): number {
     return config.SSE_SUBSCRIPTION_TTL
   }
 
   override async initialize(
     dependencies: TransportDependencies<T>,
-    config: AdapterConfig<T['CustomSettings']>,
+    config: T['Config'],
     endpointName: string,
     transportName: string,
   ): Promise<void> {

--- a/src/transports/sse.ts
+++ b/src/transports/sse.ts
@@ -74,17 +74,17 @@ export class SseTransport<T extends SSETransportGenerics> extends StreamingTrans
     super()
   }
 
-  getSubscriptionTtlFromConfig(config: T['Config']): number {
-    return config.SSE_SUBSCRIPTION_TTL
+  getSubscriptionTtlFromConfig(adapterSettings: T['Settings']): number {
+    return adapterSettings.SSE_SUBSCRIPTION_TTL
   }
 
   override async initialize(
     dependencies: TransportDependencies<T>,
-    config: T['Config'],
+    adapterSettings: T['Settings'],
     endpointName: string,
     transportName: string,
   ): Promise<void> {
-    super.initialize(dependencies, config, endpointName, transportName)
+    super.initialize(dependencies, adapterSettings, endpointName, transportName)
     this.requester = dependencies.requester
     if (dependencies.eventSource) {
       this.EventSource = dependencies.eventSource
@@ -162,7 +162,7 @@ export class SseTransport<T extends SSETransportGenerics> extends StreamingTrans
     if (
       this.config.prepareKeepAliveRequest &&
       subscriptions.desired.length &&
-      Date.now() - this.timeOfLastReq > context.adapterConfig.SSE_KEEPALIVE_SLEEP
+      Date.now() - this.timeOfLastReq > context.adapterSettings.SSE_KEEPALIVE_SLEEP
     ) {
       const prepareKeepAliveRequest = this.config.prepareKeepAliveRequest(context)
       makeRequest(
@@ -177,9 +177,9 @@ export class SseTransport<T extends SSETransportGenerics> extends StreamingTrans
 
     // The background execute loop no longer sleeps between executions, so we have to do it here
     logger.trace(
-      `SSE handler complete, sleeping for ${context.adapterConfig.BACKGROUND_EXECUTE_MS_SSE}ms...`,
+      `SSE handler complete, sleeping for ${context.adapterSettings.BACKGROUND_EXECUTE_MS_SSE}ms...`,
     )
-    await sleep(context.adapterConfig.BACKGROUND_EXECUTE_MS_SSE)
+    await sleep(context.adapterSettings.BACKGROUND_EXECUTE_MS_SSE)
 
     return
   }

--- a/src/transports/websocket.ts
+++ b/src/transports/websocket.ts
@@ -121,8 +121,8 @@ export class WebSocketTransport<
     super()
   }
 
-  getSubscriptionTtlFromConfig(config: T['Config']): number {
-    return config.WS_SUBSCRIPTION_TTL
+  getSubscriptionTtlFromConfig(adapterSettings: T['Settings']): number {
+    return adapterSettings.WS_SUBSCRIPTION_TTL
   }
 
   connectionClosed(): boolean {
@@ -246,7 +246,7 @@ export class WebSocketTransport<
     // No new subs && connection -> unsubs only
     if (!subscriptions.new.length && !this.wsConnection) {
       logger.debug('No entries in subscription set and no established connection, skipping')
-      await sleep(context.adapterConfig.BACKGROUND_EXECUTE_MS_WS)
+      await sleep(context.adapterSettings.BACKGROUND_EXECUTE_MS_WS)
       return
     }
 
@@ -263,14 +263,14 @@ export class WebSocketTransport<
     const timeSinceLastActivity = Math.min(timeSinceLastMessage, timeSinceConnectionOpened)
     const connectionUnresponsive =
       timeSinceLastActivity > 0 &&
-      timeSinceLastActivity > context.adapterConfig.WS_SUBSCRIPTION_UNRESPONSIVE_TTL
+      timeSinceLastActivity > context.adapterSettings.WS_SUBSCRIPTION_UNRESPONSIVE_TTL
     let connectionClosed = this.connectionClosed()
 
     // Check if we should close the current connection
     if (!connectionClosed && (urlChanged || connectionUnresponsive)) {
       const reason = urlChanged
         ? `Websocket url has changed from ${this.currentUrl} to ${urlFromConfig}, closing connection...`
-        : `Last message was received ${timeSinceLastMessage} ago, exceeding the threshold of ${context.adapterConfig.WS_SUBSCRIPTION_UNRESPONSIVE_TTL}ms, closing connection...`
+        : `Last message was received ${timeSinceLastMessage} ago, exceeding the threshold of ${context.adapterSettings.WS_SUBSCRIPTION_UNRESPONSIVE_TTL}ms, closing connection...`
       logger.info(reason)
 
       // Check if connection was opened very recently; if so, wait a bit before continuing.
@@ -327,9 +327,9 @@ export class WebSocketTransport<
 
     // The background execute loop no longer sleeps between executions, so we have to do it here
     logger.trace(
-      `Websocket handler complete, sleeping for ${context.adapterConfig.BACKGROUND_EXECUTE_MS_WS}ms...`,
+      `Websocket handler complete, sleeping for ${context.adapterSettings.BACKGROUND_EXECUTE_MS_WS}ms...`,
     )
-    await sleep(context.adapterConfig.BACKGROUND_EXECUTE_MS_WS)
+    await sleep(context.adapterSettings.BACKGROUND_EXECUTE_MS_WS)
 
     return
   }

--- a/src/transports/websocket.ts
+++ b/src/transports/websocket.ts
@@ -1,6 +1,5 @@
 import WebSocket, { ClientOptions, RawData } from 'ws'
 import { EndpointContext } from '../adapter'
-import { AdapterConfig } from '../config'
 import { metrics } from '../metrics'
 import { makeLogger, sleep } from '../util'
 import { PartialSuccessfulResponse, ProviderResult, TimestampedProviderResult } from '../util/types'
@@ -122,7 +121,7 @@ export class WebSocketTransport<
     super()
   }
 
-  getSubscriptionTtlFromConfig(config: AdapterConfig<T['CustomSettings']>): number {
+  getSubscriptionTtlFromConfig(config: T['Config']): number {
     return config.WS_SUBSCRIPTION_TTL
   }
 

--- a/src/util/logger.ts
+++ b/src/util/logger.ts
@@ -1,5 +1,5 @@
 import pino from 'pino'
-import { BaseSettings } from '../config'
+import { BaseSettingsDefinition } from '../config'
 import { AdapterRequest } from './types'
 import { FastifyReply, HookHandlerDoneFunction } from 'fastify'
 import { randomUUID } from 'crypto'
@@ -25,7 +25,7 @@ const debugTransport = {
 
 // Base logger, shouldn't be used because we want layers to be specified
 const baseLogger = pino({
-  level: process.env['LOG_LEVEL']?.toLowerCase() || BaseSettings.LOG_LEVEL.default,
+  level: process.env['LOG_LEVEL']?.toLowerCase() || BaseSettingsDefinition.LOG_LEVEL.default,
   formatters: {
     level(label) {
       return { level: label }

--- a/src/util/requester.ts
+++ b/src/util/requester.ts
@@ -1,6 +1,6 @@
 import axios, { AxiosError, AxiosRequestConfig, AxiosResponse } from 'axios'
 import { makeLogger, sleep } from '.'
-import { AdapterConfig } from '../config'
+import { AdapterSettings } from '../config'
 import { dataProviderMetricsLabel, metrics } from '../metrics'
 import { RateLimiter } from '../rate-limiting'
 import {
@@ -98,10 +98,10 @@ export class Requester {
   private maxRetries: number
   private timeout: number
 
-  constructor(private rateLimiter: RateLimiter, config: AdapterConfig) {
-    this.maxRetries = config.RETRY
-    this.timeout = config.API_TIMEOUT
-    this.queue = new UniqueLinkedList<QueuedRequest>(config.MAX_HTTP_REQUEST_QUEUE_LENGTH)
+  constructor(private rateLimiter: RateLimiter, adapterSettings: AdapterSettings) {
+    this.maxRetries = adapterSettings.RETRY
+    this.timeout = adapterSettings.API_TIMEOUT
+    this.queue = new UniqueLinkedList<QueuedRequest>(adapterSettings.MAX_HTTP_REQUEST_QUEUE_LENGTH)
   }
 
   /**

--- a/src/util/subscription-set/subscription-set.ts
+++ b/src/util/subscription-set/subscription-set.ts
@@ -1,6 +1,6 @@
 import Redis from 'ioredis'
 import { PromiseOrValue } from '..'
-import { AdapterConfig } from '../../config'
+import { AdapterSettings } from '../../config'
 import { ExpiringSortedSet } from './expiring-sorted-set'
 import { RedisSubscriptionSet } from './redis-sorted-set'
 
@@ -18,16 +18,16 @@ export interface SubscriptionSet<T> {
 }
 
 export class SubscriptionSetFactory {
-  private cacheType: AdapterConfig['CACHE_TYPE']
+  private cacheType: AdapterSettings['CACHE_TYPE']
   private redisClient?: Redis
   private adapterName?: string
-  private capacity: AdapterConfig['SUBSCRIPTION_SET_MAX_ITEMS']
+  private capacity: AdapterSettings['SUBSCRIPTION_SET_MAX_ITEMS']
 
-  constructor(config: AdapterConfig, adapterName: string, redisClient?: Redis) {
-    this.cacheType = config.CACHE_TYPE
+  constructor(adapterSettings: AdapterSettings, adapterName: string, redisClient?: Redis) {
+    this.cacheType = adapterSettings.CACHE_TYPE
     this.redisClient = redisClient
     this.adapterName = adapterName
-    this.capacity = config.SUBSCRIPTION_SET_MAX_ITEMS
+    this.capacity = adapterSettings.SUBSCRIPTION_SET_MAX_ITEMS
   }
 
   buildSet<T>(endpointName: string): SubscriptionSet<T> {

--- a/src/validation/index.ts
+++ b/src/validation/index.ts
@@ -1,6 +1,8 @@
 import { FastifyError, FastifyReply, FastifyRequest, HookHandlerDoneFunction } from 'fastify'
+import { ReplyError as RedisError } from 'ioredis'
 import { Adapter } from '../adapter'
 import { calculateCacheKey, recordRedisCommandMetric } from '../cache'
+import { CMD_SENT_STATUS } from '../cache/metrics'
 import { getMetricsMeta } from '../metrics/util'
 import { makeLogger } from '../util'
 import {
@@ -10,8 +12,6 @@ import {
   AdapterRequestContext,
 } from '../util/types'
 import { AdapterError, AdapterInputError, AdapterTimeoutError } from './error'
-import { CMD_SENT_STATUS } from '../cache/metrics'
-import { ReplyError as RedisError } from 'ioredis'
 export { InputParameters, SpecificInputParameters } from './input-params'
 
 const errorCatcherLogger = makeLogger('ErrorCatchingMiddleware')
@@ -65,15 +65,21 @@ export const validatorMiddleware: AdapterMiddlewareBuilder =
       endpointName: endpoint.name,
     } as AdapterRequestContext
     // We do it afterwards so the custom routers can have a request with a requestContext fulfilled (sans transportName, ofc)
-    req.requestContext.transportName = endpoint.getTransportNameForRequest(req, adapter.config)
+    req.requestContext.transportName = endpoint.getTransportNameForRequest(
+      req,
+      adapter.processedConfig.config,
+    )
 
-    if (adapter.config.METRICS_ENABLED && adapter.config.EXPERIMENTAL_METRICS_ENABLED) {
+    if (
+      adapter.processedConfig.config.METRICS_ENABLED &&
+      adapter.processedConfig.config.EXPERIMENTAL_METRICS_ENABLED
+    ) {
       // Add metrics meta which includes feedId to the request
       // Perform prior to overrides to maintain consistent Feed IDs across adapters
       const metrics = getMetricsMeta(
         {
           inputParameters: endpoint.inputParameters,
-          adapterConfig: adapter.config,
+          adapterConfig: adapter.processedConfig.config,
         },
         validatedData,
       )
@@ -82,7 +88,8 @@ export const validatorMiddleware: AdapterMiddlewareBuilder =
 
     // Custom input validation defined in the EA
     const error =
-      endpoint.customInputValidation && endpoint.customInputValidation(req, adapter.config)
+      endpoint.customInputValidation &&
+      endpoint.customInputValidation(req, adapter.processedConfig.config)
 
     if (error) {
       throw error
@@ -96,22 +103,22 @@ export const validatorMiddleware: AdapterMiddlewareBuilder =
     if (endpoint.cacheKeyGenerator) {
       let cacheKey
       cacheKey = endpoint.cacheKeyGenerator(req.requestContext.data)
-      if (cacheKey.length > adapter.config.MAX_COMMON_KEY_SIZE) {
+      if (cacheKey.length > adapter.processedConfig.config.MAX_COMMON_KEY_SIZE) {
         errorCatcherLogger.warn(
           `Generated custom cache key for adapter request is bigger than the MAX_COMMON_KEY_SIZE and will be truncated`,
         )
-        cacheKey = cacheKey.slice(0, adapter.config.MAX_COMMON_KEY_SIZE)
+        cacheKey = cacheKey.slice(0, adapter.processedConfig.config.MAX_COMMON_KEY_SIZE)
       }
       req.requestContext.cacheKey = cacheKey
     } else {
-      const transportName = endpoint.getTransportNameForRequest(req, adapter.config)
+      const transportName = endpoint.getTransportNameForRequest(req, adapter.processedConfig.config)
       req.requestContext.cacheKey = calculateCacheKey({
         data: req.requestContext.data,
         adapterName: adapter.name,
         endpointName: endpoint.name,
         transportName,
         inputParameters: endpoint.inputParameters,
-        adapterConfig: adapter.config,
+        adapterConfig: adapter.processedConfig.config,
       })
     }
 

--- a/src/validation/index.ts
+++ b/src/validation/index.ts
@@ -67,19 +67,19 @@ export const validatorMiddleware: AdapterMiddlewareBuilder =
     // We do it afterwards so the custom routers can have a request with a requestContext fulfilled (sans transportName, ofc)
     req.requestContext.transportName = endpoint.getTransportNameForRequest(
       req,
-      adapter.processedConfig.settings,
+      adapter.config.settings,
     )
 
     if (
-      adapter.processedConfig.settings.METRICS_ENABLED &&
-      adapter.processedConfig.settings.EXPERIMENTAL_METRICS_ENABLED
+      adapter.config.settings.METRICS_ENABLED &&
+      adapter.config.settings.EXPERIMENTAL_METRICS_ENABLED
     ) {
       // Add metrics meta which includes feedId to the request
       // Perform prior to overrides to maintain consistent Feed IDs across adapters
       const metrics = getMetricsMeta(
         {
           inputParameters: endpoint.inputParameters,
-          adapterSettings: adapter.processedConfig.settings,
+          adapterSettings: adapter.config.settings,
         },
         validatedData,
       )
@@ -88,8 +88,7 @@ export const validatorMiddleware: AdapterMiddlewareBuilder =
 
     // Custom input validation defined in the EA
     const error =
-      endpoint.customInputValidation &&
-      endpoint.customInputValidation(req, adapter.processedConfig.settings)
+      endpoint.customInputValidation && endpoint.customInputValidation(req, adapter.config.settings)
 
     if (error) {
       throw error
@@ -103,25 +102,22 @@ export const validatorMiddleware: AdapterMiddlewareBuilder =
     if (endpoint.cacheKeyGenerator) {
       let cacheKey
       cacheKey = endpoint.cacheKeyGenerator(req.requestContext.data)
-      if (cacheKey.length > adapter.processedConfig.settings.MAX_COMMON_KEY_SIZE) {
+      if (cacheKey.length > adapter.config.settings.MAX_COMMON_KEY_SIZE) {
         errorCatcherLogger.warn(
           `Generated custom cache key for adapter request is bigger than the MAX_COMMON_KEY_SIZE and will be truncated`,
         )
-        cacheKey = cacheKey.slice(0, adapter.processedConfig.settings.MAX_COMMON_KEY_SIZE)
+        cacheKey = cacheKey.slice(0, adapter.config.settings.MAX_COMMON_KEY_SIZE)
       }
       req.requestContext.cacheKey = cacheKey
     } else {
-      const transportName = endpoint.getTransportNameForRequest(
-        req,
-        adapter.processedConfig.settings,
-      )
+      const transportName = endpoint.getTransportNameForRequest(req, adapter.config.settings)
       req.requestContext.cacheKey = calculateCacheKey({
         data: req.requestContext.data,
         adapterName: adapter.name,
         endpointName: endpoint.name,
         transportName,
         inputParameters: endpoint.inputParameters,
-        adapterSettings: adapter.processedConfig.settings,
+        adapterSettings: adapter.config.settings,
       })
     }
 

--- a/test/background-executor.test.ts
+++ b/test/background-executor.test.ts
@@ -108,7 +108,7 @@ test.serial('background executor error does not stop the loop', async (t) => {
   metrics.assert(t, {
     name: 'bg_execute_errors',
     labels: {
-      endpoint: 'test',
+      adapter_endpoint: 'test',
       transport: 'default_single_transport',
     },
     expectedValue: 1,
@@ -116,7 +116,7 @@ test.serial('background executor error does not stop the loop', async (t) => {
   metrics.assert(t, {
     name: 'bg_execute_total',
     labels: {
-      endpoint: 'test',
+      adapter_endpoint: 'test',
       transport: 'default_single_transport',
     },
     expectedValue: 5,

--- a/test/cache/cache-key.test.ts
+++ b/test/cache/cache-key.test.ts
@@ -1,7 +1,7 @@
 import untypedTest, { TestFn } from 'ava'
 import { Adapter, AdapterEndpoint, EndpointGenerics } from '../../src/adapter'
 import { Cache } from '../../src/cache'
-import { BaseSettings, ProcessedConfig } from '../../src/config'
+import { BaseSettingsDefinition, ProcessedConfig } from '../../src/config'
 import { AdapterRequest, AdapterResponse } from '../../src/util'
 import { InputValidator } from '../../src/validation/input-validator'
 import { NopTransport, NopTransportTypes, TestAdapter } from '../util'
@@ -71,7 +71,7 @@ test.serial('no parameters returns default cache key', async (t) => {
   const response = await t.context.testAdapter.request({})
   t.is(
     response.json().result,
-    `TEST-test-default_single_transport-${BaseSettings.DEFAULT_CACHE_KEY.default}`,
+    `TEST-test-default_single_transport-${BaseSettingsDefinition.DEFAULT_CACHE_KEY.default}`,
   )
 })
 

--- a/test/cache/cache-key.test.ts
+++ b/test/cache/cache-key.test.ts
@@ -1,7 +1,7 @@
 import untypedTest, { TestFn } from 'ava'
 import { Adapter, AdapterEndpoint, EndpointGenerics } from '../../src/adapter'
 import { Cache } from '../../src/cache'
-import { BaseSettingsDefinition, ProcessedConfig } from '../../src/config'
+import { BaseSettingsDefinition, AdapterConfig } from '../../src/config'
 import { AdapterRequest, AdapterResponse } from '../../src/util'
 import { InputValidator } from '../../src/validation/input-validator'
 import { NopTransport, NopTransportTypes, TestAdapter } from '../util'
@@ -13,7 +13,7 @@ const test = untypedTest as TestFn<{
 }>
 
 test.beforeEach(async (t) => {
-  const processedConfig = new ProcessedConfig(
+  const config = new AdapterConfig(
     {},
     {
       envDefaultOverrides: {
@@ -24,7 +24,7 @@ test.beforeEach(async (t) => {
   const adapter = new Adapter({
     name: 'TEST',
     defaultEndpoint: 'test',
-    processedConfig,
+    config,
     endpoints: [
       new AdapterEndpoint({
         name: 'test',

--- a/test/cache/cache-key.test.ts
+++ b/test/cache/cache-key.test.ts
@@ -1,7 +1,7 @@
 import untypedTest, { TestFn } from 'ava'
 import { Adapter, AdapterEndpoint, EndpointGenerics } from '../../src/adapter'
 import { Cache } from '../../src/cache'
-import { BaseSettings } from '../../src/config'
+import { BaseSettings, ProcessedConfig } from '../../src/config'
 import { AdapterRequest, AdapterResponse } from '../../src/util'
 import { InputValidator } from '../../src/validation/input-validator'
 import { NopTransport, NopTransportTypes, TestAdapter } from '../util'
@@ -13,9 +13,18 @@ const test = untypedTest as TestFn<{
 }>
 
 test.beforeEach(async (t) => {
+  const processedConfig = new ProcessedConfig(
+    {},
+    {
+      envDefaultOverrides: {
+        MAX_COMMON_KEY_SIZE: 150,
+      },
+    },
+  )
   const adapter = new Adapter({
     name: 'TEST',
     defaultEndpoint: 'test',
+    processedConfig,
     endpoints: [
       new AdapterEndpoint({
         name: 'test',
@@ -52,9 +61,6 @@ test.beforeEach(async (t) => {
         })(),
       }),
     ],
-    envDefaultOverrides: {
-      MAX_COMMON_KEY_SIZE: 150,
-    },
   })
 
   t.context.adapterEndpoint = adapter.endpoints[0]

--- a/test/cache/local.test.ts
+++ b/test/cache/local.test.ts
@@ -1,12 +1,23 @@
 import { Adapter, AdapterDependencies, AdapterEndpoint } from '../../src/adapter'
 import { CacheFactory, LocalCache } from '../../src/cache'
+import { ProcessedConfig } from '../../src/config'
 import { NopTransport, TestAdapter } from '../util'
 import { BasicCacheSetterTransport, cacheTests, test } from './helper'
 
 test.beforeEach(async (t) => {
+  const processedConfig = new ProcessedConfig(
+    {},
+    {
+      envDefaultOverrides: {
+        CACHE_POLLING_SLEEP_MS: 10,
+        CACHE_POLLING_MAX_RETRIES: 3,
+      },
+    },
+  )
   const adapter = new Adapter({
     name: 'TEST',
     defaultEndpoint: 'test',
+    processedConfig,
     endpoints: [
       new AdapterEndpoint({
         name: 'test',
@@ -28,13 +39,9 @@ test.beforeEach(async (t) => {
         transport: new NopTransport(),
       }),
     ],
-    envDefaultOverrides: {
-      CACHE_POLLING_SLEEP_MS: 10,
-      CACHE_POLLING_MAX_RETRIES: 3,
-    },
   })
 
-  const cache = new LocalCache(adapter.config.CACHE_MAX_ITEMS)
+  const cache = new LocalCache(adapter.processedConfig.config.CACHE_MAX_ITEMS)
   const dependencies: Partial<AdapterDependencies> = {
     cache,
   }

--- a/test/cache/local.test.ts
+++ b/test/cache/local.test.ts
@@ -41,7 +41,7 @@ test.beforeEach(async (t) => {
     ],
   })
 
-  const cache = new LocalCache(adapter.processedConfig.config.CACHE_MAX_ITEMS)
+  const cache = new LocalCache(adapter.processedConfig.settings.CACHE_MAX_ITEMS)
   const dependencies: Partial<AdapterDependencies> = {
     cache,
   }

--- a/test/cache/local.test.ts
+++ b/test/cache/local.test.ts
@@ -1,11 +1,11 @@
 import { Adapter, AdapterDependencies, AdapterEndpoint } from '../../src/adapter'
 import { CacheFactory, LocalCache } from '../../src/cache'
-import { ProcessedConfig } from '../../src/config'
+import { AdapterConfig } from '../../src/config'
 import { NopTransport, TestAdapter } from '../util'
 import { BasicCacheSetterTransport, cacheTests, test } from './helper'
 
 test.beforeEach(async (t) => {
-  const processedConfig = new ProcessedConfig(
+  const config = new AdapterConfig(
     {},
     {
       envDefaultOverrides: {
@@ -17,7 +17,7 @@ test.beforeEach(async (t) => {
   const adapter = new Adapter({
     name: 'TEST',
     defaultEndpoint: 'test',
-    processedConfig,
+    config,
     endpoints: [
       new AdapterEndpoint({
         name: 'test',
@@ -41,7 +41,7 @@ test.beforeEach(async (t) => {
     ],
   })
 
-  const cache = new LocalCache(adapter.processedConfig.settings.CACHE_MAX_ITEMS)
+  const cache = new LocalCache(adapter.config.settings.CACHE_MAX_ITEMS)
   const dependencies: Partial<AdapterDependencies> = {
     cache,
   }

--- a/test/cache/redis.test.ts
+++ b/test/cache/redis.test.ts
@@ -1,12 +1,12 @@
 import Redis from 'ioredis'
 import { Adapter, AdapterDependencies, AdapterEndpoint } from '../../src/adapter'
 import { CacheFactory, RedisCache } from '../../src/cache'
-import { ProcessedConfig } from '../../src/config'
+import { AdapterConfig } from '../../src/config'
 import { NopTransport, RedisMock, TestAdapter } from '../util'
 import { BasicCacheSetterTransport, buildDiffResultAdapter, cacheTests, test } from './helper'
 
 test.beforeEach(async (t) => {
-  const processedConfig = new ProcessedConfig(
+  const config = new AdapterConfig(
     {},
     {
       envDefaultOverrides: {
@@ -18,7 +18,7 @@ test.beforeEach(async (t) => {
   const adapter = new Adapter({
     name: 'TEST',
     defaultEndpoint: 'test',
-    processedConfig,
+    config,
     endpoints: [
       new AdapterEndpoint({
         name: 'test',

--- a/test/cache/redis.test.ts
+++ b/test/cache/redis.test.ts
@@ -1,13 +1,24 @@
 import Redis from 'ioredis'
 import { Adapter, AdapterDependencies, AdapterEndpoint } from '../../src/adapter'
 import { CacheFactory, RedisCache } from '../../src/cache'
+import { ProcessedConfig } from '../../src/config'
 import { NopTransport, RedisMock, TestAdapter } from '../util'
 import { BasicCacheSetterTransport, buildDiffResultAdapter, cacheTests, test } from './helper'
 
 test.beforeEach(async (t) => {
+  const processedConfig = new ProcessedConfig(
+    {},
+    {
+      envDefaultOverrides: {
+        CACHE_POLLING_SLEEP_MS: 10,
+        CACHE_POLLING_MAX_RETRIES: 3,
+      },
+    },
+  )
   const adapter = new Adapter({
     name: 'TEST',
     defaultEndpoint: 'test',
+    processedConfig,
     endpoints: [
       new AdapterEndpoint({
         name: 'test',
@@ -29,10 +40,6 @@ test.beforeEach(async (t) => {
         transport: new NopTransport(),
       }),
     ],
-    envDefaultOverrides: {
-      CACHE_POLLING_SLEEP_MS: 10,
-      CACHE_POLLING_MAX_RETRIES: 3,
-    },
   })
 
   const cache = new RedisCache(new RedisMock() as unknown as Redis) // Fake redis

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -1,5 +1,5 @@
 import test from 'ava'
-import { ProcessedConfig, SettingsMap } from '../src/config'
+import { ProcessedConfig, SettingsDefinitionMap } from '../src/config'
 import { validator } from '../src/validation/utils'
 
 test.afterEach(async () => {
@@ -23,7 +23,7 @@ test.serial('Test good enum config', async (t) => {
   const config = new ProcessedConfig({})
   config.initialize()
   config.validate()
-  t.is(config.config.CACHE_TYPE, 'local')
+  t.is(config.settings.CACHE_TYPE, 'local')
 })
 
 test.serial('Test bad enum config', async (t) => {
@@ -45,15 +45,15 @@ test.serial('Test custom settings', async (t) => {
       description: 'Test custom env var',
       type: 'string',
     },
-  } satisfies SettingsMap
+  } satisfies SettingsDefinitionMap
   const config = new ProcessedConfig(customSettings)
   config.initialize()
   config.validate()
-  t.is(config.config.CUSTOM_KEY, 'test')
+  t.is(config.settings.CUSTOM_KEY, 'test')
 })
 
 test.serial('Test missing custom settings (required)', async (t) => {
-  const customSettings: SettingsMap = {
+  const customSettings: SettingsDefinitionMap = {
     CUSTOM_KEY_1: {
       description: 'Test custom env var',
       type: 'string',
@@ -72,7 +72,7 @@ test.serial('Test missing custom settings (required)', async (t) => {
 
 test.serial('Test custom settings (overlap base)', async (t) => {
   process.env['BASE_URL'] = 'test'
-  const customSettings: SettingsMap = {
+  const customSettings: SettingsDefinitionMap = {
     BASE_URL: {
       description: 'Test custom env var overlapping base',
       type: 'string',
@@ -93,12 +93,12 @@ test.serial('Test prefix settings', async (t) => {
   const envVarsPrefix = 'TEST_PREFIX'
   const config = new ProcessedConfig({}, { envVarsPrefix })
   config.initialize()
-  t.is(config.config['BASE_URL'], 'TEST_BASE_URL')
+  t.is(config.settings['BASE_URL'], 'TEST_BASE_URL')
 })
 
 test.serial('Test validate function (out of bounds)', async (t) => {
   process.env['CUSTOM_KEY'] = '11'
-  const customSettings: SettingsMap = {
+  const customSettings: SettingsDefinitionMap = {
     CUSTOM_KEY: {
       description: 'Test custom env var',
       type: 'number',
@@ -117,7 +117,7 @@ test.serial('Test validate function (out of bounds)', async (t) => {
 
 test.serial('Test validate function (decimal)', async (t) => {
   process.env['CUSTOM_KEY'] = '5.1'
-  const customSettings: SettingsMap = {
+  const customSettings: SettingsDefinitionMap = {
     CUSTOM_KEY: {
       description: 'Test custom env var',
       type: 'number',
@@ -136,7 +136,7 @@ test.serial('Test validate function (decimal)', async (t) => {
 
 test.serial('Test validate function (scientific notation)', async (t) => {
   process.env['CUSTOM_KEY'] = '3.5e+6'
-  const customSettings: SettingsMap = {
+  const customSettings: SettingsDefinitionMap = {
     CUSTOM_KEY: {
       description: 'Test custom env var',
       type: 'number',

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -10,6 +10,7 @@ test.serial('Test config validator', async (t) => {
   process.env['MAX_COMMON_KEY_SIZE'] = '1000'
   try {
     const config = new ProcessedConfig({})
+    config.initialize()
     config.validate()
     t.fail()
   } catch (e: unknown) {
@@ -20,6 +21,7 @@ test.serial('Test config validator', async (t) => {
 test.serial('Test good enum config', async (t) => {
   process.env['CACHE_TYPE'] = 'local'
   const config = new ProcessedConfig({})
+  config.initialize()
   config.validate()
   t.is(config.config.CACHE_TYPE, 'local')
 })
@@ -28,6 +30,7 @@ test.serial('Test bad enum config', async (t) => {
   process.env['CACHE_TYPE'] = 'test'
   try {
     const config = new ProcessedConfig({})
+    config.initialize()
     config.validate()
     t.fail()
   } catch (e: unknown) {
@@ -44,6 +47,7 @@ test.serial('Test custom settings', async (t) => {
     },
   } satisfies SettingsMap
   const config = new ProcessedConfig(customSettings)
+  config.initialize()
   config.validate()
   t.is(config.config.CUSTOM_KEY, 'test')
 })
@@ -58,6 +62,7 @@ test.serial('Test missing custom settings (required)', async (t) => {
   }
   try {
     const config = new ProcessedConfig(customSettings)
+    config.initialize()
     config.validate()
     t.fail()
   } catch (e: unknown) {
@@ -75,6 +80,7 @@ test.serial('Test custom settings (overlap base)', async (t) => {
   }
   try {
     const config = new ProcessedConfig(customSettings)
+    config.initialize()
     config.validate()
     t.fail()
   } catch (e: unknown) {
@@ -86,6 +92,7 @@ test.serial('Test prefix settings', async (t) => {
   process.env['TEST_PREFIX_BASE_URL'] = 'TEST_BASE_URL'
   const envVarsPrefix = 'TEST_PREFIX'
   const config = new ProcessedConfig({}, { envVarsPrefix })
+  config.initialize()
   t.is(config.config['BASE_URL'], 'TEST_BASE_URL')
 })
 
@@ -99,6 +106,7 @@ test.serial('Test validate function (out of bounds)', async (t) => {
     },
   }
   const config = new ProcessedConfig(customSettings)
+  config.initialize()
   try {
     config.validate()
     t.fail()
@@ -117,6 +125,7 @@ test.serial('Test validate function (decimal)', async (t) => {
     },
   }
   const config = new ProcessedConfig(customSettings)
+  config.initialize()
   try {
     config.validate()
     t.fail()
@@ -135,6 +144,7 @@ test.serial('Test validate function (scientific notation)', async (t) => {
     },
   }
   const config = new ProcessedConfig(customSettings)
+  config.initialize()
   try {
     config.validate()
     t.pass()

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -1,5 +1,5 @@
 import test from 'ava'
-import { ProcessedConfig, SettingsDefinitionMap } from '../src/config'
+import { AdapterConfig, SettingsDefinitionMap } from '../src/config'
 import { validator } from '../src/validation/utils'
 
 test.afterEach(async () => {
@@ -9,7 +9,7 @@ test.afterEach(async () => {
 test.serial('Test config validator', async (t) => {
   process.env['MAX_COMMON_KEY_SIZE'] = '1000'
   try {
-    const config = new ProcessedConfig({})
+    const config = new AdapterConfig({})
     config.initialize()
     config.validate()
     t.fail()
@@ -20,7 +20,7 @@ test.serial('Test config validator', async (t) => {
 
 test.serial('Test good enum config', async (t) => {
   process.env['CACHE_TYPE'] = 'local'
-  const config = new ProcessedConfig({})
+  const config = new AdapterConfig({})
   config.initialize()
   config.validate()
   t.is(config.settings.CACHE_TYPE, 'local')
@@ -29,7 +29,7 @@ test.serial('Test good enum config', async (t) => {
 test.serial('Test bad enum config', async (t) => {
   process.env['CACHE_TYPE'] = 'test'
   try {
-    const config = new ProcessedConfig({})
+    const config = new AdapterConfig({})
     config.initialize()
     config.validate()
     t.fail()
@@ -46,7 +46,7 @@ test.serial('Test custom settings', async (t) => {
       type: 'string',
     },
   } satisfies SettingsDefinitionMap
-  const config = new ProcessedConfig(customSettings)
+  const config = new AdapterConfig(customSettings)
   config.initialize()
   config.validate()
   t.is(config.settings.CUSTOM_KEY, 'test')
@@ -61,7 +61,7 @@ test.serial('Test missing custom settings (required)', async (t) => {
     },
   }
   try {
-    const config = new ProcessedConfig(customSettings)
+    const config = new AdapterConfig(customSettings)
     config.initialize()
     config.validate()
     t.fail()
@@ -79,7 +79,7 @@ test.serial('Test custom settings (overlap base)', async (t) => {
     },
   }
   try {
-    const config = new ProcessedConfig(customSettings)
+    const config = new AdapterConfig(customSettings)
     config.initialize()
     config.validate()
     t.fail()
@@ -91,7 +91,7 @@ test.serial('Test custom settings (overlap base)', async (t) => {
 test.serial('Test prefix settings', async (t) => {
   process.env['TEST_PREFIX_BASE_URL'] = 'TEST_BASE_URL'
   const envVarsPrefix = 'TEST_PREFIX'
-  const config = new ProcessedConfig({}, { envVarsPrefix })
+  const config = new AdapterConfig({}, { envVarsPrefix })
   config.initialize()
   t.is(config.settings['BASE_URL'], 'TEST_BASE_URL')
 })
@@ -105,7 +105,7 @@ test.serial('Test validate function (out of bounds)', async (t) => {
       validate: validator.integer({ min: 1, max: 10 }),
     },
   }
-  const config = new ProcessedConfig(customSettings)
+  const config = new AdapterConfig(customSettings)
   config.initialize()
   try {
     config.validate()
@@ -124,7 +124,7 @@ test.serial('Test validate function (decimal)', async (t) => {
       validate: validator.integer({ min: 1, max: 10 }),
     },
   }
-  const config = new ProcessedConfig(customSettings)
+  const config = new AdapterConfig(customSettings)
   config.initialize()
   try {
     config.validate()
@@ -143,7 +143,7 @@ test.serial('Test validate function (scientific notation)', async (t) => {
       validate: validator.integer({ min: 2_000_000, max: 5_000_000 }),
     },
   }
-  const config = new ProcessedConfig(customSettings)
+  const config = new AdapterConfig(customSettings)
   config.initialize()
   try {
     config.validate()

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,6 +1,7 @@
 import untypedTest, { TestFn } from 'ava'
 import { expose, start } from '../src'
 import { Adapter, AdapterEndpoint } from '../src/adapter'
+import { ProcessedConfig } from '../src/config'
 import { NopTransport, TestAdapter } from './util'
 
 const test = untypedTest as TestFn<{
@@ -31,8 +32,17 @@ test('health endpoint returns health OK', async (t) => {
 })
 
 test('MTLS_ENABLED with no TLS params should error', async (t) => {
+  const processedConfig = new ProcessedConfig(
+    {},
+    {
+      envDefaultOverrides: {
+        MTLS_ENABLED: true,
+      },
+    },
+  )
   const adapter = new Adapter({
     name: 'TEST',
+    processedConfig,
     endpoints: [
       new AdapterEndpoint({
         name: 'test',
@@ -40,9 +50,6 @@ test('MTLS_ENABLED with no TLS params should error', async (t) => {
         transport: new NopTransport(),
       }),
     ],
-    envDefaultOverrides: {
-      MTLS_ENABLED: true,
-    },
   })
   try {
     await start(adapter)
@@ -55,8 +62,20 @@ test('MTLS_ENABLED with no TLS params should error', async (t) => {
 })
 
 test('MTLS_ENABLED connection with incorrect params should error', async (t) => {
+  const processedConfig = new ProcessedConfig(
+    {},
+    {
+      envDefaultOverrides: {
+        MTLS_ENABLED: true,
+        TLS_PRIVATE_KEY: 'test',
+        TLS_PUBLIC_KEY: 'test',
+        TLS_CA: 'test',
+      },
+    },
+  )
   const adapter = new Adapter({
     name: 'TEST',
+    processedConfig,
     endpoints: [
       new AdapterEndpoint({
         name: 'test',
@@ -64,12 +83,6 @@ test('MTLS_ENABLED connection with incorrect params should error', async (t) => 
         transport: new NopTransport(),
       }),
     ],
-    envDefaultOverrides: {
-      MTLS_ENABLED: true,
-      TLS_PRIVATE_KEY: 'test',
-      TLS_PUBLIC_KEY: 'test',
-      TLS_CA: 'test',
-    },
   })
   try {
     await start(adapter)
@@ -79,8 +92,18 @@ test('MTLS_ENABLED connection with incorrect params should error', async (t) => 
 })
 
 test('Adapter writer mode api disabled', async (t) => {
+  const processedConfig = new ProcessedConfig(
+    {},
+    {
+      envDefaultOverrides: {
+        EA_MODE: 'writer',
+      },
+    },
+  )
+
   const adapter = new Adapter({
     name: 'TEST',
+    processedConfig,
     endpoints: [
       new AdapterEndpoint({
         name: 'test',
@@ -88,9 +111,6 @@ test('Adapter writer mode api disabled', async (t) => {
         transport: new NopTransport(),
       }),
     ],
-    envDefaultOverrides: {
-      EA_MODE: 'writer',
-    },
   })
 
   const api = await expose(adapter)

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,7 +1,7 @@
 import untypedTest, { TestFn } from 'ava'
 import { expose, start } from '../src'
 import { Adapter, AdapterEndpoint } from '../src/adapter'
-import { ProcessedConfig } from '../src/config'
+import { AdapterConfig } from '../src/config'
 import { NopTransport, TestAdapter } from './util'
 
 const test = untypedTest as TestFn<{
@@ -32,7 +32,7 @@ test('health endpoint returns health OK', async (t) => {
 })
 
 test('MTLS_ENABLED with no TLS params should error', async (t) => {
-  const processedConfig = new ProcessedConfig(
+  const config = new AdapterConfig(
     {},
     {
       envDefaultOverrides: {
@@ -42,7 +42,7 @@ test('MTLS_ENABLED with no TLS params should error', async (t) => {
   )
   const adapter = new Adapter({
     name: 'TEST',
-    processedConfig,
+    config,
     endpoints: [
       new AdapterEndpoint({
         name: 'test',
@@ -62,7 +62,7 @@ test('MTLS_ENABLED with no TLS params should error', async (t) => {
 })
 
 test('MTLS_ENABLED connection with incorrect params should error', async (t) => {
-  const processedConfig = new ProcessedConfig(
+  const config = new AdapterConfig(
     {},
     {
       envDefaultOverrides: {
@@ -75,7 +75,7 @@ test('MTLS_ENABLED connection with incorrect params should error', async (t) => 
   )
   const adapter = new Adapter({
     name: 'TEST',
-    processedConfig,
+    config,
     endpoints: [
       new AdapterEndpoint({
         name: 'test',
@@ -92,7 +92,7 @@ test('MTLS_ENABLED connection with incorrect params should error', async (t) => 
 })
 
 test('Adapter writer mode api disabled', async (t) => {
-  const processedConfig = new ProcessedConfig(
+  const config = new AdapterConfig(
     {},
     {
       envDefaultOverrides: {
@@ -103,7 +103,7 @@ test('Adapter writer mode api disabled', async (t) => {
 
   const adapter = new Adapter({
     name: 'TEST',
-    processedConfig,
+    config,
     endpoints: [
       new AdapterEndpoint({
         name: 'test',

--- a/test/logger.test.ts
+++ b/test/logger.test.ts
@@ -1,7 +1,7 @@
 import test from 'ava'
 import { start } from '../src'
 import { Adapter, AdapterEndpoint } from '../src/adapter'
-import { ProcessedConfig, SettingsDefinitionMap } from '../src/config'
+import { AdapterConfig, SettingsDefinitionMap } from '../src/config'
 import CensorList from '../src/util/censor/censor-list'
 import { censor, colorFactory, COLORS } from '../src/util/logger'
 import { NopTransport } from './util'
@@ -15,10 +15,10 @@ test.before(async () => {
     },
   } satisfies SettingsDefinitionMap
   process.env['API_KEY'] = 'mock-api-key'
-  const processedConfig = new ProcessedConfig(customSettings)
+  const config = new AdapterConfig(customSettings)
   const adapter = new Adapter({
     name: 'TEST',
-    processedConfig,
+    config,
     endpoints: [
       new AdapterEndpoint({
         name: 'test',

--- a/test/logger.test.ts
+++ b/test/logger.test.ts
@@ -1,7 +1,7 @@
 import test from 'ava'
 import { start } from '../src'
 import { Adapter, AdapterEndpoint } from '../src/adapter'
-import { ProcessedConfig, SettingsMap } from '../src/config'
+import { ProcessedConfig, SettingsDefinitionMap } from '../src/config'
 import CensorList from '../src/util/censor/censor-list'
 import { censor, colorFactory, COLORS } from '../src/util/logger'
 import { NopTransport } from './util'
@@ -13,7 +13,7 @@ test.before(async () => {
       type: 'string',
       sensitive: true,
     },
-  } satisfies SettingsMap
+  } satisfies SettingsDefinitionMap
   process.env['API_KEY'] = 'mock-api-key'
   const processedConfig = new ProcessedConfig(customSettings)
   const adapter = new Adapter({

--- a/test/logger.test.ts
+++ b/test/logger.test.ts
@@ -1,23 +1,24 @@
 import test from 'ava'
 import { start } from '../src'
 import { Adapter, AdapterEndpoint } from '../src/adapter'
-import { SettingsMap } from '../src/config'
+import { ProcessedConfig, SettingsMap } from '../src/config'
 import CensorList from '../src/util/censor/censor-list'
 import { censor, colorFactory, COLORS } from '../src/util/logger'
 import { NopTransport } from './util'
 
 test.before(async () => {
-  const customSettings: SettingsMap = {
+  const customSettings = {
     API_KEY: {
       description: 'Test custom env var',
       type: 'string',
       sensitive: true,
     },
-  }
+  } satisfies SettingsMap
   process.env['API_KEY'] = 'mock-api-key'
+  const processedConfig = new ProcessedConfig(customSettings)
   const adapter = new Adapter({
     name: 'TEST',
-    customSettings,
+    processedConfig,
     endpoints: [
       new AdapterEndpoint({
         name: 'test',

--- a/test/metrics/feed-id.test.ts
+++ b/test/metrics/feed-id.test.ts
@@ -1,18 +1,18 @@
 import untypedTest, { TestFn } from 'ava'
 import { calculateFeedId } from '../../src/cache'
-import { AdapterConfig, buildAdapterConfig } from '../../src/config'
+import { AdapterSettings, buildAdapterSettings } from '../../src/config'
 import { InputParameters } from '../../src/validation'
 
 const feedIdTest = untypedTest as TestFn<{
   inputParameters: InputParameters
   endpointName: string
-  adapterConfig: AdapterConfig
+  adapterSettings: AdapterSettings
 }>
 
 feedIdTest.beforeEach(async (t) => {
   t.context.endpointName = 'TEST'
   t.context.inputParameters = {}
-  t.context.adapterConfig = buildAdapterConfig({})
+  t.context.adapterSettings = buildAdapterSettings({})
 })
 
 feedIdTest.serial('no parameters returns N/A', async (t) => {

--- a/test/metrics/helper.ts
+++ b/test/metrics/helper.ts
@@ -1,6 +1,6 @@
 import { AxiosResponse } from 'axios'
 import { Adapter, AdapterEndpoint } from '../../src/adapter'
-import { SettingsMap } from '../../src/config'
+import { BaseAdapterConfig } from '../../src/config'
 import { HttpTransport } from '../../src/transports'
 import { SingleNumberResultResponse } from '../../src/util'
 
@@ -44,7 +44,7 @@ type HttpEndpointTypes = {
     Params: AdapterRequestParams
   }
   Response: SingleNumberResultResponse
-  CustomSettings: SettingsMap
+  Config: BaseAdapterConfig
   Provider: {
     RequestBody: ProviderRequestBody
     ResponseBody: ProviderResponseBody

--- a/test/metrics/helper.ts
+++ b/test/metrics/helper.ts
@@ -1,6 +1,6 @@
 import { AxiosResponse } from 'axios'
 import { Adapter, AdapterEndpoint } from '../../src/adapter'
-import { BaseAdapterConfig } from '../../src/config'
+import { BaseAdapterSettings } from '../../src/config'
 import { HttpTransport } from '../../src/transports'
 import { SingleNumberResultResponse } from '../../src/util'
 
@@ -44,7 +44,7 @@ type HttpEndpointTypes = {
     Params: AdapterRequestParams
   }
   Response: SingleNumberResultResponse
-  Config: BaseAdapterConfig
+  Settings: BaseAdapterSettings
   Provider: {
     RequestBody: ProviderRequestBody
     ResponseBody: ProviderResponseBody

--- a/test/metrics/labels.test.ts
+++ b/test/metrics/labels.test.ts
@@ -1,7 +1,7 @@
 import test from 'ava'
 import { priceEndpointInputParameters } from '../../src/adapter'
 import { cacheMetricsLabel } from '../../src/cache/metrics'
-import { AdapterConfig } from '../../src/config'
+import { AdapterSettings } from '../../src/config'
 import { buildHttpRequestMetricsLabel } from '../../src/metrics'
 import { HttpRequestType } from '../../src/metrics/constants'
 import { connectionErrorLabels, messageSubsLabels } from '../../src/transports/metrics'
@@ -76,7 +76,7 @@ test('Generate WS message and subscription label test', (t) => {
   t.deepEqual(
     messageSubsLabels(
       {
-        adapterConfig: {} as AdapterConfig,
+        adapterSettings: {} as AdapterSettings,
         inputParameters: priceEndpointInputParameters,
         endpointName: 'test',
       },

--- a/test/metrics/metrics.test.ts
+++ b/test/metrics/metrics.test.ts
@@ -1,12 +1,12 @@
+import FakeTimers, { InstalledClock } from '@sinonjs/fake-timers'
 import untypedTest, { TestFn } from 'ava'
+import axios from 'axios'
+import MockAdapter from 'axios-mock-adapter'
 import { Adapter, AdapterEndpoint } from '../../src/adapter'
-import { SettingsMap } from '../../src/config'
+import { BaseAdapterConfig, ProcessedConfig } from '../../src/config'
 import { retrieveCost } from '../../src/metrics'
 import { HttpTransport } from '../../src/transports'
 import { TestAdapter } from '../util'
-import MockAdapter from 'axios-mock-adapter'
-import axios from 'axios'
-import FakeTimers, { InstalledClock } from '@sinonjs/fake-timers'
 
 const test = untypedTest as TestFn<{
   testAdapter: TestAdapter
@@ -39,7 +39,7 @@ type RestEndpointTypes = {
     }
     Result: number
   }
-  CustomSettings: SettingsMap
+  Config: BaseAdapterConfig
   Provider: {
     RequestBody: ProviderRequestBody
     ResponseBody: ProviderResponseBody
@@ -104,13 +104,19 @@ const price = 1234
 test.before(async (t) => {
   t.context.clock = FakeTimers.install()
   process.env['METRICS_ENABLED'] = 'true'
+  const processedConfig = new ProcessedConfig(
+    {},
+    {
+      envDefaultOverrides: {
+        RATE_LIMIT_CAPACITY_SECOND: 10,
+      },
+    },
+  )
   const adapter = new Adapter({
     name: 'TEST',
     defaultEndpoint: 'test',
+    processedConfig,
     endpoints: [createAdapterEndpoint()],
-    envDefaultOverrides: {
-      RATE_LIMIT_CAPACITY_SECOND: 10,
-    },
   })
 
   t.context.testAdapter = await TestAdapter.start(adapter, t.context)

--- a/test/metrics/metrics.test.ts
+++ b/test/metrics/metrics.test.ts
@@ -3,7 +3,7 @@ import untypedTest, { TestFn } from 'ava'
 import axios from 'axios'
 import MockAdapter from 'axios-mock-adapter'
 import { Adapter, AdapterEndpoint } from '../../src/adapter'
-import { BaseAdapterSettings, ProcessedConfig } from '../../src/config'
+import { BaseAdapterSettings, AdapterConfig } from '../../src/config'
 import { retrieveCost } from '../../src/metrics'
 import { HttpTransport } from '../../src/transports'
 import { TestAdapter } from '../util'
@@ -104,7 +104,7 @@ const price = 1234
 test.before(async (t) => {
   t.context.clock = FakeTimers.install()
   process.env['METRICS_ENABLED'] = 'true'
-  const processedConfig = new ProcessedConfig(
+  const config = new AdapterConfig(
     {},
     {
       envDefaultOverrides: {
@@ -115,7 +115,7 @@ test.before(async (t) => {
   const adapter = new Adapter({
     name: 'TEST',
     defaultEndpoint: 'test',
-    processedConfig,
+    config,
     endpoints: [createAdapterEndpoint()],
   })
 

--- a/test/metrics/metrics.test.ts
+++ b/test/metrics/metrics.test.ts
@@ -3,7 +3,7 @@ import untypedTest, { TestFn } from 'ava'
 import axios from 'axios'
 import MockAdapter from 'axios-mock-adapter'
 import { Adapter, AdapterEndpoint } from '../../src/adapter'
-import { BaseAdapterConfig, ProcessedConfig } from '../../src/config'
+import { BaseAdapterSettings, ProcessedConfig } from '../../src/config'
 import { retrieveCost } from '../../src/metrics'
 import { HttpTransport } from '../../src/transports'
 import { TestAdapter } from '../util'
@@ -39,7 +39,7 @@ type RestEndpointTypes = {
     }
     Result: number
   }
-  Config: BaseAdapterConfig
+  Settings: BaseAdapterSettings
   Provider: {
     RequestBody: ProviderRequestBody
     ResponseBody: ProviderResponseBody

--- a/test/metrics/polling-metrics.test.ts
+++ b/test/metrics/polling-metrics.test.ts
@@ -60,13 +60,13 @@ test.serial('Test cache warmer active metric', async (t) => {
   const metrics = await t.context.testAdapter.getMetrics()
   metrics.assert(t, {
     name: 'transport_polling_failure_count',
-    labels: { endpoint: 'test' },
+    labels: { adapter_endpoint: 'test' },
     expectedValue: 1,
   })
   metrics.assertPositiveNumber(t, {
     name: 'transport_polling_duration_seconds',
     labels: {
-      endpoint: 'test',
+      adapter_endpoint: 'test',
       succeeded: 'false',
     },
   })

--- a/test/metrics/redis-metrics.test.ts
+++ b/test/metrics/redis-metrics.test.ts
@@ -2,7 +2,7 @@ import untypedTest, { TestFn } from 'ava'
 import Redis from 'ioredis'
 import { Adapter, AdapterDependencies, AdapterEndpoint, EndpointGenerics } from '../../src/adapter'
 import { Cache, LocalCache, RedisCache } from '../../src/cache'
-import { ProcessedConfig } from '../../src/config'
+import { AdapterConfig } from '../../src/config'
 import { BasicCacheSetterTransport } from '../cache/helper'
 import { NopTransport, TestAdapter } from '../util'
 
@@ -50,7 +50,7 @@ test.before(async (t) => {
   process.env['METRICS_ENABLED'] = 'true'
   // Set unique port between metrics tests to avoid conflicts in metrics servers
   process.env['METRICS_PORT'] = '9091'
-  const processedConfig = new ProcessedConfig(
+  const config = new AdapterConfig(
     {},
     {
       envDefaultOverrides: {
@@ -62,7 +62,7 @@ test.before(async (t) => {
   const adapter = new Adapter({
     name: 'TEST',
     defaultEndpoint: 'test',
-    processedConfig,
+    config,
     endpoints: [
       new AdapterEndpoint({
         name: 'test',

--- a/test/metrics/redis-metrics.test.ts
+++ b/test/metrics/redis-metrics.test.ts
@@ -2,6 +2,7 @@ import untypedTest, { TestFn } from 'ava'
 import Redis from 'ioredis'
 import { Adapter, AdapterDependencies, AdapterEndpoint, EndpointGenerics } from '../../src/adapter'
 import { Cache, LocalCache, RedisCache } from '../../src/cache'
+import { ProcessedConfig } from '../../src/config'
 import { BasicCacheSetterTransport } from '../cache/helper'
 import { NopTransport, TestAdapter } from '../util'
 
@@ -49,9 +50,19 @@ test.before(async (t) => {
   process.env['METRICS_ENABLED'] = 'true'
   // Set unique port between metrics tests to avoid conflicts in metrics servers
   process.env['METRICS_PORT'] = '9091'
+  const processedConfig = new ProcessedConfig(
+    {},
+    {
+      envDefaultOverrides: {
+        CACHE_POLLING_SLEEP_MS: 10,
+        CACHE_POLLING_MAX_RETRIES: 3,
+      },
+    },
+  )
   const adapter = new Adapter({
     name: 'TEST',
     defaultEndpoint: 'test',
+    processedConfig,
     endpoints: [
       new AdapterEndpoint({
         name: 'test',
@@ -73,10 +84,6 @@ test.before(async (t) => {
         transport: new NopTransport(),
       }),
     ],
-    envDefaultOverrides: {
-      CACHE_POLLING_SLEEP_MS: 10,
-      CACHE_POLLING_MAX_RETRIES: 3,
-    },
   })
 
   const cache = new RedisCache(new RedisMock() as unknown as Redis) // Fake redis

--- a/test/metrics/warmer-metrics.test.ts
+++ b/test/metrics/warmer-metrics.test.ts
@@ -75,17 +75,17 @@ test.serial('Test cache warmer active metric', async (t) => {
   })
   metrics.assert(t, {
     name: 'bg_execute_total',
-    labels: { endpoint: 'test', transport: 'default_single_transport' },
+    labels: { adapter_endpoint: 'test', transport: 'default_single_transport' },
     expectedValue: 2,
   })
   metrics.assert(t, {
     name: 'bg_execute_subscription_set_count',
-    labels: { endpoint: 'test', transport_type: 'MockHttpTransport' },
+    labels: { adapter_endpoint: 'test', transport_type: 'MockHttpTransport' },
     expectedValue: 1,
   })
   metrics.assertPositiveNumber(t, {
     name: 'bg_execute_duration_seconds',
-    labels: { endpoint: 'test', transport: 'default_single_transport' },
+    labels: { adapter_endpoint: 'test', transport: 'default_single_transport' },
   })
 
   // Wait until the cache expires, and the subscription is out
@@ -106,12 +106,12 @@ test.serial('Test cache warmer active metric', async (t) => {
   })
   metrics.assert(t, {
     name: 'bg_execute_total',
-    labels: { endpoint: 'test', transport: 'default_single_transport' },
+    labels: { adapter_endpoint: 'test', transport: 'default_single_transport' },
     expectedValue: 17,
   })
   metrics.assert(t, {
     name: 'bg_execute_subscription_set_count',
-    labels: { endpoint: 'test', transport_type: 'MockHttpTransport' },
+    labels: { adapter_endpoint: 'test', transport_type: 'MockHttpTransport' },
     expectedValue: 0,
   })
 })

--- a/test/metrics/ws-metrics.test.ts
+++ b/test/metrics/ws-metrics.test.ts
@@ -2,7 +2,7 @@ import FakeTimers, { InstalledClock } from '@sinonjs/fake-timers'
 import untypedTest, { TestFn } from 'ava'
 import { Server, WebSocket } from 'mock-socket'
 import { Adapter, AdapterEndpoint } from '../../src/adapter'
-import { BaseAdapterSettings, ProcessedConfig } from '../../src/config'
+import { BaseAdapterSettings, AdapterConfig } from '../../src/config'
 import { WebSocketClassProvider, WebSocketTransport } from '../../src/transports'
 import { InputParameters } from '../../src/validation'
 import { TestAdapter } from '../util'
@@ -127,7 +127,7 @@ process.env['CACHE_POLLING_MAX_RETRIES'] = '0'
 
 process.env['WS_SUBSCRIPTION_TTL'] = '10000'
 
-const processedConfig = new ProcessedConfig(
+const config = new AdapterConfig(
   {},
   {
     envDefaultOverrides: {
@@ -140,7 +140,7 @@ const processedConfig = new ProcessedConfig(
 const adapter = new Adapter({
   name: 'TEST',
   defaultEndpoint: 'test',
-  processedConfig,
+  config,
   endpoints: [webSocketEndpoint],
 })
 
@@ -239,8 +239,8 @@ test.serial('test WS connection, subscription, and message metrics', async (t) =
 
   // Wait until the cache expires, and the subscription is out
   await t.context.clock.tickAsync(
-    Math.ceil(CACHE_MAX_AGE / adapter.processedConfig.settings.WS_SUBSCRIPTION_TTL) *
-      adapter.processedConfig.settings.WS_SUBSCRIPTION_TTL *
+    Math.ceil(CACHE_MAX_AGE / adapter.config.settings.WS_SUBSCRIPTION_TTL) *
+      adapter.config.settings.WS_SUBSCRIPTION_TTL *
       2 +
       1,
   )

--- a/test/metrics/ws-metrics.test.ts
+++ b/test/metrics/ws-metrics.test.ts
@@ -2,7 +2,7 @@ import FakeTimers, { InstalledClock } from '@sinonjs/fake-timers'
 import untypedTest, { TestFn } from 'ava'
 import { Server, WebSocket } from 'mock-socket'
 import { Adapter, AdapterEndpoint } from '../../src/adapter'
-import { BaseAdapterConfig, ProcessedConfig } from '../../src/config'
+import { BaseAdapterSettings, ProcessedConfig } from '../../src/config'
 import { WebSocketClassProvider, WebSocketTransport } from '../../src/transports'
 import { InputParameters } from '../../src/validation'
 import { TestAdapter } from '../util'
@@ -45,7 +45,7 @@ type WebSocketEndpointTypes = {
     }
     Result: number
   }
-  Config: BaseAdapterConfig
+  Settings: BaseAdapterSettings
   Provider: {
     WsMessage: ProviderMessage
   }
@@ -239,8 +239,8 @@ test.serial('test WS connection, subscription, and message metrics', async (t) =
 
   // Wait until the cache expires, and the subscription is out
   await t.context.clock.tickAsync(
-    Math.ceil(CACHE_MAX_AGE / adapter.processedConfig.config.WS_SUBSCRIPTION_TTL) *
-      adapter.processedConfig.config.WS_SUBSCRIPTION_TTL *
+    Math.ceil(CACHE_MAX_AGE / adapter.processedConfig.settings.WS_SUBSCRIPTION_TTL) *
+      adapter.processedConfig.settings.WS_SUBSCRIPTION_TTL *
       2 +
       1,
   )

--- a/test/metrics/ws-metrics.test.ts
+++ b/test/metrics/ws-metrics.test.ts
@@ -184,7 +184,7 @@ test.serial('test WS connection, subscription, and message metrics', async (t) =
   let metrics = await t.context.testAdapter.getMetrics()
   const feed_id = '{\\"base\\":\\"eth\\",\\"quote\\":\\"usd\\"}'
   const subscription_key = `test-${feed_id}`
-  const endpoint = `test`
+  const adapter_endpoint = `test`
   const transport = 'default_single_transport'
   const transport_type = `WebSocketTransport`
 
@@ -224,17 +224,17 @@ test.serial('test WS connection, subscription, and message metrics', async (t) =
   })
   metrics.assert(t, {
     name: 'bg_execute_total',
-    labels: { endpoint, transport },
+    labels: { adapter_endpoint, transport },
     expectedValue: 2,
   })
   metrics.assert(t, {
     name: 'bg_execute_subscription_set_count',
-    labels: { endpoint, transport_type },
+    labels: { adapter_endpoint, transport_type },
     expectedValue: 1,
   })
   metrics.assertPositiveNumber(t, {
     name: 'bg_execute_duration_seconds',
-    labels: { endpoint, transport },
+    labels: { adapter_endpoint, transport },
   })
 
   // Wait until the cache expires, and the subscription is out
@@ -288,12 +288,12 @@ test.serial('test WS connection, subscription, and message metrics', async (t) =
   })
   metrics.assert(t, {
     name: 'bg_execute_total',
-    labels: { endpoint, transport },
+    labels: { adapter_endpoint, transport },
     expectedValue: 5,
   })
   metrics.assert(t, {
     name: 'bg_execute_subscription_set_count',
-    labels: { endpoint, transport_type },
+    labels: { adapter_endpoint, transport_type },
     expectedValue: 0,
   })
 })

--- a/test/price.test.ts
+++ b/test/price.test.ts
@@ -9,7 +9,7 @@ import {
   priceEndpointInputParameters,
 } from '../src/adapter'
 import { ResponseCache } from '../src/cache/response'
-import { BaseAdapterConfig } from '../src/config'
+import { BaseAdapterSettings } from '../src/config'
 import { Transport } from '../src/transports'
 import { AdapterRequest, AdapterResponse } from '../src/util'
 import { NopTransport, TestAdapter } from './util'
@@ -27,7 +27,7 @@ type PriceTestTypes = {
     Data: null
     Result: number
   }
-  Config: BaseAdapterConfig
+  Settings: BaseAdapterSettings
 }
 
 class PriceTestTransport implements Transport<PriceTestTypes> {

--- a/test/price.test.ts
+++ b/test/price.test.ts
@@ -9,7 +9,7 @@ import {
   priceEndpointInputParameters,
 } from '../src/adapter'
 import { ResponseCache } from '../src/cache/response'
-import { SettingsMap } from '../src/config'
+import { BaseAdapterConfig } from '../src/config'
 import { Transport } from '../src/transports'
 import { AdapterRequest, AdapterResponse } from '../src/util'
 import { NopTransport, TestAdapter } from './util'
@@ -27,7 +27,7 @@ type PriceTestTypes = {
     Data: null
     Result: number
   }
-  CustomSettings: SettingsMap
+  Config: BaseAdapterConfig
 }
 
 class PriceTestTransport implements Transport<PriceTestTypes> {

--- a/test/rate-limit-config.test.ts
+++ b/test/rate-limit-config.test.ts
@@ -1,7 +1,7 @@
 import test from 'ava'
 import { start } from '../src'
 import { Adapter, AdapterDependencies, AdapterEndpoint } from '../src/adapter'
-import { ProcessedConfig } from '../src/config'
+import { AdapterConfig } from '../src/config'
 import {
   buildRateLimitTiersFromConfig,
   highestRateLimitTiers,
@@ -31,7 +31,7 @@ test('empty tiers in rate limiting fails on startup', async (t) => {
 })
 
 test('selected tier is not a valid option', async (t) => {
-  const processedConfig = new ProcessedConfig(
+  const config = new AdapterConfig(
     {},
     {
       envDefaultOverrides: {
@@ -41,7 +41,7 @@ test('selected tier is not a valid option', async (t) => {
   )
   const adapter = new Adapter({
     name: 'TEST',
-    processedConfig,
+    config,
     endpoints: [
       new AdapterEndpoint({
         name: 'test',
@@ -67,7 +67,7 @@ test('selected tier is not a valid option', async (t) => {
 })
 
 test('throws error if explicit allocation leaves no room for implicitly allocated endpoints', async (t) => {
-  const processedConfig = new ProcessedConfig(
+  const config = new AdapterConfig(
     {},
     {
       envDefaultOverrides: {
@@ -79,7 +79,7 @@ test('throws error if explicit allocation leaves no room for implicitly allocate
     async () =>
       new Adapter({
         name: 'TEST',
-        processedConfig,
+        config,
         endpoints: [
           new AdapterEndpoint({
             name: 'test',
@@ -114,7 +114,7 @@ test('throws error if explicit allocation leaves no room for implicitly allocate
 })
 
 test('throws error if explicit allocation exceeds 100%', async (t) => {
-  const processedConfig = new ProcessedConfig(
+  const config = new AdapterConfig(
     {},
     {
       envDefaultOverrides: {
@@ -126,7 +126,7 @@ test('throws error if explicit allocation exceeds 100%', async (t) => {
     async () =>
       new Adapter({
         name: 'TEST',
-        processedConfig,
+        config,
         endpoints: [
           new AdapterEndpoint({
             name: 'test',
@@ -224,7 +224,7 @@ test('uses unlimited tier if none is specified in settings', async (t) => {
 })
 
 test('uses specified tier if present in settings', async (t) => {
-  const processedConfig = new ProcessedConfig(
+  const config = new AdapterConfig(
     {},
     {
       envDefaultOverrides: {
@@ -234,7 +234,7 @@ test('uses specified tier if present in settings', async (t) => {
   )
   const adapter = new Adapter({
     name: 'TEST',
-    processedConfig,
+    config,
     endpoints: [
       new AdapterEndpoint({
         name: 'test',
@@ -273,7 +273,7 @@ test('uses specified tier if present in settings', async (t) => {
 test('test build rate limits from env vars (second, minute)', async (t) => {
   process.env['RATE_LIMIT_CAPACITY_SECOND'] = '1'
   process.env['RATE_LIMIT_CAPACITY_MINUTE'] = '60'
-  const processedConfig = new ProcessedConfig(
+  const config = new AdapterConfig(
     {},
     {
       envDefaultOverrides: {
@@ -283,7 +283,7 @@ test('test build rate limits from env vars (second, minute)', async (t) => {
   )
   const adapter = new Adapter({
     name: 'TEST',
-    processedConfig,
+    config,
     endpoints: [
       new AdapterEndpoint({
         name: 'test',
@@ -302,7 +302,7 @@ test('test build rate limits from env vars (second, minute)', async (t) => {
       },
     },
   })
-  const tiers = buildRateLimitTiersFromConfig(adapter.processedConfig.settings)
+  const tiers = buildRateLimitTiersFromConfig(adapter.config.settings)
   t.is(tiers?.rateLimit1m, 60)
   t.is(tiers?.rateLimit1s, 1)
   t.is(tiers?.rateLimit1h, undefined)
@@ -311,7 +311,7 @@ test('test build rate limits from env vars (second, minute)', async (t) => {
 test('test build rate limits from env vars (second, capacity)', async (t) => {
   process.env['RATE_LIMIT_CAPACITY_SECOND'] = '1'
   process.env['RATE_LIMIT_CAPACITY'] = '60'
-  const processedConfig = new ProcessedConfig(
+  const config = new AdapterConfig(
     {},
     {
       envDefaultOverrides: {
@@ -321,7 +321,7 @@ test('test build rate limits from env vars (second, capacity)', async (t) => {
   )
   const adapter = new Adapter({
     name: 'TEST',
-    processedConfig,
+    config,
     endpoints: [
       new AdapterEndpoint({
         name: 'test',
@@ -340,7 +340,7 @@ test('test build rate limits from env vars (second, capacity)', async (t) => {
       },
     },
   })
-  const tiers = buildRateLimitTiersFromConfig(adapter.processedConfig.settings)
+  const tiers = buildRateLimitTiersFromConfig(adapter.config.settings)
   t.is(tiers?.rateLimit1m, 60)
   t.is(tiers?.rateLimit1s, 1)
   t.is(tiers?.rateLimit1h, undefined)
@@ -350,7 +350,7 @@ test('test build rate limits from env vars (second, minute, capacity)', async (t
   process.env['RATE_LIMIT_CAPACITY_MINUTE'] = '100'
   process.env['RATE_LIMIT_CAPACITY'] = '60'
   process.env['RATE_LIMIT_CAPACITY_SECOND'] = '1'
-  const processedConfig = new ProcessedConfig(
+  const config = new AdapterConfig(
     {},
     {
       envDefaultOverrides: {
@@ -360,7 +360,7 @@ test('test build rate limits from env vars (second, minute, capacity)', async (t
   )
   const adapter = new Adapter({
     name: 'TEST',
-    processedConfig,
+    config,
     endpoints: [
       new AdapterEndpoint({
         name: 'test',
@@ -379,7 +379,7 @@ test('test build rate limits from env vars (second, minute, capacity)', async (t
       },
     },
   })
-  const tiers = buildRateLimitTiersFromConfig(adapter.processedConfig.settings)
+  const tiers = buildRateLimitTiersFromConfig(adapter.config.settings)
   t.is(tiers?.rateLimit1m, 100)
   t.is(tiers?.rateLimit1s, 1)
   t.is(tiers?.rateLimit1h, undefined)
@@ -389,7 +389,7 @@ test('test build rate limits from env vars (capacity)', async (t) => {
   process.env['RATE_LIMIT_CAPACITY_MINUTE'] = undefined
   process.env['RATE_LIMIT_CAPACITY'] = '60'
   process.env['RATE_LIMIT_CAPACITY_SECOND'] = undefined
-  const processedConfig = new ProcessedConfig(
+  const config = new AdapterConfig(
     {},
     {
       envDefaultOverrides: {
@@ -399,7 +399,7 @@ test('test build rate limits from env vars (capacity)', async (t) => {
   )
   const adapter = new Adapter({
     name: 'TEST',
-    processedConfig,
+    config,
     endpoints: [
       new AdapterEndpoint({
         name: 'test',
@@ -418,7 +418,7 @@ test('test build rate limits from env vars (capacity)', async (t) => {
       },
     },
   })
-  const tiers = buildRateLimitTiersFromConfig(adapter.processedConfig.settings)
+  const tiers = buildRateLimitTiersFromConfig(adapter.config.settings)
   t.is(tiers?.rateLimit1m, 60)
 })
 

--- a/test/rate-limit-config.test.ts
+++ b/test/rate-limit-config.test.ts
@@ -302,7 +302,7 @@ test('test build rate limits from env vars (second, minute)', async (t) => {
       },
     },
   })
-  const tiers = buildRateLimitTiersFromConfig(adapter.processedConfig.config)
+  const tiers = buildRateLimitTiersFromConfig(adapter.processedConfig.settings)
   t.is(tiers?.rateLimit1m, 60)
   t.is(tiers?.rateLimit1s, 1)
   t.is(tiers?.rateLimit1h, undefined)
@@ -340,7 +340,7 @@ test('test build rate limits from env vars (second, capacity)', async (t) => {
       },
     },
   })
-  const tiers = buildRateLimitTiersFromConfig(adapter.processedConfig.config)
+  const tiers = buildRateLimitTiersFromConfig(adapter.processedConfig.settings)
   t.is(tiers?.rateLimit1m, 60)
   t.is(tiers?.rateLimit1s, 1)
   t.is(tiers?.rateLimit1h, undefined)
@@ -379,7 +379,7 @@ test('test build rate limits from env vars (second, minute, capacity)', async (t
       },
     },
   })
-  const tiers = buildRateLimitTiersFromConfig(adapter.processedConfig.config)
+  const tiers = buildRateLimitTiersFromConfig(adapter.processedConfig.settings)
   t.is(tiers?.rateLimit1m, 100)
   t.is(tiers?.rateLimit1s, 1)
   t.is(tiers?.rateLimit1h, undefined)
@@ -418,7 +418,7 @@ test('test build rate limits from env vars (capacity)', async (t) => {
       },
     },
   })
-  const tiers = buildRateLimitTiersFromConfig(adapter.processedConfig.config)
+  const tiers = buildRateLimitTiersFromConfig(adapter.processedConfig.settings)
   t.is(tiers?.rateLimit1m, 60)
 })
 

--- a/test/rate-limit-config.test.ts
+++ b/test/rate-limit-config.test.ts
@@ -1,6 +1,7 @@
 import test from 'ava'
 import { start } from '../src'
 import { Adapter, AdapterDependencies, AdapterEndpoint } from '../src/adapter'
+import { ProcessedConfig } from '../src/config'
 import {
   buildRateLimitTiersFromConfig,
   highestRateLimitTiers,
@@ -30,8 +31,17 @@ test('empty tiers in rate limiting fails on startup', async (t) => {
 })
 
 test('selected tier is not a valid option', async (t) => {
+  const processedConfig = new ProcessedConfig(
+    {},
+    {
+      envDefaultOverrides: {
+        RATE_LIMIT_API_TIER: 'asdasdasd',
+      },
+    },
+  )
   const adapter = new Adapter({
     name: 'TEST',
+    processedConfig,
     endpoints: [
       new AdapterEndpoint({
         name: 'test',
@@ -49,9 +59,6 @@ test('selected tier is not a valid option', async (t) => {
         },
       },
     },
-    envDefaultOverrides: {
-      RATE_LIMIT_API_TIER: 'asdasdasd',
-    },
   })
 
   await t.throwsAsync(async () => start(adapter), {
@@ -60,10 +67,19 @@ test('selected tier is not a valid option', async (t) => {
 })
 
 test('throws error if explicit allocation leaves no room for implicitly allocated endpoints', async (t) => {
+  const processedConfig = new ProcessedConfig(
+    {},
+    {
+      envDefaultOverrides: {
+        RATE_LIMIT_API_TIER: 'asdasdasd',
+      },
+    },
+  )
   await t.throwsAsync(
     async () =>
       new Adapter({
         name: 'TEST',
+        processedConfig,
         endpoints: [
           new AdapterEndpoint({
             name: 'test',
@@ -89,9 +105,6 @@ test('throws error if explicit allocation leaves no room for implicitly allocate
             },
           },
         },
-        envDefaultOverrides: {
-          RATE_LIMIT_API_TIER: 'asdasdasd',
-        },
       }),
     {
       message:
@@ -101,10 +114,19 @@ test('throws error if explicit allocation leaves no room for implicitly allocate
 })
 
 test('throws error if explicit allocation exceeds 100%', async (t) => {
+  const processedConfig = new ProcessedConfig(
+    {},
+    {
+      envDefaultOverrides: {
+        RATE_LIMIT_API_TIER: 'asdasdasd',
+      },
+    },
+  )
   await t.throwsAsync(
     async () =>
       new Adapter({
         name: 'TEST',
+        processedConfig,
         endpoints: [
           new AdapterEndpoint({
             name: 'test',
@@ -133,9 +155,6 @@ test('throws error if explicit allocation exceeds 100%', async (t) => {
             },
           },
         },
-        envDefaultOverrides: {
-          RATE_LIMIT_API_TIER: 'asdasdasd',
-        },
       }),
     {
       message: 'The total allocation set for all endpoints summed cannot exceed 100%',
@@ -144,8 +163,17 @@ test('throws error if explicit allocation exceeds 100%', async (t) => {
 })
 
 test('uses most restrictive tier if none is specified in settings', async (t) => {
+  const processedConfig = new ProcessedConfig(
+    {},
+    {
+      envDefaultOverrides: {
+        RATE_LIMIT_API_TIER: 'asdasdasd',
+      },
+    },
+  )
   const adapter = new Adapter({
     name: 'TEST',
+    processedConfig,
     endpoints: [
       new AdapterEndpoint({
         name: 'test',
@@ -205,8 +233,17 @@ test('uses unlimited tier if none is specified in settings', async (t) => {
 })
 
 test('uses specified tier if present in settings', async (t) => {
+  const processedConfig = new ProcessedConfig(
+    {},
+    {
+      envDefaultOverrides: {
+        RATE_LIMIT_API_TIER: 'pro',
+      },
+    },
+  )
   const adapter = new Adapter({
     name: 'TEST',
+    processedConfig,
     endpoints: [
       new AdapterEndpoint({
         name: 'test',
@@ -237,9 +274,6 @@ test('uses specified tier if present in settings', async (t) => {
         },
       },
     },
-    envDefaultOverrides: {
-      RATE_LIMIT_API_TIER: 'pro',
-    },
   })
 
   await start(adapter)
@@ -248,8 +282,17 @@ test('uses specified tier if present in settings', async (t) => {
 test('test build rate limits from env vars (second, minute)', async (t) => {
   process.env['RATE_LIMIT_CAPACITY_SECOND'] = '1'
   process.env['RATE_LIMIT_CAPACITY_MINUTE'] = '60'
+  const processedConfig = new ProcessedConfig(
+    {},
+    {
+      envDefaultOverrides: {
+        RATE_LIMIT_API_TIER: 'pro',
+      },
+    },
+  )
   const adapter = new Adapter({
     name: 'TEST',
+    processedConfig,
     endpoints: [
       new AdapterEndpoint({
         name: 'test',
@@ -267,11 +310,8 @@ test('test build rate limits from env vars (second, minute)', async (t) => {
         },
       },
     },
-    envDefaultOverrides: {
-      RATE_LIMIT_API_TIER: 'pro',
-    },
   })
-  const tiers = buildRateLimitTiersFromConfig(adapter.config)
+  const tiers = buildRateLimitTiersFromConfig(adapter.processedConfig.config)
   t.is(tiers?.rateLimit1m, 60)
   t.is(tiers?.rateLimit1s, 1)
   t.is(tiers?.rateLimit1h, undefined)
@@ -280,8 +320,17 @@ test('test build rate limits from env vars (second, minute)', async (t) => {
 test('test build rate limits from env vars (second, capacity)', async (t) => {
   process.env['RATE_LIMIT_CAPACITY_SECOND'] = '1'
   process.env['RATE_LIMIT_CAPACITY'] = '60'
+  const processedConfig = new ProcessedConfig(
+    {},
+    {
+      envDefaultOverrides: {
+        RATE_LIMIT_API_TIER: 'pro',
+      },
+    },
+  )
   const adapter = new Adapter({
     name: 'TEST',
+    processedConfig,
     endpoints: [
       new AdapterEndpoint({
         name: 'test',
@@ -299,11 +348,8 @@ test('test build rate limits from env vars (second, capacity)', async (t) => {
         },
       },
     },
-    envDefaultOverrides: {
-      RATE_LIMIT_API_TIER: 'pro',
-    },
   })
-  const tiers = buildRateLimitTiersFromConfig(adapter.config)
+  const tiers = buildRateLimitTiersFromConfig(adapter.processedConfig.config)
   t.is(tiers?.rateLimit1m, 60)
   t.is(tiers?.rateLimit1s, 1)
   t.is(tiers?.rateLimit1h, undefined)
@@ -313,8 +359,17 @@ test('test build rate limits from env vars (second, minute, capacity)', async (t
   process.env['RATE_LIMIT_CAPACITY_MINUTE'] = '100'
   process.env['RATE_LIMIT_CAPACITY'] = '60'
   process.env['RATE_LIMIT_CAPACITY_SECOND'] = '1'
+  const processedConfig = new ProcessedConfig(
+    {},
+    {
+      envDefaultOverrides: {
+        RATE_LIMIT_API_TIER: 'pro',
+      },
+    },
+  )
   const adapter = new Adapter({
     name: 'TEST',
+    processedConfig,
     endpoints: [
       new AdapterEndpoint({
         name: 'test',
@@ -332,11 +387,8 @@ test('test build rate limits from env vars (second, minute, capacity)', async (t
         },
       },
     },
-    envDefaultOverrides: {
-      RATE_LIMIT_API_TIER: 'pro',
-    },
   })
-  const tiers = buildRateLimitTiersFromConfig(adapter.config)
+  const tiers = buildRateLimitTiersFromConfig(adapter.processedConfig.config)
   t.is(tiers?.rateLimit1m, 100)
   t.is(tiers?.rateLimit1s, 1)
   t.is(tiers?.rateLimit1h, undefined)
@@ -346,8 +398,17 @@ test('test build rate limits from env vars (capacity)', async (t) => {
   process.env['RATE_LIMIT_CAPACITY_MINUTE'] = undefined
   process.env['RATE_LIMIT_CAPACITY'] = '60'
   process.env['RATE_LIMIT_CAPACITY_SECOND'] = undefined
+  const processedConfig = new ProcessedConfig(
+    {},
+    {
+      envDefaultOverrides: {
+        RATE_LIMIT_API_TIER: 'pro',
+      },
+    },
+  )
   const adapter = new Adapter({
     name: 'TEST',
+    processedConfig,
     endpoints: [
       new AdapterEndpoint({
         name: 'test',
@@ -365,11 +426,8 @@ test('test build rate limits from env vars (capacity)', async (t) => {
         },
       },
     },
-    envDefaultOverrides: {
-      RATE_LIMIT_API_TIER: 'pro',
-    },
   })
-  const tiers = buildRateLimitTiersFromConfig(adapter.config)
+  const tiers = buildRateLimitTiersFromConfig(adapter.processedConfig.config)
   t.is(tiers?.rateLimit1m, 60)
 })
 

--- a/test/rate-limit-config.test.ts
+++ b/test/rate-limit-config.test.ts
@@ -163,17 +163,8 @@ test('throws error if explicit allocation exceeds 100%', async (t) => {
 })
 
 test('uses most restrictive tier if none is specified in settings', async (t) => {
-  const processedConfig = new ProcessedConfig(
-    {},
-    {
-      envDefaultOverrides: {
-        RATE_LIMIT_API_TIER: 'asdasdasd',
-      },
-    },
-  )
   const adapter = new Adapter({
     name: 'TEST',
-    processedConfig,
     endpoints: [
       new AdapterEndpoint({
         name: 'test',

--- a/test/subscription-set/redis-subscription-set.test.ts
+++ b/test/subscription-set/redis-subscription-set.test.ts
@@ -4,7 +4,7 @@ import axios, { AxiosResponse } from 'axios'
 import MockAdapter from 'axios-mock-adapter'
 import Redis, { ScanStream } from 'ioredis'
 import { Adapter, AdapterDependencies, AdapterEndpoint } from '../../src/adapter'
-import { BaseAdapterConfig, ProcessedConfig } from '../../src/config'
+import { BaseAdapterSettings, ProcessedConfig } from '../../src/config'
 import { HttpTransport } from '../../src/transports'
 import { SingleNumberResultResponse } from '../../src/util'
 import { assertEqualResponses, runAllUntilTime, TestAdapter } from '../util'
@@ -73,7 +73,7 @@ type BatchEndpointTypes = {
     Params: AdapterRequestParams
   }
   Response: SingleNumberResultResponse
-  Config: BaseAdapterConfig
+  Settings: BaseAdapterSettings
   Provider: {
     RequestBody: ProviderRequestBody
     ResponseBody: ProviderResponseBody

--- a/test/subscription-set/redis-subscription-set.test.ts
+++ b/test/subscription-set/redis-subscription-set.test.ts
@@ -1,13 +1,13 @@
 import FakeTimers, { InstalledClock } from '@sinonjs/fake-timers'
 import untypedTest, { TestFn } from 'ava'
 import axios, { AxiosResponse } from 'axios'
+import MockAdapter from 'axios-mock-adapter'
 import Redis, { ScanStream } from 'ioredis'
 import { Adapter, AdapterDependencies, AdapterEndpoint } from '../../src/adapter'
-import { SettingsMap } from '../../src/config'
+import { BaseAdapterConfig, ProcessedConfig } from '../../src/config'
 import { HttpTransport } from '../../src/transports'
 import { SingleNumberResultResponse } from '../../src/util'
 import { assertEqualResponses, runAllUntilTime, TestAdapter } from '../util'
-import MockAdapter from 'axios-mock-adapter'
 
 export const test = untypedTest as TestFn<{
   testAdapter: TestAdapter
@@ -73,7 +73,7 @@ type BatchEndpointTypes = {
     Params: AdapterRequestParams
   }
   Response: SingleNumberResultResponse
-  CustomSettings: SettingsMap
+  Config: BaseAdapterConfig
   Provider: {
     RequestBody: ProviderRequestBody
     ResponseBody: ProviderResponseBody
@@ -111,9 +111,20 @@ const buildAdapter = () => {
     },
   })
 
+  const processedConfig = new ProcessedConfig(
+    {},
+    {
+      envDefaultOverrides: {
+        CACHE_MAX_AGE: 1000,
+        CACHE_POLLING_MAX_RETRIES: 0,
+      },
+    },
+  )
+
   return new Adapter({
     name: 'TEST',
     defaultEndpoint: 'test',
+    processedConfig,
     endpoints: [
       new AdapterEndpoint({
         name: 'test',
@@ -121,10 +132,6 @@ const buildAdapter = () => {
         transport: batchTransport,
       }),
     ],
-    envDefaultOverrides: {
-      CACHE_MAX_AGE: 1000,
-      CACHE_POLLING_MAX_RETRIES: 0,
-    },
   })
 }
 

--- a/test/subscription-set/redis-subscription-set.test.ts
+++ b/test/subscription-set/redis-subscription-set.test.ts
@@ -4,7 +4,7 @@ import axios, { AxiosResponse } from 'axios'
 import MockAdapter from 'axios-mock-adapter'
 import Redis, { ScanStream } from 'ioredis'
 import { Adapter, AdapterDependencies, AdapterEndpoint } from '../../src/adapter'
-import { BaseAdapterSettings, ProcessedConfig } from '../../src/config'
+import { BaseAdapterSettings, AdapterConfig } from '../../src/config'
 import { HttpTransport } from '../../src/transports'
 import { SingleNumberResultResponse } from '../../src/util'
 import { assertEqualResponses, runAllUntilTime, TestAdapter } from '../util'
@@ -111,7 +111,7 @@ const buildAdapter = () => {
     },
   })
 
-  const processedConfig = new ProcessedConfig(
+  const config = new AdapterConfig(
     {},
     {
       envDefaultOverrides: {
@@ -124,7 +124,7 @@ const buildAdapter = () => {
   return new Adapter({
     name: 'TEST',
     defaultEndpoint: 'test',
-    processedConfig,
+    config,
     endpoints: [
       new AdapterEndpoint({
         name: 'test',

--- a/test/subscription-set/subscription-set-factory.test.ts
+++ b/test/subscription-set/subscription-set-factory.test.ts
@@ -1,6 +1,6 @@
 import test from 'ava'
 import Redis from 'ioredis'
-import { buildAdapterConfig } from '../../src/config'
+import { buildAdapterSettings } from '../../src/config'
 import { SubscriptionSetFactory } from '../../src/util'
 import { ExpiringSortedSet } from '../../src/util/subscription-set/expiring-sorted-set'
 import { RedisSubscriptionSet } from '../../src/util/subscription-set/redis-sorted-set'
@@ -8,7 +8,7 @@ import { RedisMock } from '../util'
 
 test('subscription set factory (local cache)', async (t) => {
   process.env['CACHE_TYPE'] = 'local'
-  const config = buildAdapterConfig({})
+  const config = buildAdapterSettings({})
   const factory = new SubscriptionSetFactory(config, 'test')
   const subscriptionSet = factory.buildSet('test')
   t.is(subscriptionSet instanceof ExpiringSortedSet, true)
@@ -16,7 +16,7 @@ test('subscription set factory (local cache)', async (t) => {
 
 test('subscription set factory (redis cache)', async (t) => {
   process.env['CACHE_TYPE'] = 'redis'
-  const config = buildAdapterConfig({})
+  const config = buildAdapterSettings({})
   const factory = new SubscriptionSetFactory(config, 'test', new RedisMock() as unknown as Redis)
   const subscriptionSet = factory.buildSet('test')
   t.is(subscriptionSet instanceof RedisSubscriptionSet, true)
@@ -24,7 +24,7 @@ test('subscription set factory (redis cache)', async (t) => {
 
 test('subscription set factory (redis cache missing client)', async (t) => {
   process.env['CACHE_TYPE'] = 'redis'
-  const config = buildAdapterConfig({})
+  const config = buildAdapterSettings({})
   const factory = new SubscriptionSetFactory(config, 'test')
   try {
     factory.buildSet('test')
@@ -37,7 +37,7 @@ test('subscription set factory (redis cache missing client)', async (t) => {
 test('subscription set factory (local cache) max capacity', async (t) => {
   process.env['CACHE_TYPE'] = 'local'
   process.env['SUBSCRIPTION_SET_MAX_ITEMS'] = '3'
-  const config = buildAdapterConfig({})
+  const config = buildAdapterSettings({})
   const factory = new SubscriptionSetFactory(config, 'test')
   const subscriptionSet = factory.buildSet('test')
 

--- a/test/transports/http.test.ts
+++ b/test/transports/http.test.ts
@@ -5,7 +5,7 @@ import MockAdapter from 'axios-mock-adapter'
 import { FastifyInstance } from 'fastify'
 import { Adapter, AdapterEndpoint, EndpointContext } from '../../src/adapter'
 import { calculateHttpRequestKey } from '../../src/cache'
-import { BaseAdapterSettings, buildAdapterSettings, ProcessedConfig } from '../../src/config'
+import { BaseAdapterSettings, buildAdapterSettings, AdapterConfig } from '../../src/config'
 import { HttpTransport } from '../../src/transports'
 import { ProviderResult, SingleNumberResultResponse, sleep } from '../../src/util'
 import { InputParameters } from '../../src/validation'
@@ -203,7 +203,7 @@ test.serial(
     const rateLimit1m = 4
     const transport = new MockHttpTransport(true)
 
-    const processedConfig = new ProcessedConfig(
+    const config = new AdapterConfig(
       {},
       {
         envDefaultOverrides: {
@@ -215,7 +215,7 @@ test.serial(
     const adapter = new Adapter({
       name: 'TEST',
       defaultEndpoint: 'test',
-      processedConfig,
+      config,
       endpoints: [
         new AdapterEndpoint({
           name: 'test',
@@ -243,7 +243,7 @@ test.serial(
     // Advance the clock a few minutes and check that the amount of calls is as expected
     await runAllUntilTime(t.context.clock, 3 * 60 * 1000) // 4m
     const expected =
-      rateLimit1m * Math.ceil(adapter.processedConfig.settings.WARMUP_SUBSCRIPTION_TTL / 60_000)
+      rateLimit1m * Math.ceil(adapter.config.settings.WARMUP_SUBSCRIPTION_TTL / 60_000)
     t.is(transport.backgroundExecuteCalls, expected)
   },
 )
@@ -254,7 +254,7 @@ test.serial(
     const rateLimit1s = 1
     const transport = new MockHttpTransport(true)
 
-    const processedConfig = new ProcessedConfig(
+    const config = new AdapterConfig(
       {},
       {
         envDefaultOverrides: {
@@ -266,7 +266,7 @@ test.serial(
     const adapter = new Adapter({
       name: 'TEST',
       defaultEndpoint: 'test',
-      processedConfig,
+      config,
       endpoints: [
         new AdapterEndpoint({
           name: 'test',
@@ -304,7 +304,7 @@ test.serial(
     const transportA = new MockHttpTransport(true)
     const transportB = new MockHttpTransport(true)
 
-    const processedConfig = new ProcessedConfig(
+    const config = new AdapterConfig(
       {},
       {
         envDefaultOverrides: {
@@ -315,7 +315,7 @@ test.serial(
 
     const adapter = new Adapter({
       name: 'TEST',
-      processedConfig,
+      config,
       endpoints: [
         new AdapterEndpoint({
           name: 'A',
@@ -402,7 +402,7 @@ test.serial(
         ],
       })
 
-    const processedConfig = new ProcessedConfig(
+    const config = new AdapterConfig(
       {},
       {
         envDefaultOverrides: {
@@ -413,7 +413,7 @@ test.serial(
 
     const adapter = new Adapter({
       name: 'TEST',
-      processedConfig,
+      config,
       endpoints: [
         new AdapterEndpoint({
           name: 'A',
@@ -474,7 +474,7 @@ test.serial('DP request fails, EA returns 502 cached error', async (t) => {
   })
   // Create mocked cache so we can listen when values are set
   // This is a more reliable method than expecting precise clock timings
-  const mockCache = new MockCache(adapter.processedConfig.settings.CACHE_MAX_ITEMS)
+  const mockCache = new MockCache(adapter.config.settings.CACHE_MAX_ITEMS)
 
   // Start the adapter
   const testAdapter = await TestAdapter.start(adapter, t.context, {
@@ -676,7 +676,7 @@ test.serial(
     //   - Queued
     const numbers = [1, 2, 3, 4]
 
-    const processedConfig = new ProcessedConfig(
+    const config = new AdapterConfig(
       {},
       {
         envDefaultOverrides: {
@@ -691,7 +691,7 @@ test.serial(
     const adapter = new Adapter({
       name: 'TEST',
       defaultEndpoint: 'test',
-      processedConfig,
+      config,
       endpoints: numbers.map(
         (n) =>
           new AdapterEndpoint({

--- a/test/transports/http.test.ts
+++ b/test/transports/http.test.ts
@@ -5,7 +5,7 @@ import MockAdapter from 'axios-mock-adapter'
 import { FastifyInstance } from 'fastify'
 import { Adapter, AdapterEndpoint, EndpointContext } from '../../src/adapter'
 import { calculateHttpRequestKey } from '../../src/cache'
-import { BaseAdapterConfig, buildAdapterConfig, ProcessedConfig } from '../../src/config'
+import { BaseAdapterSettings, buildAdapterSettings, ProcessedConfig } from '../../src/config'
 import { HttpTransport } from '../../src/transports'
 import { ProviderResult, SingleNumberResultResponse, sleep } from '../../src/util'
 import { InputParameters } from '../../src/validation'
@@ -61,7 +61,7 @@ type HttpTransportTypes = {
     Params: AdapterRequestParams
   }
   Response: SingleNumberResultResponse
-  Config: BaseAdapterConfig
+  Settings: BaseAdapterSettings
   Provider: {
     RequestBody: ProviderRequestBody
     ResponseBody: ProviderResponseBody
@@ -243,7 +243,7 @@ test.serial(
     // Advance the clock a few minutes and check that the amount of calls is as expected
     await runAllUntilTime(t.context.clock, 3 * 60 * 1000) // 4m
     const expected =
-      rateLimit1m * Math.ceil(adapter.processedConfig.config.WARMUP_SUBSCRIPTION_TTL / 60_000)
+      rateLimit1m * Math.ceil(adapter.processedConfig.settings.WARMUP_SUBSCRIPTION_TTL / 60_000)
     t.is(transport.backgroundExecuteCalls, expected)
   },
 )
@@ -474,7 +474,7 @@ test.serial('DP request fails, EA returns 502 cached error', async (t) => {
   })
   // Create mocked cache so we can listen when values are set
   // This is a more reliable method than expecting precise clock timings
-  const mockCache = new MockCache(adapter.processedConfig.config.CACHE_MAX_ITEMS)
+  const mockCache = new MockCache(adapter.processedConfig.settings.CACHE_MAX_ITEMS)
 
   // Start the adapter
   const testAdapter = await TestAdapter.start(adapter, t.context, {
@@ -766,7 +766,7 @@ test.serial(
 
 test.serial('builds HTTP request queue key correctly from input params', async (t) => {
   const endpointName = 'test'
-  const adapterConfig = buildAdapterConfig({})
+  const adapterSettings = buildAdapterSettings({})
   const params: InputParameters = {
     base: {
       type: 'string',
@@ -784,7 +784,7 @@ test.serial('builds HTTP request queue key correctly from input params', async (
       transportName: 'transport',
       context: {
         endpointName,
-        adapterConfig,
+        adapterSettings,
         inputParameters: params,
       },
     }),

--- a/test/transports/routing.test.ts
+++ b/test/transports/routing.test.ts
@@ -3,7 +3,7 @@ import axios, { AxiosRequestConfig, AxiosResponse } from 'axios'
 import MockAdapter from 'axios-mock-adapter'
 import { Server, WebSocket } from 'mock-socket'
 import { Adapter, AdapterEndpoint, EndpointContext } from '../../src/adapter'
-import { ProcessedConfig, SettingsDefinitionMap } from '../../src/config'
+import { AdapterConfig, SettingsDefinitionMap } from '../../src/config'
 import {
   HttpTransport,
   SSEConfig,
@@ -16,7 +16,7 @@ import { InputParameters } from '../../src/validation'
 import { TestAdapter } from '../util'
 
 const test = untypedTest as TestFn<{
-  testAdapter: TestAdapter<typeof processedConfig>
+  testAdapter: TestAdapter<typeof adapterConfig>
 }>
 
 interface ProviderRequestBody {
@@ -48,7 +48,7 @@ const settings = {
   },
 } satisfies SettingsDefinitionMap
 
-const processedConfig = new ProcessedConfig(settings)
+const adapterConfig = new AdapterConfig(settings)
 
 const restUrl = 'http://test-url.com'
 const websocketUrl = 'wss://test-ws.com/asd'
@@ -64,7 +64,7 @@ type BaseEndpointTypes = {
     }
     Result: number
   }
-  Settings: typeof processedConfig.settings
+  Settings: typeof adapterConfig.settings
 }
 
 type WebSocketTypes = BaseEndpointTypes & {
@@ -285,7 +285,7 @@ test.beforeEach(async (t) => {
     transports,
   })
 
-  const customConfig = new ProcessedConfig(settings, {
+  const customConfig = new AdapterConfig(settings, {
     envDefaultOverrides: {
       LOG_LEVEL: 'debug',
       METRICS_ENABLED: false,
@@ -297,7 +297,7 @@ test.beforeEach(async (t) => {
   const sampleAdapter = new Adapter({
     name: 'TEST',
     defaultEndpoint: 'price',
-    processedConfig: customConfig,
+    config: customConfig,
     endpoints: [sampleEndpoint],
     rateLimiting: {
       tiers: {
@@ -404,7 +404,7 @@ test.serial('custom router is applied to get valid transport to route to', async
     customRouter: () => 'batch',
   })
 
-  const customConfig = new ProcessedConfig(settings, {
+  const customConfig = new AdapterConfig(settings, {
     envDefaultOverrides: {
       LOG_LEVEL: 'debug',
       METRICS_ENABLED: false,
@@ -416,7 +416,7 @@ test.serial('custom router is applied to get valid transport to route to', async
   const adapter = new Adapter({
     name: 'TEST',
     defaultEndpoint: 'price',
-    processedConfig: customConfig,
+    config: customConfig,
     endpoints: [endpoint],
     rateLimiting: {
       tiers: {
@@ -466,7 +466,7 @@ test.serial('custom router returns invalid transport and request fails', async (
     customRouter: () => 'qweqwe',
   })
 
-  const customConfig = new ProcessedConfig(settings, {
+  const customConfig = new AdapterConfig(settings, {
     envDefaultOverrides: {
       LOG_LEVEL: 'debug',
       METRICS_ENABLED: false,
@@ -479,7 +479,7 @@ test.serial('custom router returns invalid transport and request fails', async (
     name: 'TEST',
     defaultEndpoint: 'price',
     endpoints: [endpoint],
-    processedConfig: customConfig,
+    config: customConfig,
     rateLimiting: {
       tiers: {
         default: {
@@ -528,7 +528,7 @@ test.serial('missing transport in input params with no default fails request', a
     transports,
   })
 
-  const customConfig = new ProcessedConfig(settings, {
+  const customConfig = new AdapterConfig(settings, {
     envDefaultOverrides: {
       LOG_LEVEL: 'debug',
       METRICS_ENABLED: false,
@@ -540,7 +540,7 @@ test.serial('missing transport in input params with no default fails request', a
   const adapter = new Adapter({
     name: 'TEST',
     defaultEndpoint: 'price',
-    processedConfig: customConfig,
+    config: customConfig,
     endpoints: [endpoint],
     rateLimiting: {
       tiers: {
@@ -590,7 +590,7 @@ test.serial('missing transport in input params with default succeeds', async (t)
     defaultTransport: 'batch',
   })
 
-  const customConfig = new ProcessedConfig(settings, {
+  const customConfig = new AdapterConfig(settings, {
     envDefaultOverrides: {
       LOG_LEVEL: 'debug',
       METRICS_ENABLED: false,
@@ -603,7 +603,7 @@ test.serial('missing transport in input params with default succeeds', async (t)
     name: 'TEST',
     defaultEndpoint: 'price',
     endpoints: [endpoint],
-    processedConfig: customConfig,
+    config: customConfig,
     rateLimiting: {
       tiers: {
         default: {

--- a/test/transports/routing.test.ts
+++ b/test/transports/routing.test.ts
@@ -3,7 +3,7 @@ import axios, { AxiosRequestConfig, AxiosResponse } from 'axios'
 import MockAdapter from 'axios-mock-adapter'
 import { Server, WebSocket } from 'mock-socket'
 import { Adapter, AdapterEndpoint, EndpointContext } from '../../src/adapter'
-import { SettingsMap } from '../../src/config'
+import { ProcessedConfig, SettingsMap } from '../../src/config'
 import {
   HttpTransport,
   SSEConfig,
@@ -16,7 +16,7 @@ import { InputParameters } from '../../src/validation'
 import { TestAdapter } from '../util'
 
 const test = untypedTest as TestFn<{
-  testAdapter: TestAdapter
+  testAdapter: TestAdapter<typeof processedConfig>
 }>
 
 interface ProviderRequestBody {
@@ -38,7 +38,7 @@ interface ProviderMessage {
   value: number
 }
 
-const CustomSettings: SettingsMap = {
+const settings = {
   TEST_SETTING: {
     type: 'string',
     description: 'test setting',
@@ -46,7 +46,9 @@ const CustomSettings: SettingsMap = {
     required: false,
     sensitive: false,
   },
-}
+} satisfies SettingsMap
+
+const processedConfig = new ProcessedConfig(settings)
 
 const restUrl = 'http://test-url.com'
 const websocketUrl = 'wss://test-ws.com/asd'
@@ -62,7 +64,7 @@ type BaseEndpointTypes = {
     }
     Result: number
   }
-  CustomSettings: SettingsMap
+  Config: typeof processedConfig.config
 }
 
 type WebSocketTypes = BaseEndpointTypes & {
@@ -283,9 +285,19 @@ test.beforeEach(async (t) => {
     transports,
   })
 
-  const sampleAdapter = new Adapter<typeof CustomSettings>({
+  const customConfig = new ProcessedConfig(settings, {
+    envDefaultOverrides: {
+      LOG_LEVEL: 'debug',
+      METRICS_ENABLED: false,
+      CACHE_POLLING_SLEEP_MS: 10,
+      CACHE_POLLING_MAX_RETRIES: 0,
+    },
+  })
+
+  const sampleAdapter = new Adapter({
     name: 'TEST',
     defaultEndpoint: 'price',
+    processedConfig: customConfig,
     endpoints: [sampleEndpoint],
     rateLimiting: {
       tiers: {
@@ -293,12 +305,6 @@ test.beforeEach(async (t) => {
           rateLimit1s: 5,
         },
       },
-    },
-    envDefaultOverrides: {
-      LOG_LEVEL: 'debug',
-      METRICS_ENABLED: false,
-      CACHE_POLLING_SLEEP_MS: 10,
-      CACHE_POLLING_MAX_RETRIES: 0,
     },
   })
 
@@ -398,9 +404,19 @@ test.serial('custom router is applied to get valid transport to route to', async
     customRouter: () => 'batch',
   })
 
-  const adapter = new Adapter<typeof CustomSettings>({
+  const customConfig = new ProcessedConfig(settings, {
+    envDefaultOverrides: {
+      LOG_LEVEL: 'debug',
+      METRICS_ENABLED: false,
+      CACHE_POLLING_SLEEP_MS: 10,
+      CACHE_POLLING_MAX_RETRIES: 0,
+    },
+  })
+
+  const adapter = new Adapter({
     name: 'TEST',
     defaultEndpoint: 'price',
+    processedConfig: customConfig,
     endpoints: [endpoint],
     rateLimiting: {
       tiers: {
@@ -408,12 +424,6 @@ test.serial('custom router is applied to get valid transport to route to', async
           rateLimit1s: 5,
         },
       },
-    },
-    envDefaultOverrides: {
-      LOG_LEVEL: 'debug',
-      METRICS_ENABLED: false,
-      CACHE_POLLING_SLEEP_MS: 10,
-      CACHE_POLLING_MAX_RETRIES: 0,
     },
   })
 
@@ -456,22 +466,26 @@ test.serial('custom router returns invalid transport and request fails', async (
     customRouter: () => 'qweqwe',
   })
 
-  const adapter = new Adapter<typeof CustomSettings>({
+  const customConfig = new ProcessedConfig(settings, {
+    envDefaultOverrides: {
+      LOG_LEVEL: 'debug',
+      METRICS_ENABLED: false,
+      CACHE_POLLING_SLEEP_MS: 10,
+      CACHE_POLLING_MAX_RETRIES: 0,
+    },
+  })
+
+  const adapter = new Adapter({
     name: 'TEST',
     defaultEndpoint: 'price',
     endpoints: [endpoint],
+    processedConfig: customConfig,
     rateLimiting: {
       tiers: {
         default: {
           rateLimit1s: 5,
         },
       },
-    },
-    envDefaultOverrides: {
-      LOG_LEVEL: 'debug',
-      METRICS_ENABLED: false,
-      CACHE_POLLING_SLEEP_MS: 10,
-      CACHE_POLLING_MAX_RETRIES: 0,
     },
   })
 
@@ -514,9 +528,19 @@ test.serial('missing transport in input params with no default fails request', a
     transports,
   })
 
-  const adapter = new Adapter<typeof CustomSettings>({
+  const customConfig = new ProcessedConfig(settings, {
+    envDefaultOverrides: {
+      LOG_LEVEL: 'debug',
+      METRICS_ENABLED: false,
+      CACHE_POLLING_SLEEP_MS: 10,
+      CACHE_POLLING_MAX_RETRIES: 0,
+    },
+  })
+
+  const adapter = new Adapter({
     name: 'TEST',
     defaultEndpoint: 'price',
+    processedConfig: customConfig,
     endpoints: [endpoint],
     rateLimiting: {
       tiers: {
@@ -524,12 +548,6 @@ test.serial('missing transport in input params with no default fails request', a
           rateLimit1s: 5,
         },
       },
-    },
-    envDefaultOverrides: {
-      LOG_LEVEL: 'debug',
-      METRICS_ENABLED: false,
-      CACHE_POLLING_SLEEP_MS: 10,
-      CACHE_POLLING_MAX_RETRIES: 0,
     },
   })
 
@@ -572,22 +590,26 @@ test.serial('missing transport in input params with default succeeds', async (t)
     defaultTransport: 'batch',
   })
 
-  const adapter = new Adapter<typeof CustomSettings>({
+  const customConfig = new ProcessedConfig(settings, {
+    envDefaultOverrides: {
+      LOG_LEVEL: 'debug',
+      METRICS_ENABLED: false,
+      CACHE_POLLING_SLEEP_MS: 10,
+      CACHE_POLLING_MAX_RETRIES: 0,
+    },
+  })
+
+  const adapter = new Adapter({
     name: 'TEST',
     defaultEndpoint: 'price',
     endpoints: [endpoint],
+    processedConfig: customConfig,
     rateLimiting: {
       tiers: {
         default: {
           rateLimit1s: 5,
         },
       },
-    },
-    envDefaultOverrides: {
-      LOG_LEVEL: 'debug',
-      METRICS_ENABLED: false,
-      CACHE_POLLING_SLEEP_MS: 10,
-      CACHE_POLLING_MAX_RETRIES: 0,
     },
   })
 

--- a/test/transports/routing.test.ts
+++ b/test/transports/routing.test.ts
@@ -3,7 +3,7 @@ import axios, { AxiosRequestConfig, AxiosResponse } from 'axios'
 import MockAdapter from 'axios-mock-adapter'
 import { Server, WebSocket } from 'mock-socket'
 import { Adapter, AdapterEndpoint, EndpointContext } from '../../src/adapter'
-import { ProcessedConfig, SettingsMap } from '../../src/config'
+import { ProcessedConfig, SettingsDefinitionMap } from '../../src/config'
 import {
   HttpTransport,
   SSEConfig,
@@ -46,7 +46,7 @@ const settings = {
     required: false,
     sensitive: false,
   },
-} satisfies SettingsMap
+} satisfies SettingsDefinitionMap
 
 const processedConfig = new ProcessedConfig(settings)
 
@@ -64,7 +64,7 @@ type BaseEndpointTypes = {
     }
     Result: number
   }
-  Config: typeof processedConfig.config
+  Settings: typeof processedConfig.settings
 }
 
 type WebSocketTypes = BaseEndpointTypes & {

--- a/test/transports/sse.test.ts
+++ b/test/transports/sse.test.ts
@@ -3,7 +3,7 @@ import untypedTest, { TestFn } from 'ava'
 import axios, { AxiosRequestConfig } from 'axios'
 import MockAdapter from 'axios-mock-adapter'
 import { Adapter, AdapterEndpoint } from '../../src/adapter'
-import { BaseAdapterSettings, ProcessedConfig } from '../../src/config'
+import { BaseAdapterSettings, AdapterConfig } from '../../src/config'
 import { SSEConfig, SseTransport } from '../../src/transports'
 import { ProviderResult, SingleNumberResultResponse } from '../../src/util'
 import { InputParameters } from '../../src/validation'
@@ -102,7 +102,7 @@ const BACKGROUND_EXECUTE_MS_SSE = 5000
 // Disable retries to make the testing flow easier
 process.env['CACHE_POLLING_MAX_RETRIES'] = '0'
 
-const processedConfig = new ProcessedConfig(
+const config = new AdapterConfig(
   {},
   {
     envDefaultOverrides: {
@@ -115,7 +115,7 @@ const processedConfig = new ProcessedConfig(
 const adapter = new Adapter({
   name: 'TEST',
   defaultEndpoint: 'test',
-  processedConfig,
+  config,
   endpoints: [sseEndpoint],
 })
 

--- a/test/transports/sse.test.ts
+++ b/test/transports/sse.test.ts
@@ -1,13 +1,13 @@
 import FakeTimers, { InstalledClock } from '@sinonjs/fake-timers'
 import untypedTest, { TestFn } from 'ava'
 import axios, { AxiosRequestConfig } from 'axios'
+import MockAdapter from 'axios-mock-adapter'
 import { Adapter, AdapterEndpoint } from '../../src/adapter'
-import { SettingsMap } from '../../src/config'
+import { BaseAdapterConfig, ProcessedConfig } from '../../src/config'
 import { SSEConfig, SseTransport } from '../../src/transports'
 import { ProviderResult, SingleNumberResultResponse } from '../../src/util'
 import { InputParameters } from '../../src/validation'
 import { TestAdapter } from '../util'
-import MockAdapter from 'axios-mock-adapter'
 const { MockEvent, EventSource } = require('mocksse') // eslint-disable-line
 
 const URL = 'http://test.com'
@@ -39,7 +39,7 @@ type StreamEndpointTypes = {
     Params: AdapterRequestParams
   }
   Response: SingleNumberResultResponse
-  CustomSettings: SettingsMap
+  Config: BaseAdapterConfig
   Provider: {
     RequestBody: never
   }
@@ -102,14 +102,21 @@ const BACKGROUND_EXECUTE_MS_SSE = 5000
 // Disable retries to make the testing flow easier
 process.env['CACHE_POLLING_MAX_RETRIES'] = '0'
 
+const processedConfig = new ProcessedConfig(
+  {},
+  {
+    envDefaultOverrides: {
+      CACHE_MAX_AGE,
+      BACKGROUND_EXECUTE_MS_SSE,
+    },
+  },
+)
+
 const adapter = new Adapter({
   name: 'TEST',
   defaultEndpoint: 'test',
+  processedConfig,
   endpoints: [sseEndpoint],
-  envDefaultOverrides: {
-    CACHE_MAX_AGE,
-    BACKGROUND_EXECUTE_MS_SSE,
-  },
 })
 
 const mockSSE = () => {

--- a/test/transports/sse.test.ts
+++ b/test/transports/sse.test.ts
@@ -3,7 +3,7 @@ import untypedTest, { TestFn } from 'ava'
 import axios, { AxiosRequestConfig } from 'axios'
 import MockAdapter from 'axios-mock-adapter'
 import { Adapter, AdapterEndpoint } from '../../src/adapter'
-import { BaseAdapterConfig, ProcessedConfig } from '../../src/config'
+import { BaseAdapterSettings, ProcessedConfig } from '../../src/config'
 import { SSEConfig, SseTransport } from '../../src/transports'
 import { ProviderResult, SingleNumberResultResponse } from '../../src/util'
 import { InputParameters } from '../../src/validation'
@@ -39,7 +39,7 @@ type StreamEndpointTypes = {
     Params: AdapterRequestParams
   }
   Response: SingleNumberResultResponse
-  Config: BaseAdapterConfig
+  Settings: BaseAdapterSettings
   Provider: {
     RequestBody: never
   }

--- a/test/transports/websocket.test.ts
+++ b/test/transports/websocket.test.ts
@@ -2,7 +2,7 @@ import FakeTimers, { InstalledClock } from '@sinonjs/fake-timers'
 import untypedTest, { TestFn } from 'ava'
 import { Server, WebSocket } from 'mock-socket'
 import { Adapter, AdapterEndpoint } from '../../src/adapter'
-import { BaseAdapterSettings, ProcessedConfig } from '../../src/config'
+import { BaseAdapterSettings, AdapterConfig } from '../../src/config'
 import {
   WebSocketClassProvider,
   WebsocketReverseMappingTransport,
@@ -118,7 +118,7 @@ const createAdapter = (envDefaultOverrides: Record<string, string | number | sym
     inputParameters,
   })
 
-  const processedConfig = new ProcessedConfig(
+  const config = new AdapterConfig(
     {},
     {
       envDefaultOverrides: {
@@ -132,7 +132,7 @@ const createAdapter = (envDefaultOverrides: Record<string, string | number | sym
     name: 'TEST',
     defaultEndpoint: 'test',
     endpoints: [webSocketEndpoint],
-    processedConfig,
+    config,
   })
 
   return adapter
@@ -187,8 +187,8 @@ test.serial('connects to websocket, subscribes, gets message, unsubscribes', asy
 
   // Wait until the cache expires, and the subscription is out
   const duration =
-    Math.ceil(CACHE_MAX_AGE / adapter.processedConfig.settings.WS_SUBSCRIPTION_TTL) *
-      adapter.processedConfig.settings.WS_SUBSCRIPTION_TTL +
+    Math.ceil(CACHE_MAX_AGE / adapter.config.settings.WS_SUBSCRIPTION_TTL) *
+      adapter.config.settings.WS_SUBSCRIPTION_TTL +
     1
   await runAllUntilTime(t.context.clock, duration)
 
@@ -265,7 +265,7 @@ test.serial('reconnects when url changed', async (t) => {
     inputParameters,
   })
 
-  const processedConfig = new ProcessedConfig(
+  const config = new AdapterConfig(
     {},
     {
       envDefaultOverrides: {
@@ -277,7 +277,7 @@ test.serial('reconnects when url changed', async (t) => {
   const adapter = new Adapter({
     name: 'TEST',
     defaultEndpoint: 'test',
-    processedConfig,
+    config,
     endpoints: [webSocketEndpoint],
   })
 
@@ -412,7 +412,7 @@ test.serial(
       inputParameters,
     })
 
-    const processedConfig = new ProcessedConfig(
+    const config = new AdapterConfig(
       {},
       {
         envDefaultOverrides: {
@@ -425,7 +425,7 @@ test.serial(
     const adapter = new Adapter({
       name: 'TEST',
       defaultEndpoint: 'test',
-      processedConfig,
+      config,
       endpoints: [webSocketEndpoint],
     })
 
@@ -444,8 +444,8 @@ test.serial(
 
     // Wait until the cache expires, and the subscription is out
     const duration =
-      Math.ceil(CACHE_MAX_AGE / adapter.processedConfig.settings.WS_SUBSCRIPTION_TTL) *
-        adapter.processedConfig.settings.WS_SUBSCRIPTION_TTL +
+      Math.ceil(CACHE_MAX_AGE / adapter.config.settings.WS_SUBSCRIPTION_TTL) *
+        adapter.config.settings.WS_SUBSCRIPTION_TTL +
       1
     await runAllUntilTime(t.context.clock, duration)
 
@@ -510,7 +510,7 @@ const createReverseMappingAdapter = (
     inputParameters,
   })
 
-  const processedConfig = new ProcessedConfig(
+  const config = new AdapterConfig(
     {},
     {
       envDefaultOverrides: {
@@ -523,7 +523,7 @@ const createReverseMappingAdapter = (
   const adapter = new Adapter({
     name: 'TEST',
     defaultEndpoint: 'test',
-    processedConfig,
+    config,
     endpoints: [webSocketEndpoint],
   })
 

--- a/test/transports/websocket.test.ts
+++ b/test/transports/websocket.test.ts
@@ -2,7 +2,7 @@ import FakeTimers, { InstalledClock } from '@sinonjs/fake-timers'
 import untypedTest, { TestFn } from 'ava'
 import { Server, WebSocket } from 'mock-socket'
 import { Adapter, AdapterEndpoint } from '../../src/adapter'
-import { BaseAdapterConfig, ProcessedConfig } from '../../src/config'
+import { BaseAdapterSettings, ProcessedConfig } from '../../src/config'
 import {
   WebSocketClassProvider,
   WebsocketReverseMappingTransport,
@@ -73,7 +73,7 @@ type WebSocketTypes = {
     Params: AdapterRequestParams
   }
   Response: SingleNumberResultResponse
-  Config: BaseAdapterConfig
+  Settings: BaseAdapterSettings
   Provider: {
     WsMessage: ProviderMessage
   }
@@ -187,8 +187,8 @@ test.serial('connects to websocket, subscribes, gets message, unsubscribes', asy
 
   // Wait until the cache expires, and the subscription is out
   const duration =
-    Math.ceil(CACHE_MAX_AGE / adapter.processedConfig.config.WS_SUBSCRIPTION_TTL) *
-      adapter.processedConfig.config.WS_SUBSCRIPTION_TTL +
+    Math.ceil(CACHE_MAX_AGE / adapter.processedConfig.settings.WS_SUBSCRIPTION_TTL) *
+      adapter.processedConfig.settings.WS_SUBSCRIPTION_TTL +
     1
   await runAllUntilTime(t.context.clock, duration)
 
@@ -444,8 +444,8 @@ test.serial(
 
     // Wait until the cache expires, and the subscription is out
     const duration =
-      Math.ceil(CACHE_MAX_AGE / adapter.processedConfig.config.WS_SUBSCRIPTION_TTL) *
-        adapter.processedConfig.config.WS_SUBSCRIPTION_TTL +
+      Math.ceil(CACHE_MAX_AGE / adapter.processedConfig.settings.WS_SUBSCRIPTION_TTL) *
+        adapter.processedConfig.settings.WS_SUBSCRIPTION_TTL +
       1
     await runAllUntilTime(t.context.clock, duration)
 

--- a/test/util.ts
+++ b/test/util.ts
@@ -6,7 +6,7 @@ import { start } from '../src'
 import { Adapter, AdapterDependencies } from '../src/adapter'
 import { Cache, LocalCache } from '../src/cache'
 import { ResponseCache } from '../src/cache/response'
-import { BaseAdapterSettings, ProcessedConfig } from '../src/config'
+import { BaseAdapterSettings, AdapterConfig } from '../src/config'
 import { Transport, TransportDependencies } from '../src/transports'
 import { AdapterRequest, AdapterResponse, PartialAdapterResponse } from '../src/util'
 
@@ -256,7 +256,7 @@ class TestMetrics {
   }
 }
 
-export class TestAdapter<T extends ProcessedConfig = ProcessedConfig> {
+export class TestAdapter<T extends AdapterConfig = AdapterConfig> {
   mockCache?: MockCache
 
   // eslint-disable-next-line max-params
@@ -272,7 +272,7 @@ export class TestAdapter<T extends ProcessedConfig = ProcessedConfig> {
     }
   }
 
-  static async startWithMockedCache<T extends ProcessedConfig>(
+  static async startWithMockedCache<T extends AdapterConfig>(
     adapter: Adapter<T>,
     context: ExecutionContext<{
       clock?: InstalledClock
@@ -282,7 +282,7 @@ export class TestAdapter<T extends ProcessedConfig = ProcessedConfig> {
   ) {
     // Create mocked cache so we can listen when values are set
     // This is a more reliable method than expecting precise clock timings
-    const mockCache = new MockCache(adapter.processedConfig.settings.CACHE_MAX_ITEMS)
+    const mockCache = new MockCache(adapter.config.settings.CACHE_MAX_ITEMS)
 
     return TestAdapter.start(adapter, context, {
       cache: mockCache,
@@ -294,7 +294,7 @@ export class TestAdapter<T extends ProcessedConfig = ProcessedConfig> {
     >
   }
 
-  static async start<T extends ProcessedConfig>(
+  static async start<T extends AdapterConfig>(
     adapter: Adapter<T>,
     context: ExecutionContext<{
       clock?: InstalledClock

--- a/test/util.ts
+++ b/test/util.ts
@@ -6,7 +6,7 @@ import { start } from '../src'
 import { Adapter, AdapterDependencies } from '../src/adapter'
 import { Cache, LocalCache } from '../src/cache'
 import { ResponseCache } from '../src/cache/response'
-import { BaseAdapterConfig, ProcessedConfig } from '../src/config'
+import { BaseAdapterSettings, ProcessedConfig } from '../src/config'
 import { Transport, TransportDependencies } from '../src/transports'
 import { AdapterRequest, AdapterResponse, PartialAdapterResponse } from '../src/util'
 
@@ -18,7 +18,7 @@ export type NopTransportTypes = {
     Data: null
     Result: null
   }
-  Config: BaseAdapterConfig
+  Settings: BaseAdapterSettings
 }
 
 export class NopTransport implements Transport<NopTransportTypes> {
@@ -30,7 +30,7 @@ export class NopTransport implements Transport<NopTransportTypes> {
 
   async initialize(
     dependencies: TransportDependencies<NopTransportTypes>,
-    config: NopTransportTypes['Config'],
+    adapterSettings: NopTransportTypes['Settings'],
     endpointName: string,
     transportName: string,
   ): Promise<void> {
@@ -282,7 +282,7 @@ export class TestAdapter<T extends ProcessedConfig = ProcessedConfig> {
   ) {
     // Create mocked cache so we can listen when values are set
     // This is a more reliable method than expecting precise clock timings
-    const mockCache = new MockCache(adapter.processedConfig.config.CACHE_MAX_ITEMS)
+    const mockCache = new MockCache(adapter.processedConfig.settings.CACHE_MAX_ITEMS)
 
     return TestAdapter.start(adapter, context, {
       cache: mockCache,

--- a/test/validation.test.ts
+++ b/test/validation.test.ts
@@ -1,6 +1,6 @@
 import untypedTest, { TestFn } from 'ava'
 import { Adapter, AdapterEndpoint, EndpointGenerics } from '../src/adapter'
-import { AdapterConfig } from '../src/config'
+import { BaseAdapterConfig } from '../src/config'
 import { AdapterResponse } from '../src/util'
 import { AdapterInputError } from '../src/validation/error'
 import { InputValidator } from '../src/validation/input-validator'
@@ -520,7 +520,7 @@ test.serial('custom input validation', async (t) => {
       required: true,
     },
   }
-  const customInputValidation = (input: any, _: AdapterConfig) => {
+  const customInputValidation = (input: any, _: BaseAdapterConfig) => {
     if (input.requestContext.data.base === input.requestContext.data.quote) {
       return new AdapterInputError({ statusCode: 400 })
     }

--- a/test/validation.test.ts
+++ b/test/validation.test.ts
@@ -1,6 +1,6 @@
 import untypedTest, { TestFn } from 'ava'
 import { Adapter, AdapterEndpoint, EndpointGenerics } from '../src/adapter'
-import { BaseAdapterConfig } from '../src/config'
+import { BaseAdapterSettings } from '../src/config'
 import { AdapterResponse } from '../src/util'
 import { AdapterInputError } from '../src/validation/error'
 import { InputValidator } from '../src/validation/input-validator'
@@ -520,7 +520,7 @@ test.serial('custom input validation', async (t) => {
       required: true,
     },
   }
-  const customInputValidation = (input: any, _: BaseAdapterConfig) => {
+  const customInputValidation = (input: any, _: BaseAdapterSettings) => {
     if (input.requestContext.data.base === input.requestContext.data.quote) {
       return new AdapterInputError({ statusCode: 400 })
     }


### PR DESCRIPTION
The current implementation of custom settings caused a lot of issues with generics. The problem was mainly around the fact that the type for the resolved settings (that is, the key:value pair once processed) was also itself a generic parameter, and it really messed up with polymorphism. Things like 
```typescript
const adapter = new Adapter({
	name: 'TEST',
	endpoints: [customEndpoint] // Endpoint is of type CustomEndpoint, with typeof customSettings
	customSettings: customSettings
})
```
Would fail in the assignment of the endpoint to the array of endpoints for the adapter parameters, due to a clash in settings. Another thing was a bit annoying, in that in order to define the settings in a way that added type safety one needed to make use of the `satisfies` keyword. There is nothing necessarily wrong with that, but it's a newer feature and developers might not be very familiar with it. 

This PR refactors the way the adapter config is defined, providing a class based approach that allows for cleaner generics and a type safe way to define them without asking a lot of the developer.