### PR TITLE
Fix resubscribes on server side ws connection closures

### DIFF
--- a/src/transports/websocket.ts
+++ b/src/transports/websocket.ts
@@ -327,12 +327,10 @@ export class WebSocketTransport<
       this.wsConnection?.close()
       connectionClosed = true
 
-      // If the connection was closed, the new subscriptions should be the desired ones
-      subscriptions.new = subscriptions.desired
-      if (subscriptions.new.length) {
+      if (subscriptions.desired.length) {
         logger.trace(
           `Connection will be reopened and will subscribe to new and resubscribe to existing: ${JSON.stringify(
-            subscriptions.new,
+            subscriptions.desired,
           )}`,
         )
       }
@@ -345,6 +343,9 @@ export class WebSocketTransport<
       this.currentUrl = urlFromConfig
       // Need to write this now, otherwise there could be messages sent with values before the open handler finishes
       this.providerDataStreamEstablished = Date.now()
+
+      // If the connection was closed, the new subscriptions should be the desired ones
+      subscriptions.new = subscriptions.desired
 
       // Connect to the provider
       this.wsConnection = await this.establishWsConnection(context, urlFromConfig, options)

--- a/src/transports/websocket.ts
+++ b/src/transports/websocket.ts
@@ -344,6 +344,9 @@ export class WebSocketTransport<
       // Need to write this now, otherwise there could be messages sent with values before the open handler finishes
       this.providerDataStreamEstablished = Date.now()
 
+      // Local subscriptions array should be empty before the connection is opened
+      this.localSubscriptions = []
+
       // If the connection was closed, the new subscriptions should be the desired ones
       subscriptions.new = subscriptions.desired
 


### PR DESCRIPTION
Moved setting new subscriptions to the open connection block. This accounts for the scenario that the connection is closed on the server side.