### PR TITLE
enforce uppercase ea name

### DIFF
--- a/src/adapter/basic.ts
+++ b/src/adapter/basic.ts
@@ -80,6 +80,10 @@ export class Adapter<CustomSettingsDefinition extends SettingsDefinitionMap = Se
       throw new Error('This adapter has already been initialized!')
     }
 
+    if (this.name !== this.name.toUpperCase()) {
+      throw new Error('Adapter name must be uppercase')
+    }
+
     // Initialize metrics to register them with the prom-client
     metrics.initialize()
 

--- a/test/adapter.test.ts
+++ b/test/adapter.test.ts
@@ -25,3 +25,21 @@ test('duplicate endpoint names throw error on startup', async (t) => {
     message: 'Duplicate endpoint / alias: "test"',
   })
 })
+
+test('lowercase adapter name throws error on startup', async (t) => {
+  const adapter = new Adapter({
+    // @ts-expect-error - tests that lowercase names throw errors in runtime
+    name: 'test',
+    endpoints: [
+      new AdapterEndpoint({
+        name: 'test',
+        inputParameters: {},
+        transport: new NopTransport(),
+      }),
+    ],
+  })
+
+  await t.throwsAsync(async () => expose(adapter), {
+    message: 'Adapter name must be uppercase',
+  })
+})


### PR DESCRIPTION
[PDI-1955](https://smartcontract-it.atlassian.net/browse/PDI-1955)

I want to note that i was not able to reproduce this issues. Typescript was always complaining about name being lowercase 

[PDI-1955]: https://smartcontract-it.atlassian.net/browse/PDI-1955?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ