### PR TITLE
Add background execute and websocket open timeouts

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -218,6 +218,13 @@ export const BaseSettingsDefinition = {
     default: 120000,
     validate: validator.integer({ min: 1000, max: 180000 }),
   },
+  WS_CONNECTION_OPEN_TIMEOUT: {
+    description:
+      'The maximum amount of time in milliseconds to wait for the websocket connection to open (including custom open handler)',
+    type: 'number',
+    default: 10_000,
+    validate: validator.integer({ min: 500, max: 30_000 }),
+  },
   // WS_TIME_UNTIL_HANDLE_NEXT_MESSAGE_OVERRIDE: {
   //   description: 'Time to wait until adapter should handle next WS message',
   //   type: 'number',
@@ -311,6 +318,13 @@ export const BaseSettingsDefinition = {
     type: 'number',
     default: 1000,
     validate: validator.integer({ min: 1, max: 10000 }),
+  },
+  BACKGROUND_EXECUTE_TIMEOUT: {
+    description:
+      'The maximum amount of time in milliseconds to wait for a background execute to finish',
+    type: 'number',
+    default: 90_000,
+    validate: validator.integer({ min: 1000, max: 180_000 }),
   },
 } as const satisfies SettingsDefinitionMap
 

--- a/src/metrics/index.ts
+++ b/src/metrics/index.ts
@@ -25,6 +25,7 @@ export function setupMetricsServer(name: string, adapterSettings: AdapterSetting
   setupMetrics(name)
 
   metricsApp.get(endpoint, async (_, res) => {
+    logger.trace('Metrics endpoint hit')
     res.type('txt')
     res.send(await client.register.metrics())
   })
@@ -91,6 +92,11 @@ export class Metrics<T extends Record<string, unknown>> {
       throw new Error(`Metric "${name as string}" was not initialized before use`)
     }
     return metric
+  }
+
+  clear() {
+    client.register.clear()
+    this.metrics = undefined
   }
 }
 
@@ -271,6 +277,11 @@ export const metrics = new Metrics(() => ({
     name: 'ws_connection_errors',
     help: 'The number of connection errors',
     labelNames: ['url', 'message'] as const,
+  }),
+  wsConnectionClosures: new client.Counter({
+    name: 'ws_connection_closures',
+    help: 'The number of connection closures',
+    labelNames: ['url', 'code'] as const,
   }),
   wsSubscriptionActive: new client.Gauge({
     name: 'ws_subscription_active',


### PR DESCRIPTION
This PR attempts to mitigate issues found with v3 EAs, primarily websocket ones (DAR, Galaxy). Those EAs work perfectly for a period of time, then suddenly we can observe the background executions drop to zero. This means one of two things:

- **The background execution loop is crashing.** This seems very unlikely to be the culprit because there's no logs to this end, and one would expect them (things like unhandled promises). I have verified that some output would be present by simply throwing an exception manually from the loop, and it results in both a very clear log message and the process exiting.
- **The background execution loop is stuck.** This is the current best guess. If an issue were happening in the background execution, looking at the current logic that is in the deployed adapters it could be possible for a bad execute to hang forever.

In an effort to both verify that the current hypothesis is true and mitigate it, this PR includes the following:

- Adds logic to time out background executes. It is set to a configurable time of 90s, but this should be more than enough to cover all current execution timings (in the future it can be dialed down).
- Same logic applied to the WebSocket open handler. This one is set to 10s, also configurable.
- Some rearranging of the WS opening logic so that if we have this stuck connection, it won't affect the overall loop and just stay in the background.
- Addition of a WS closure metric, including code, to better track the causes of WS closures from DPs.

A note on the way the timeouts are implemented: it's not straightforward to "cancel" the execution of an async promise. The best course of action seems to be to try and guarantee, as best as possible, that the promise that times out won't have any side effects if it eventually resolves. This of course should raise concerns on the garbage collection of these promises, and the potential overflow they could cause. It is something I am aware of; for now it seems a safe approach due to the easy to spot nature of the memory increase (which from my testing is very very low, I'd need a very long running time to verify if it even happens at all).
 