### PR TITLE
Update custom script to avoid using redis functions

### DIFF
--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -87,7 +87,6 @@ test('MTLS_ENABLED connection with incorrect params should error', async (t) => 
   try {
     await start(adapter)
   } catch (e: unknown) {
-    console.log(e)
     t.pass()
   }
 })

--- a/test/util.ts
+++ b/test/util.ts
@@ -125,14 +125,14 @@ export class RedisMock {
     return new CommandChainMock(this)
   }
 
-  function(subcommand: 'LOAD', replace: 'REPLACE', functionCode: string) {
-    const match = functionCode.match(/name=(\w+)/)
-    const libName = match?.[1]
-    return Promise.resolve(libName)
+  defineCommand(
+    _name: 'setExternalAdapterResponse',
+    _options: { lua: string; numberOfKeys: number },
+  ) {
+    return
   }
 
-  // eslint-disable-next-line max-params
-  fcall(fnName: string, numOfKeys: number, key: string, value: string, ttl: number) {
+  setExternalAdapterResponse(key: string, value: string, ttl: number) {
     return this.set(key, value, 'PX', ttl)
   }
 }
@@ -148,8 +148,8 @@ class CommandChainMock {
   }
 
   // eslint-disable-next-line max-params
-  fcall(fnName: string, numOfKeys: number, key: string, value: string, ttl: number) {
-    this.promises.push(this.redisMock.fcall(fnName, numOfKeys, key, value, ttl))
+  setExternalAdapterResponse(key: string, value: string, ttl: number) {
+    this.promises.push(this.redisMock.setExternalAdapterResponse(key, value, ttl))
     return this
   }
 


### PR DESCRIPTION
Redis functions is only available starting version 7. Not all NOPs are running Redis 7 and some cannot since it isn't available for Azure or GCP. The implementation was updated so that it does not use functions but still leverages custom scripting. The new implementation still leverages server side caching to maintain performance.