### PR TITLE
Refactor transport routes

### DIFF
--- a/src/adapter/basic.ts
+++ b/src/adapter/basic.ts
@@ -339,7 +339,7 @@ export class Adapter<T extends AdapterConfig = AdapterConfig>
   ): Promise<Readonly<AdapterResponse>> {
     // Get transport, must be here because it's already checked in the validator
     const endpoint = this.endpointsMap[req.requestContext.endpointName]
-    const transport = endpoint.transports[req.requestContext.transportName]
+    const transport = endpoint.transportRoutes.get(req.requestContext.transportName)
 
     // First try to find the response in our cache, keep it ready
     const cachedResponse = await this.findResponseInCache(req)

--- a/src/adapter/types.ts
+++ b/src/adapter/types.ts
@@ -3,7 +3,7 @@ import Redis from 'ioredis'
 import { Cache } from '../cache'
 import { BaseAdapterSettings, AdapterConfig, SettingsDefinitionMap } from '../config'
 import { AdapterRateLimitTier, RateLimiter } from '../rate-limiting'
-import { Transport, TransportGenerics } from '../transports'
+import { Transport, TransportGenerics, TransportRoutes } from '../transports'
 import { AdapterRequest, SingleNumberResultResponse, SubscriptionSetFactory } from '../util'
 import { Requester } from '../util/requester'
 import { InputParameters, SpecificInputParameters } from '../validation'
@@ -173,7 +173,7 @@ type SingleTransportAdapterEndpointParams<T extends EndpointGenerics> = {
 
 type MultiTransportAdapterEndpointParams<T extends EndpointGenerics> = {
   /** Map of transports that will be used when routing the request through this endpoint */
-  transports: Record<string, Transport<T>>
+  transportRoutes: TransportRoutes<T>
 
   /** Custom function to direct an incoming request to the appropriate transport from the transports map */
   customRouter?: (req: AdapterRequest<T['Request']>, settings: T['Settings']) => string

--- a/src/background-executor.ts
+++ b/src/background-executor.ts
@@ -98,7 +98,7 @@ export async function callBackgroundExecutes(adapter: Adapter, apiShutdownPromis
   }
 
   for (const endpoint of adapter.endpoints) {
-    for (const [transportName, transport] of Object.entries(endpoint.transports)) {
+    for (const [transportName, transport] of endpoint.transportRoutes.entries()) {
       callBackgroundExecute(endpoint, transport, transportName)
     }
   }

--- a/src/transports/index.ts
+++ b/src/transports/index.ts
@@ -1,4 +1,4 @@
-import { AdapterDependencies, EndpointContext } from '../adapter'
+import { AdapterDependencies, DEFAULT_TRANSPORT_NAME, EndpointContext } from '../adapter'
 import { ResponseCache } from '../cache/response'
 import { BaseAdapterSettings } from '../config'
 import { AdapterRequest, AdapterResponse, RequestGenerics, ResponseGenerics } from '../util/types'
@@ -117,4 +117,34 @@ export interface Transport<T extends TransportGenerics> {
    * @returns an empty Promise
    */
   backgroundExecute?: (context: EndpointContext<T>) => Promise<void>
+}
+
+export class TransportRoutes<T extends TransportGenerics> {
+  private map: Record<string, Transport<T>> = {}
+
+  register<T2 extends T>(name: string, transport: Transport<T2>) {
+    // This is intentional, to keep names to one word only
+    if (name !== DEFAULT_TRANSPORT_NAME && !/^[a-z]+$/.test(name)) {
+      throw new Error(
+        `Transport name "${name}" is invalid. Names in the AdapterEndpoint transports map can only include lowercase letters.`,
+      )
+    }
+    if (this.map[name]) {
+      throw new Error(`Transport with name "${name}" is already registered in this map`)
+    }
+    this.map[name] = transport as unknown as Transport<T>
+    return this
+  }
+
+  get(name: string) {
+    return this.map[name]
+  }
+
+  routeNames() {
+    return Object.keys(this.map)
+  }
+
+  entries() {
+    return Object.entries(this.map)
+  }
 }


### PR DESCRIPTION
There is a problem with the way the transport routes were declared and passed as parameters in the current version of the framework. The `AdapterEndpoint` specifies the transport as `Record<string, Transport<T>`, but in cases where we have different transport types, the type of the `Provider` property of the generics would be different, and the compiler would not like this (because it would attempt to give T a concrete type, and there would be different alternatives to use).
This PR delegates this typing resolution to a separate class, that will perform a simpler check by the use of a builder pattern.