### PR TITLE
PDI 2010 - Added rate limit config validations for non-positive numbers in v3 framework

### DIFF
--- a/src/adapter/basic.ts
+++ b/src/adapter/basic.ts
@@ -275,10 +275,12 @@ export class Adapter<CustomSettingsDefinition extends SettingsDefinitionMap = Se
 
     if (perMinuteRateLimit > highestTierValue) {
       logger.warn(
-        `The configured ${this.config.settings.RATE_LIMIT_CAPACITY_MINUTE
-          ? 'RATE_LIMIT_CAPACITY_MINUTE'
-          : 'RATE_LIMIT_CAPACITY'
-        } value (${perMinuteRateLimit}) is higher than the highest tier value the adapter rate limiting configurations (${highestTierValue * 60
+        `The configured ${
+          this.config.settings.RATE_LIMIT_CAPACITY_MINUTE
+            ? 'RATE_LIMIT_CAPACITY_MINUTE'
+            : 'RATE_LIMIT_CAPACITY'
+        } value (${perMinuteRateLimit}) is higher than the highest tier value the adapter rate limiting configurations (${
+          highestTierValue * 60
         })`,
       )
     }
@@ -385,7 +387,8 @@ export class Adapter<CustomSettingsDefinition extends SettingsDefinitionMap = Se
 
       // Execute the registration handler without blocking
       logger.debug(
-        `Firing request registration handler${cachedResponse ? ' (cached response already sent)' : ''
+        `Firing request registration handler${
+          cachedResponse ? ' (cached response already sent)' : ''
         }`,
       )
 

--- a/src/adapter/basic.ts
+++ b/src/adapter/basic.ts
@@ -254,6 +254,14 @@ export class Adapter<CustomSettingsDefinition extends SettingsDefinitionMap = Se
 
     const rateLimitingTier = getRateLimitingTier(this.config.settings, this.rateLimiting?.tiers)
 
+    if (rateLimitingTier) {
+      for (const limit of Object.values(rateLimitingTier)) {
+        if (limit && limit < 0) {
+          throw new Error('Rate limit must be a positive number')
+        }
+      }
+    }
+
     const highestTierValue = highestRateLimitTiers(this.rateLimiting?.tiers)
     const rateLimitTierFromConfig = buildRateLimitTiersFromConfig(this.config.settings)
     const perSecRateLimit = rateLimitTierFromConfig?.rateLimit1s || 0
@@ -267,12 +275,10 @@ export class Adapter<CustomSettingsDefinition extends SettingsDefinitionMap = Se
 
     if (perMinuteRateLimit > highestTierValue) {
       logger.warn(
-        `The configured ${
-          this.config.settings.RATE_LIMIT_CAPACITY_MINUTE
-            ? 'RATE_LIMIT_CAPACITY_MINUTE'
-            : 'RATE_LIMIT_CAPACITY'
-        } value (${perMinuteRateLimit}) is higher than the highest tier value the adapter rate limiting configurations (${
-          highestTierValue * 60
+        `The configured ${this.config.settings.RATE_LIMIT_CAPACITY_MINUTE
+          ? 'RATE_LIMIT_CAPACITY_MINUTE'
+          : 'RATE_LIMIT_CAPACITY'
+        } value (${perMinuteRateLimit}) is higher than the highest tier value the adapter rate limiting configurations (${highestTierValue * 60
         })`,
       )
     }
@@ -379,8 +385,7 @@ export class Adapter<CustomSettingsDefinition extends SettingsDefinitionMap = Se
 
       // Execute the registration handler without blocking
       logger.debug(
-        `Firing request registration handler${
-          cachedResponse ? ' (cached response already sent)' : ''
+        `Firing request registration handler${cachedResponse ? ' (cached response already sent)' : ''
         }`,
       )
 

--- a/test/rate-limit-config.test.ts
+++ b/test/rate-limit-config.test.ts
@@ -31,6 +31,37 @@ test('empty tiers in rate limiting fails on startup', async (t) => {
   })
 })
 
+test('throws error if rate limit is a negative number', async (t) => {
+  const adapter = new Adapter({
+    name: 'TEST',
+    endpoints: [
+      new AdapterEndpoint({
+        name: 'test',
+        inputParameters: {},
+        transport: new NopTransport(),
+      }),
+    ],
+    rateLimiting: {
+      tiers: {
+        free: {
+          rateLimit1s: 1,
+          rateLimit1m: -1,
+          rateLimit1h: -1
+        },
+        pro: {
+          rateLimit1s: -1,
+          rateLimit1m: -1,
+          rateLimit1h: -1
+        }
+      },
+    },
+  })
+
+  await t.throwsAsync(async () => start(adapter), {
+    message: 'Rate limit must be a positive number',
+  })
+})
+
 test('selected tier is not a valid option', async (t) => {
   const config = new AdapterConfig(
     {},

--- a/test/rate-limit-config.test.ts
+++ b/test/rate-limit-config.test.ts
@@ -46,7 +46,7 @@ test('throws error if rate limit is a negative number', async (t) => {
         free: {
           rateLimit1s: undefined,
           rateLimit1m: 1,
-          rateLimit1h: -1
+          rateLimit1h: -1.5
         },
         pro: {
           rateLimit1s: -1,

--- a/test/rate-limit-config.test.ts
+++ b/test/rate-limit-config.test.ts
@@ -46,13 +46,13 @@ test('throws error if rate limit is a negative number', async (t) => {
         free: {
           rateLimit1s: undefined,
           rateLimit1m: 1,
-          rateLimit1h: -1.5
+          rateLimit1h: -1.5,
         },
         pro: {
           rateLimit1s: -1,
           rateLimit1m: 1,
-          rateLimit1h: 1
-        }
+          rateLimit1h: 1,
+        },
       },
     },
   })

--- a/test/rate-limit-config.test.ts
+++ b/test/rate-limit-config.test.ts
@@ -44,14 +44,14 @@ test('throws error if rate limit is a negative number', async (t) => {
     rateLimiting: {
       tiers: {
         free: {
-          rateLimit1s: 1,
-          rateLimit1m: -1,
+          rateLimit1s: undefined,
+          rateLimit1m: 1,
           rateLimit1h: -1
         },
         pro: {
           rateLimit1s: -1,
-          rateLimit1m: -1,
-          rateLimit1h: -1
+          rateLimit1m: 1,
+          rateLimit1h: 1
         }
       },
     },


### PR DESCRIPTION
Added a check in adapters/basic.ts for non-positive numbers in rate limit tiers. The framework now throws an error on startup if the rate limit value is not a positive number.

Also added a test in test/rate-limit-config.test.ts.