### PR TITLE
Fix settings generics in adapter

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "generate-docs": "typedoc src/**/*.ts",
     "lint-fix": "eslint --max-warnings=0 --fix ./src && prettier --write ./src/**/*.ts ./*.{json,js,yaml}",
     "lint": "eslint --max-warnings=0 ./src && prettier --check ./src/**/*.ts ./*.{json,js,yaml}",
-    "portal-path": "readlink -f ./dist/src",
+    "portal-path": "echo \"portal:$(readlink -f ./dist/src)\"",
     "start": "ts-node -e 'import(`./src/examples/${process.argv[1]}/src/index`).then(ea => ea.server())'",
     "test-debug": "EA_HOST=localhost LOG_LEVEL=trace DEBUG=true EA_PORT=0 c8 ava --verbose",
     "test": "EA_HOST=localhost LOG_LEVEL=error EA_PORT=0 c8 ava",

--- a/src/adapter/basic.ts
+++ b/src/adapter/basic.ts
@@ -30,8 +30,8 @@ const logger = makeLogger('Adapter')
 /**
  * Main class to represent an External Adapter
  */
-export class Adapter<CustomSettings extends SettingsDefinitionMap = SettingsDefinitionMap>
-  implements Omit<AdapterParams<CustomSettings>, 'bootstrap'>
+export class Adapter<CustomSettingsDefinition extends SettingsDefinitionMap = SettingsDefinitionMap>
+  implements Omit<AdapterParams<CustomSettingsDefinition>, 'bootstrap'>
 {
   // Adapter params
   name: Uppercase<string>
@@ -51,19 +51,20 @@ export class Adapter<CustomSettings extends SettingsDefinitionMap = SettingsDefi
   dependencies!: AdapterDependencies
 
   /** Configuration params for various adapter properties */
-  config: AdapterConfig<CustomSettings>
+  config: AdapterConfig<CustomSettingsDefinition>
 
   /** Bootstrap function that will run when initializing the adapter */
-  private readonly bootstrap?: (adapter: Adapter<CustomSettings>) => Promise<void>
+  private readonly bootstrap?: (adapter: Adapter<CustomSettingsDefinition>) => Promise<void>
 
-  constructor(params: AdapterParams<CustomSettings>) {
+  constructor(params: AdapterParams<CustomSettingsDefinition>) {
     // Copy over params
     this.name = params.name
     this.defaultEndpoint = params.defaultEndpoint?.toLowerCase()
     this.endpoints = params.endpoints
     this.rateLimiting = params.rateLimiting
     this.bootstrap = params.bootstrap
-    this.config = params.config || (new AdapterConfig({}) as AdapterConfig<CustomSettings>)
+    this.config =
+      params.config || (new AdapterConfig({}) as AdapterConfig<CustomSettingsDefinition>)
 
     this.config.initialize()
     this.normalizeEndpointNames()

--- a/src/adapter/price.ts
+++ b/src/adapter/price.ts
@@ -1,4 +1,4 @@
-import { AdapterConfig } from '../config'
+import { SettingsDefinitionMap } from '../config'
 import { AdapterRequest, AdapterRequestContext, AdapterResponse, RequestGenerics } from '../util'
 import { AdapterEndpoint } from './endpoint'
 import { Adapter, AdapterEndpointParams, AdapterParams, PriceEndpointGenerics } from './index'
@@ -102,11 +102,13 @@ type PriceAdapterRequest<T extends RequestGenerics> = AdapterRequest<T> & {
 /**
  * A PriceAdapter is a specific kind of Adapter that includes at least one PriceEnpoint.
  */
-export class PriceAdapter<T extends AdapterConfig> extends Adapter<T> {
+export class PriceAdapter<
+  CustomSettingsDefinition extends SettingsDefinitionMap,
+> extends Adapter<CustomSettingsDefinition> {
   includesMap?: IncludesMap
 
   constructor(
-    params: AdapterParams<T> & {
+    params: AdapterParams<CustomSettingsDefinition> & {
       includes?: IncludesFile
     },
   ) {

--- a/src/adapter/types.ts
+++ b/src/adapter/types.ts
@@ -1,7 +1,7 @@
 import type EventSource from 'eventsource'
 import Redis from 'ioredis'
 import { Cache } from '../cache'
-import { BaseAdapterSettings, AdapterConfig, SettingsDefinitionMap } from '../config'
+import { AdapterConfig, BaseAdapterSettings, SettingsDefinitionMap } from '../config'
 import { AdapterRateLimitTier, RateLimiter } from '../rate-limiting'
 import { Transport, TransportGenerics, TransportRoutes } from '../transports'
 import { AdapterRequest, SingleNumberResultResponse, SubscriptionSetFactory } from '../util'
@@ -81,7 +81,7 @@ export type Overrides = {
 /**
  * Main structure of an External Adapter
  */
-export interface AdapterParams<T extends AdapterConfig = AdapterConfig> {
+export interface AdapterParams<CustomSettingsDefinition extends SettingsDefinitionMap> {
   /** Name of the adapter */
   name: Uppercase<string>
 
@@ -103,10 +103,10 @@ export interface AdapterParams<T extends AdapterConfig = AdapterConfig> {
   rateLimiting?: AdapterRateLimitingConfig
 
   /** Bootstrap function that will run when initializing the adapter */
-  bootstrap?: (adapter: Adapter<T>) => Promise<void>
+  bootstrap?: (adapter: Adapter<CustomSettingsDefinition>) => Promise<void>
 
   /** The custom [[AdapterConfig]] to use. If not provided, the default configuration will be used instead */
-  config?: T
+  config?: AdapterConfig<CustomSettingsDefinition>
 }
 
 /**

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -433,7 +433,7 @@ type SettingType<C extends SettingDefinition> = C['type'] extends 'string'
     ? C['options'][number]
     : never
   : never
-type BaseSettingsDefinitionType = typeof BaseSettingsDefinition
+export type BaseSettingsDefinitionType = typeof BaseSettingsDefinition
 export type SettingDefinition =
   | {
       type: 'string'
@@ -521,13 +521,17 @@ export type Settings<T extends SettingsDefinitionMap> = {
 }
 
 export type BaseAdapterSettings = Settings<BaseSettingsDefinitionType>
-export type AdapterSettings<T extends CustomSettingsDefinition<T> = SettingsDefinitionMap> =
-  Settings<T> & BaseAdapterSettings & SettingsObjectSpecifier
+export type AdapterSettings<T extends CustomSettingsDefinition<T> = object> = Settings<T> &
+  BaseAdapterSettings &
+  SettingsObjectSpecifier
 
 export type CustomSettingsDefinition<T = SettingsDefinitionMap> = Record<keyof T, SettingDefinition>
 export type EmptySettingsDefinitionMap = Record<string, never>
 export type SettingsDefinitionMap = Record<string, SettingDefinition>
 export type ValidationErrorMessage = string | undefined
+export type SettingsDefinitionFromConfig<T> = T extends AdapterConfig<infer Definition>
+  ? Definition
+  : never
 
 /**
  * This class will hold the processed config type, and the basic settings.
@@ -604,7 +608,7 @@ export class AdapterConfig<T extends SettingsDefinitionMap = SettingsDefinitionM
         // Escaping potential special characters in values before creating regex
         value: new RegExp(
           // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-          ((this.settings as AdapterSettings)[name]! as string).replace(
+          ((this.settings as Record<string, ValidSettingValue>)[name]! as string).replace(
             /[-[\]{}()*+?.,\\^$|#\s]/g,
             '\\$&',
           ),

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ import { AddressInfo } from 'net'
 import { join } from 'path'
 import { Adapter, AdapterDependencies } from './adapter'
 import { callBackgroundExecutes } from './background-executor'
-import { AdapterSettings, AdapterConfig } from './config'
+import { AdapterSettings, SettingsDefinitionMap } from './config'
 import { buildMetricsMiddleware, setupMetricsServer } from './metrics'
 import { AdapterRouteGeneric, loggingContextMiddleware, makeLogger } from './util'
 import { errorCatchingMiddleware, validatorMiddleware } from './validation'
@@ -54,7 +54,7 @@ export const getMTLSOptions = (adapterSettings: AdapterSettings) => {
  * @param dependencies - an optional object with adapter dependencies to inject
  * @returns a Promise that resolves to the http.Server listening for connections
  */
-export const start = async <T extends AdapterConfig = AdapterConfig>(
+export const start = async <T extends SettingsDefinitionMap>(
   adapter: Adapter<T>,
   dependencies?: Partial<AdapterDependencies>,
 ): Promise<{
@@ -114,7 +114,7 @@ export const start = async <T extends AdapterConfig = AdapterConfig>(
   return { api, metricsApi }
 }
 
-export const expose = async <T extends AdapterConfig = AdapterConfig>(
+export const expose = async <T extends SettingsDefinitionMap>(
   adapter: Adapter<T>,
   dependencies?: Partial<AdapterDependencies>,
 ): Promise<FastifyInstance | undefined> => {

--- a/test/transports/routing.test.ts
+++ b/test/transports/routing.test.ts
@@ -3,7 +3,11 @@ import axios, { AxiosRequestConfig, AxiosResponse } from 'axios'
 import MockAdapter from 'axios-mock-adapter'
 import { Server, WebSocket } from 'mock-socket'
 import { Adapter, AdapterEndpoint, EndpointContext } from '../../src/adapter'
-import { AdapterConfig, SettingsDefinitionMap } from '../../src/config'
+import {
+  AdapterConfig,
+  SettingsDefinitionFromConfig,
+  SettingsDefinitionMap,
+} from '../../src/config'
 import {
   HttpTransport,
   SSEConfig,
@@ -16,7 +20,7 @@ import { InputParameters } from '../../src/validation'
 import { TestAdapter } from '../util'
 
 const test = untypedTest as TestFn<{
-  testAdapter: TestAdapter<typeof adapterConfig>
+  testAdapter: TestAdapter<SettingsDefinitionFromConfig<typeof adapterConfig>>
 }>
 
 interface ProviderRequestBody {

--- a/test/util.ts
+++ b/test/util.ts
@@ -6,7 +6,7 @@ import { start } from '../src'
 import { Adapter, AdapterDependencies } from '../src/adapter'
 import { Cache, LocalCache } from '../src/cache'
 import { ResponseCache } from '../src/cache/response'
-import { BaseAdapterSettings, AdapterConfig } from '../src/config'
+import { BaseAdapterSettings, SettingsDefinitionMap } from '../src/config'
 import { Transport, TransportDependencies } from '../src/transports'
 import { AdapterRequest, AdapterResponse, PartialAdapterResponse } from '../src/util'
 
@@ -256,7 +256,7 @@ class TestMetrics {
   }
 }
 
-export class TestAdapter<T extends AdapterConfig = AdapterConfig> {
+export class TestAdapter<T extends SettingsDefinitionMap = SettingsDefinitionMap> {
   mockCache?: MockCache
 
   // eslint-disable-next-line max-params
@@ -272,11 +272,11 @@ export class TestAdapter<T extends AdapterConfig = AdapterConfig> {
     }
   }
 
-  static async startWithMockedCache<T extends AdapterConfig>(
+  static async startWithMockedCache<T extends SettingsDefinitionMap = SettingsDefinitionMap>(
     adapter: Adapter<T>,
     context: ExecutionContext<{
       clock?: InstalledClock
-      testAdapter: TestAdapter<T>
+      testAdapter: TestAdapter<any>
     }>['context'],
     dependencies?: Partial<AdapterDependencies>,
   ) {
@@ -294,7 +294,7 @@ export class TestAdapter<T extends AdapterConfig = AdapterConfig> {
     >
   }
 
-  static async start<T extends AdapterConfig>(
+  static async start<T extends SettingsDefinitionMap = SettingsDefinitionMap>(
     adapter: Adapter<T>,
     context: ExecutionContext<{
       clock?: InstalledClock


### PR DESCRIPTION
The refactor of the adapter generics worked pretty well, but there was one problem: the `Adapter` class itself used the config as a type, instead of taking advantage of the new classes to rely on simpler types. This PR changes the adapter basic generics to use the settings definitions instead.