### PR TITLE
Add transport name and metrics to redis subscription set

### DIFF
--- a/src/cache/metrics.ts
+++ b/src/cache/metrics.ts
@@ -51,9 +51,3 @@ export enum CacheTypes {
   Redis = 'redis',
   Local = 'local',
 }
-
-export enum CMD_SENT_STATUS {
-  TIMEOUT = 'TIMEOUT',
-  FAIL = 'FAIL',
-  SUCCESS = 'SUCCESS',
-}

--- a/src/cache/redis.ts
+++ b/src/cache/redis.ts
@@ -1,16 +1,10 @@
 import Redis from 'ioredis'
-import { metrics } from '../metrics'
+import { CMD_SENT_STATUS, recordRedisCommandMetric } from '../metrics'
 import { AdapterResponse, makeLogger } from '../util'
 import { Cache, CacheEntry } from './index'
-import { cacheMetricsLabel, cacheSet, CacheTypes, CMD_SENT_STATUS } from './metrics'
+import { cacheMetricsLabel, cacheSet, CacheTypes } from './metrics'
 
 const logger = makeLogger('RedisCache')
-
-export const recordRedisCommandMetric = (status: CMD_SENT_STATUS, functionName: string): void =>
-  metrics
-    .get('redisCommandsSentCount')
-    .labels({ status: CMD_SENT_STATUS[status], function_name: functionName })
-    .inc()
 
 /**
  * Redis implementation of a Cache. It uses a simple js Object, storing entries with both

--- a/src/metrics/index.ts
+++ b/src/metrics/index.ts
@@ -9,6 +9,12 @@ import { getMTLSOptions, httpsOptions } from '../index'
 
 const logger = makeLogger('Metrics')
 
+export enum CMD_SENT_STATUS {
+  TIMEOUT = 'TIMEOUT',
+  FAIL = 'FAIL',
+  SUCCESS = 'SUCCESS',
+}
+
 export function setupMetricsServer(name: string, adapterSettings: AdapterSettings) {
   const mTLSOptions: httpsOptions | Record<string, unknown> = getMTLSOptions(adapterSettings)
   const metricsApp = fastify({
@@ -165,6 +171,12 @@ export const retrieveCost = <ProviderResponseBody>(data: ProviderResponseBody): 
     return 1
   }
 }
+
+export const recordRedisCommandMetric = (status: CMD_SENT_STATUS, functionName: string): void =>
+  metrics
+    .get('redisCommandsSentCount')
+    .labels({ status: CMD_SENT_STATUS[status], function_name: functionName })
+    .inc()
 
 export const metrics = new Metrics(() => ({
   httpRequestsTotal: new client.Counter({

--- a/src/transports/abstract/subscription.ts
+++ b/src/transports/abstract/subscription.ts
@@ -29,7 +29,7 @@ export abstract class SubscriptionTransport<T extends TransportGenerics> impleme
     name: string,
   ): Promise<void> {
     this.responseCache = dependencies.responseCache
-    this.subscriptionSet = dependencies.subscriptionSetFactory.buildSet(endpointName)
+    this.subscriptionSet = dependencies.subscriptionSetFactory.buildSet(endpointName, name)
     this.subscriptionTtl = this.getSubscriptionTtlFromConfig(adapterSettings) // Will be implemented by subclasses
     this.name = name
   }

--- a/src/util/subscription-set/subscription-set.ts
+++ b/src/util/subscription-set/subscription-set.ts
@@ -30,7 +30,7 @@ export class SubscriptionSetFactory {
     this.capacity = adapterSettings.SUBSCRIPTION_SET_MAX_ITEMS
   }
 
-  buildSet<T>(endpointName: string): SubscriptionSet<T> {
+  buildSet<T>(endpointName: string, transportName: string): SubscriptionSet<T> {
     switch (this.cacheType) {
       case 'local':
         return new ExpiringSortedSet<T>(this.capacity)
@@ -39,7 +39,7 @@ export class SubscriptionSetFactory {
           throw new Error('Redis client undefined. Cannot create Redis subscription set')
         }
         // Identifier key used for the subscription set in redis
-        const subscriptionSetKey = `${this.adapterName}-${endpointName}-subscriptionSet`
+        const subscriptionSetKey = `${this.adapterName}-${endpointName}-${transportName}-subscriptionSet`
         return new RedisSubscriptionSet<T>(this.redisClient, subscriptionSetKey)
       }
     }

--- a/src/validation/index.ts
+++ b/src/validation/index.ts
@@ -1,8 +1,8 @@
 import { FastifyError, FastifyReply, FastifyRequest, HookHandlerDoneFunction } from 'fastify'
 import { ReplyError as RedisError } from 'ioredis'
 import { Adapter } from '../adapter'
-import { calculateCacheKey, recordRedisCommandMetric } from '../cache'
-import { CMD_SENT_STATUS } from '../cache/metrics'
+import { calculateCacheKey } from '../cache'
+import { CMD_SENT_STATUS, recordRedisCommandMetric } from '../metrics'
 import { getMetricsMeta } from '../metrics/util'
 import { makeLogger } from '../util'
 import {

--- a/test/subscription-set/subscription-set-factory.test.ts
+++ b/test/subscription-set/subscription-set-factory.test.ts
@@ -10,7 +10,7 @@ test('subscription set factory (local cache)', async (t) => {
   process.env['CACHE_TYPE'] = 'local'
   const config = buildAdapterSettings({})
   const factory = new SubscriptionSetFactory(config, 'test')
-  const subscriptionSet = factory.buildSet('test')
+  const subscriptionSet = factory.buildSet('test', 'test')
   t.is(subscriptionSet instanceof ExpiringSortedSet, true)
 })
 
@@ -18,7 +18,7 @@ test('subscription set factory (redis cache)', async (t) => {
   process.env['CACHE_TYPE'] = 'redis'
   const config = buildAdapterSettings({})
   const factory = new SubscriptionSetFactory(config, 'test', new RedisMock() as unknown as Redis)
-  const subscriptionSet = factory.buildSet('test')
+  const subscriptionSet = factory.buildSet('test', 'test')
   t.is(subscriptionSet instanceof RedisSubscriptionSet, true)
 })
 
@@ -27,7 +27,7 @@ test('subscription set factory (redis cache missing client)', async (t) => {
   const config = buildAdapterSettings({})
   const factory = new SubscriptionSetFactory(config, 'test')
   try {
-    factory.buildSet('test')
+    factory.buildSet('test', 'test')
     t.fail()
   } catch (e: unknown) {
     t.pass()
@@ -39,7 +39,7 @@ test('subscription set factory (local cache) max capacity', async (t) => {
   process.env['SUBSCRIPTION_SET_MAX_ITEMS'] = '3'
   const config = buildAdapterSettings({})
   const factory = new SubscriptionSetFactory(config, 'test')
-  const subscriptionSet = factory.buildSet('test')
+  const subscriptionSet = factory.buildSet('test', 'test')
 
   await subscriptionSet.add(1, 10000, '1')
   await subscriptionSet.add(2, 10000, '2')


### PR DESCRIPTION
- Added transport name to the redis subscription set key to help avoid subscription sets being shared between transports of the same endpoint
- Added redis metrics to the redis subscription set