### PR TITLE
Reorganize WebSocket listeners

### DIFF
--- a/docs/v3-ea-components/tests.md
+++ b/docs/v3-ea-components/tests.md
@@ -167,6 +167,13 @@ export const mockWebSocketProvider = (provider: typeof WebSocketClassProvider): 
     constructor(url: string, protocol: string | string[] | Record<string, string> | undefined) {
       super(url, protocol instanceof Object ? undefined : protocol)
     }
+    removeAllListeners() {
+      for (const eventType in this.listeners) {
+        if (!eventType.startsWith('server')) {
+          delete this.listeners[eventType]
+        }
+      }
+    }
     // Mock WebSocket does not come with built on function which adapter handlers could be using for ws
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     on(_: Event) {

--- a/src/transports/websocket.ts
+++ b/src/transports/websocket.ts
@@ -1,7 +1,7 @@
 import WebSocket, { ClientOptions, RawData } from 'ws'
 import { EndpointContext } from '../adapter'
 import { metrics } from '../metrics'
-import { makeLogger, sleep, timeoutPromise } from '../util'
+import { deferredPromise, makeLogger, sleep, timeoutPromise } from '../util'
 import { PartialSuccessfulResponse, ProviderResult, TimestampedProviderResult } from '../util/types'
 import { TransportGenerics } from './'
 import { StreamingTransport, SubscriptionDeltas } from './abstract/streaming'
@@ -215,29 +215,21 @@ export class WebSocketTransport<
     context: EndpointContext<T>,
     url: string,
     options?: WebSocket.ClientOptions | undefined,
-  ): Promise<void> {
-    const connectionBuilder = () =>
-      new Promise<WebSocket>((resolve, reject) => {
-        const ctor = WebSocketClassProvider.get()
-        const connection = new ctor(url, undefined, options)
-        const handlers = this.buildConnectionHandlers(context, connection, resolve)
-        connection.addEventListener(
-          'open',
-          this.rejectionHandler<WebSocket.Event>(reject, handlers.open),
-        )
-        connection.addEventListener(
-          'message',
-          this.rejectionHandler<WebSocket.MessageEvent>(reject, handlers.message),
-        )
-        connection.addEventListener('error', handlers.error)
-        connection.addEventListener('close', handlers.close)
-      })
+  ): Promise<WebSocket> {
+    const [promise, resolve, reject] = deferredPromise()
+    const ctor = WebSocketClassProvider.get()
+    const connection = new ctor(url, undefined, options)
+    const handlers = this.buildConnectionHandlers(context, connection, resolve)
+    connection.addEventListener(
+      'open',
+      this.rejectionHandler<WebSocket.Event>(reject, handlers.open),
+    )
 
     // Attempt to establish the connection
     try {
-      this.wsConnection = await timeoutPromise(
+      await timeoutPromise(
         'WS Open Handler',
-        connectionBuilder(),
+        promise,
         context.adapterSettings.WS_CONNECTION_OPEN_TIMEOUT,
       )
 
@@ -247,6 +239,17 @@ export class WebSocketTransport<
       logger.error(`There was an error connecting to the provider websocket`)
       throw e
     }
+
+    // Now that the connection is established, we can clean up listeners and set the proper ones
+    connection.removeAllListeners()
+    connection.addEventListener(
+      'message',
+      this.rejectionHandler<WebSocket.MessageEvent>(reject, handlers.message),
+    )
+    connection.addEventListener('error', handlers.error)
+    connection.addEventListener('close', handlers.close)
+
+    return connection
   }
 
   async sendMessages(context: EndpointContext<T>, subscribes: unknown[], unsubscribes: unknown[]) {
@@ -254,6 +257,11 @@ export class WebSocketTransport<
     const serializedUnsubscribes = unsubscribes.map(this.serializeMessage)
 
     const messages = serializedSubscribes.concat(serializedUnsubscribes)
+
+    if (messages.length > 0) {
+      logger.debug(`There are ${messages.length} messages to send`)
+    }
+
     for (const message of messages) {
       this.wsConnection?.send(message)
     }
@@ -328,7 +336,7 @@ export class WebSocketTransport<
       this.providerDataStreamEstablished = Date.now()
 
       // Connect to the provider
-      await this.establishWsConnection(context, urlFromConfig, options)
+      this.wsConnection = await this.establishWsConnection(context, urlFromConfig, options)
 
       // Now that we successfully opened the connection, we can reset the variables
       connectionClosed = false

--- a/src/transports/websocket.ts
+++ b/src/transports/websocket.ts
@@ -48,6 +48,7 @@ export interface WebSocketTransportConfig<T extends WebsocketTransportGenerics> 
     /**
      * Handles when the WS is successfully opened.
      * Optional since logic is not always needed on connection.
+     * Note: any listeners set in this method will be cleared after its execution.
      *
      * @param wsConnection - the WebSocket with an established connection
      * @returns an empty Promise, or void

--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -1,6 +1,6 @@
-export * from './types'
 export * from './logger'
 export * from './subscription-set/subscription-set'
+export * from './types'
 
 /**
  * Sleeps for the provided number of milliseconds
@@ -121,4 +121,22 @@ export const timeoutPromise = <T>(
       )
     }),
   ]).finally(() => clearTimeout(timer))
+}
+
+type DeferredResolve<T> = (value: T) => void
+type DeferredReject = (reason?: unknown) => void
+/**
+ * This function will create a promise, and synchronously return both the promise itself and
+ * the resolve and reject callbacks so that they can be used and passed around individually.
+ *
+ * @returns all the deconstructed elements of a promise, to handle in synchronous-ish logic
+ */
+export const deferredPromise = <T>(): [Promise<T>, DeferredResolve<T>, DeferredReject] => {
+  let resolve!: DeferredResolve<T>
+  let reject!: DeferredReject
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res
+    reject = rej
+  })
+  return [promise, resolve, reject]
 }

--- a/test/background-executor.test.ts
+++ b/test/background-executor.test.ts
@@ -3,8 +3,8 @@ import untypedTest, { TestFn } from 'ava'
 import { start } from '../src'
 import { Adapter, AdapterEndpoint, EndpointContext } from '../src/adapter'
 import { metrics as eaMetrics } from '../src/metrics'
-import { sleep } from '../src/util'
-import { deferredPromise, NopTransport, NopTransportTypes, TestAdapter } from './util'
+import { deferredPromise, sleep } from '../src/util'
+import { NopTransport, NopTransportTypes, TestAdapter } from './util'
 
 const test = untypedTest as TestFn<{
   testAdapter: TestAdapter

--- a/test/transports/routing.test.ts
+++ b/test/transports/routing.test.ts
@@ -1,7 +1,7 @@
 import untypedTest, { TestFn } from 'ava'
 import axios, { AxiosRequestConfig, AxiosResponse } from 'axios'
 import MockAdapter from 'axios-mock-adapter'
-import { Server, WebSocket } from 'mock-socket'
+import { Server } from 'mock-socket'
 import { Adapter, AdapterEndpoint, EndpointContext } from '../../src/adapter'
 import {
   AdapterConfig,
@@ -17,7 +17,7 @@ import {
   WebSocketTransport,
 } from '../../src/transports'
 import { InputParameters } from '../../src/validation'
-import { TestAdapter } from '../util'
+import { mockWebSocketProvider, TestAdapter } from '../util'
 
 const test = untypedTest as TestFn<{
   testAdapter: TestAdapter<SettingsDefinitionFromConfig<typeof adapterConfig>>
@@ -134,18 +134,6 @@ class MockWebSocketTransport extends WebSocketTransport<WebSocketTypes> {
     this.backgroundExecuteCalls++
     return super.backgroundExecute(context)
   }
-}
-
-const mockWebSocketProvider = (provider: typeof WebSocketClassProvider): void => {
-  // Extend mock WebSocket class to bypass protocol headers error
-  class MockWebSocket extends WebSocket {
-    constructor(url: string, protocol: string | string[] | Record<string, string> | undefined) {
-      super(url, protocol instanceof Object ? undefined : protocol)
-    }
-  }
-
-  // Need to disable typing, the mock-socket impl does not implement the ws interface fully
-  provider.set(MockWebSocket as any) // eslint-disable-line @typescript-eslint/no-explicit-any
 }
 
 mockWebSocketProvider(WebSocketClassProvider)

--- a/test/transports/websocket.test.ts
+++ b/test/transports/websocket.test.ts
@@ -1,6 +1,6 @@
 import FakeTimers, { InstalledClock } from '@sinonjs/fake-timers'
 import untypedTest, { TestFn } from 'ava'
-import { Server, WebSocket } from 'mock-socket'
+import { Server } from 'mock-socket'
 import { Adapter, AdapterEndpoint } from '../../src/adapter'
 import { AdapterConfig, BaseAdapterSettings } from '../../src/config'
 import { metrics as eaMetrics } from '../../src/metrics'
@@ -11,7 +11,7 @@ import {
 } from '../../src/transports'
 import { SingleNumberResultResponse } from '../../src/util'
 import { InputParameters } from '../../src/validation'
-import { runAllUntil, runAllUntilTime, TestAdapter } from '../util'
+import { mockWebSocketProvider, runAllUntil, runAllUntilTime, TestAdapter } from '../util'
 
 interface AdapterRequestParams {
   base: string
@@ -40,27 +40,6 @@ interface ProviderMessage {
 }
 
 const URL = 'wss://test-ws.com/asd'
-
-/**
- * Sets the mocked websocket instance in the provided provider class.
- * We need this here, because the tests will connect using their instance of WebSocketClassProvider;
- * fetching from this library to the \@chainlink/ea-bootstrap package would access _another_ instance
- * of the same constructor. Although it should be a singleton, dependencies are different so that
- * means that the static classes themselves are also different.
- *
- * @param provider - singleton WebSocketClassProvider
- */
-export const mockWebSocketProvider = (provider: typeof WebSocketClassProvider): void => {
-  // Extend mock WebSocket class to bypass protocol headers error
-  class MockWebSocket extends WebSocket {
-    constructor(url: string, protocol: string | string[] | Record<string, string> | undefined) {
-      super(url, protocol instanceof Object ? undefined : protocol)
-    }
-  }
-
-  // Need to disable typing, the mock-socket impl does not implement the ws interface fully
-  provider.set(MockWebSocket as any) // eslint-disable-line @typescript-eslint/no-explicit-any
-}
 
 const CACHE_MAX_AGE = 1000
 

--- a/test/util.ts
+++ b/test/util.ts
@@ -2,12 +2,13 @@ import { InstalledClock } from '@sinonjs/fake-timers'
 import { ExecutionContext } from 'ava'
 import { FastifyInstance } from 'fastify'
 import { ReplyError } from 'ioredis'
+import { WebSocket } from 'mock-socket'
 import { start } from '../src'
 import { Adapter, AdapterDependencies } from '../src/adapter'
 import { Cache, LocalCache } from '../src/cache'
 import { ResponseCache } from '../src/cache/response'
 import { BaseAdapterSettings, SettingsDefinitionMap } from '../src/config'
-import { Transport, TransportDependencies } from '../src/transports'
+import { Transport, TransportDependencies, WebSocketClassProvider } from '../src/transports'
 import { AdapterRequest, AdapterResponse, PartialAdapterResponse } from '../src/util'
 
 export type NopTransportTypes = {
@@ -44,15 +45,6 @@ export class NopTransport implements Transport<NopTransportTypes> {
   ): Promise<void | AdapterResponse<NopTransportTypes['Response']>> {
     return
   }
-}
-
-type Resolve<T> = (value: T) => void
-export const deferredPromise = <T>(): [Promise<T>, Resolve<T>] => {
-  let resolve!: Resolve<T>
-  const promise = new Promise<T>((r) => {
-    resolve = r
-  })
-  return [promise, resolve]
 }
 
 export class MockCache extends LocalCache {
@@ -417,4 +409,34 @@ export async function waitUntilResolved<T>(
   }
 
   return result
+}
+
+/**
+ * Sets the mocked websocket instance in the provided provider class.
+ * We need this here, because the tests will connect using their instance of WebSocketClassProvider;
+ * fetching from this library to the \@chainlink/ea-bootstrap package would access _another_ instance
+ * of the same constructor. Although it should be a singleton, dependencies are different so that
+ * means that the static classes themselves are also different.
+ *
+ * @param provider - singleton WebSocketClassProvider
+ */
+export const mockWebSocketProvider = (provider: typeof WebSocketClassProvider): void => {
+  // Extend mock WebSocket class to bypass protocol headers error
+  class MockWebSocket extends WebSocket {
+    constructor(url: string, protocol: string | string[] | Record<string, string> | undefined) {
+      super(url, protocol instanceof Object ? undefined : protocol)
+    }
+    // This is part of the 'ws' node library but not the common interface, but it's used in our WS transport
+    removeAllListeners() {
+      for (const eventType in this.listeners) {
+        // We have to manually check because the mock-socket library shares this instance, and adds the server listeners to the same obj
+        if (!eventType.startsWith('server')) {
+          delete this.listeners[eventType]
+        }
+      }
+    }
+  }
+
+  // Need to disable typing, the mock-socket impl does not implement the ws interface fully
+  provider.set(MockWebSocket as any) // eslint-disable-line @typescript-eslint/no-explicit-any
 }


### PR DESCRIPTION
This hadn't surfaced as an issue yet, but there was a potential problem in the code: the open handler that the transport will use exposes the entire WS connection to the user. This is great for extensibility and allows for custom login flows for example, but if the user were to, say, completely replace all listeners from this function, it could affect the logic of the websocket transport itself. This PR changes how those listeners are set up, and the connection flow, as follows:
- Connection is created
- Open listener is registered (which will call the user handler)
- User can do whatever in their handler, including setting up new listeners
- The user handler resolves or rejects
- All listeners are removed, and the rest of the transport listeners are added (message, error, close)