### PR TITLE
check for outdated framework version

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -24,7 +24,7 @@ jobs:
           main_version=$(node -pe "require('${{ github.workspace }}/package.json').version")
 
           if [ "$main_version" != "$current_version" ]; then
-           echo "Error: Package version on current branch ($current_package_version) does not match the one on ${{ github.base_ref }} branch ($main_package_version)"
+           echo "Error: Package version on current branch ($current_version) does not match the one on ${{ github.base_ref }} branch ($main_version)"
           exit 1
           fi
       - uses: actions/checkout@v3

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -14,6 +14,20 @@ jobs:
     if: ${{ !startsWith(github.head_ref, 'version-bump') }}
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      - run: |
+          # Check for outdated framework version
+          current_version=$(node -pe "require('${{ github.workspace }}/package.json').version")
+          git fetch origin ${{ github.base_ref }}
+          git checkout ${{ github.base_ref }}
+          main_version=$(node -pe "require('${{ github.workspace }}/package.json').version")
+
+          if [ "$main_version" != "$current_version" ]; then
+           echo "Error: Package version on current branch ($current_package_version) does not match the one on ${{ github.base_ref }} branch ($main_package_version)"
+          exit 1
+          fi
+      - uses: actions/checkout@v3
       - uses: ./.github/actions/setup
       - run: yarn build
   lint:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chainlink/external-adapter-framework",
-  "version": "0.28.3",
+  "version": "0.28.4",
   "main": "dist/index.js",
   "license": "MIT",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chainlink/external-adapter-framework",
-  "version": "0.28.4",
+  "version": "0.28.3",
   "main": "dist/index.js",
   "license": "MIT",
   "dependencies": {


### PR DESCRIPTION
[PDI-2009](https://smartcontract-it.atlassian.net/browse/PDI-2009)

This PR adds a step in main workflow that checks if the version in package.json is the same as in main branch, if not it errors. I think it also makes sense to [enable branch sync ](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/keeping-your-pull-request-in-sync-with-the-base-branch) so it will be much easier to sync the PR with main branch

[PDI-2009]: https://smartcontract-it.atlassian.net/browse/PDI-2009?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ