### PR TITLE
Adjust response timestamp validator to account for clock drift

### DIFF
--- a/src/validation/utils.ts
+++ b/src/validation/utils.ts
@@ -30,7 +30,7 @@ const _integer: () => Validator<number | string> = () => {
 
 const positive: () => Validator<number | string> = () => {
   return (value) => {
-    if (value !== undefined && value < 0) {
+    if (value !== undefined && Number(value) < 0) {
       return `Value should be positive number, Received ${value}`
     }
     return
@@ -39,7 +39,7 @@ const positive: () => Validator<number | string> = () => {
 
 const minNumber: ValidatorWithParams<number, number | string> = (param) => {
   return (value) => {
-    if (value !== undefined && value < param) {
+    if (value !== undefined && Number(value) < param) {
       return `Minimum allowed value is ${param}. Received ${value}`
     }
     return
@@ -48,7 +48,7 @@ const minNumber: ValidatorWithParams<number, number | string> = (param) => {
 
 const maxNumber: ValidatorWithParams<number, number | string> = (param) => {
   return (value) => {
-    if (value !== undefined && value > param) {
+    if (value !== undefined && Number(value) > param) {
       return `Maximum allowed value is ${param}. Received ${value}`
     }
     return
@@ -101,8 +101,8 @@ const integer = (params?: { min?: number; max?: number }) => {
 
 const port = () => integer({ min: 1, max: 65535 })
 
-// Validates that value is a valid timestamp from 2018-01-01 to now
-const responseTimestamp = () => integer({ min: 1514764861000, max: new Date().getTime() })
+// Validates that value is a valid timestamp from 2018-01-01 to now + 50ms to account for clock drift
+const responseTimestamp = () => integer({ min: 1514764861000, max: new Date().getTime() + 50 })
 
 const base64: () => Validator<string> = () => {
   return (value) => {

--- a/test/validation.test.ts
+++ b/test/validation.test.ts
@@ -519,6 +519,13 @@ test.serial('Test response timestamp validator', async (t) => {
   let value = new Date().getTime()
   let error = timestampValidator(value)
   t.is(error, undefined)
+  // Test reasonable limit over current timestamp
+  error = timestampValidator(value + 30)
+  t.is(error, undefined)
+  // Test over maximum timestamp
+  error = timestampValidator(value + 1000)
+  t.is(error, `Maximum allowed value is ${value + 50}. Received ${value + 1000}`)
+  // Test under minimum timestamp
   value = 0
   error = timestampValidator(value)
   t.is(error, 'Minimum allowed value is 1514764861000. Received 0')


### PR DESCRIPTION
Some data providers indicated timestamps are slightly ahead due to clock drift causing logs to get filled with response timestamp warnings. The validator was adjusted to allowed timestamps up to 50ms over the current time in the adapter.