### PR TITLE
add badges to readme

### DIFF
--- a/.c8rc.json
+++ b/.c8rc.json
@@ -1,3 +1,3 @@
 {
-  "reporter": ["lcov", "text"]
+  "reporter": ["lcov", "text", "json-summary"]
 }

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -47,7 +47,9 @@ jobs:
       - uses: actions/upload-artifact@v3
         with:
           name: coverage-reports
-          path: ./**/coverage/tmp/*.json
+          path: |
+            ./**/coverage/tmp/*.json
+            ./**/coverage/coverage-summary.json
   # Only run if tests have run and completed successfully
   code-coverage:
     needs: test

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -60,3 +60,13 @@ jobs:
         with:
           name: coverage-reports
       - run: yarn code-coverage
+      - uses: ./.github/actions/set-git-credentials
+      - run: |
+          # save coverage summary in a branch 'coverage-pr-PR_NUMBER' so we can have access to it in a different workflow
+          BRANCH="coverage-pr-${{ github.event.pull_request.number }}"
+          git checkout -b $BRANCH          
+          git add -f coverage/coverage-summary.json
+          git commit -m "coverage summary report"
+          git push --set-upstream origin $BRANCH --force
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/open-version-bump-pr.yaml
+++ b/.github/workflows/open-version-bump-pr.yaml
@@ -119,6 +119,55 @@ jobs:
             --field sha="$NEW_TAG_SHA"
           fi
           echo "VERSION_BRANCH=$VERSION_BRANCH" >> $GITHUB_OUTPUT
+      - name: Update code coverage badge
+        continue-on-error: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # get the current and new code coverage result and update the coverage badge if needed
+          VERSION_BRANCH="${{ steps.create-commit.outputs.VERSION_BRANCH }}"
+          COVERAGE_BRANCH="coverage-pr-${{ github.event.number }}"
+          COVERAGE_FILE="coverage/coverage-summary.json"
+
+          # read the content of readme from $VERSION_BRANCH
+          README_CONTENT=$(gh api --method GET /repos/:owner/:repo/contents/README.md \
+              -f "ref=refs/heads/$VERSION_BRANCH" \
+              | jq -r '.content' \
+              | base64 -d)
+
+          CURRENT_COVERAGE=$(echo "$README_CONTENT" | grep -o 'coverage-[0-9]*\(\.[0-9]\{1,\}\)\?%' | sed 's/coverage-\(.*\)%/\1/')
+
+          echo "Current code coverage - $CURRENT_COVERAGE"
+
+          # read the content of coverage-report.json from $COVERAGE_BRANCH and get the coverage number for statements
+          COVERAGE_REPORT=$(gh api --method GET /repos/:owner/:repo/contents/$COVERAGE_FILE \
+              -f "ref=refs/heads/$COVERAGE_BRANCH" \
+              | jq -r '.content' \
+              | base64 -d)
+
+          NEW_COVERAGE=$(echo "$COVERAGE_REPORT" | jq '.total.statements.pct')
+
+          echo "New code coverage - $NEW_COVERAGE"
+
+          if [ "$NEW_COVERAGE" != "$CURRENT_COVERAGE" ]; then
+            # change the README content by replacing coverage percentage 
+            FILE_TO_COMMIT="README.md"
+            awk -v new_coverage="$NEW_COVERAGE" '{gsub(/!\[Coverage\]\(https:\/\/img\.shields\.io\/badge\/coverage-[0-9]{1,3}(\.[0-9]{1,4})?%25-green\)/,"![Coverage](https://img.shields.io/badge/coverage-" new_coverage "%25-green)")}1' "$FILE_TO_COMMIT" > tmp && mv tmp "$FILE_TO_COMMIT"
+
+            # commit changes to repo
+            SHA=$(gh api --method GET /repos/:owner/:repo/contents/$FILE_TO_COMMIT \
+              -f "ref=refs/heads/$VERSION_BRANCH" \
+              --jq '.sha')
+          
+            CONTENT=$( base64 -i $FILE_TO_COMMIT )
+          
+            gh api --method PUT /repos/:owner/:repo/contents/$FILE_TO_COMMIT \
+                --field message="update code coverage badge" \
+                 --field content="$CONTENT" \
+                --field encoding="base64" \
+                --field branch="$VERSION_BRANCH" \
+                --field sha="$SHA"   
+          fi
       - name: Create PR
         id: create-pr
         if: inputs.dry-run != 'true'
@@ -174,6 +223,23 @@ jobs:
               ...needs?.preflight?.outputs,
               ...needs?.createVersionBumpPR?.outputs,
             }
+            
+            // delete the coverage-pr branch if it exists
+            const ref = `heads/coverage-pr-${context.payload.pull_request.number}`
+            try {
+            const coverageRef = await github.rest.git.getRef({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               ref,
+            });
+            if (coverageRef && coverageRef.data && coverageRef.data.ref) {
+                await github.rest.git.deleteRef({
+                  owner: context.repo.owner,
+                  repo:  context.repo.repo,
+                  ref,
+                });
+            }
+            }catch(error) {}
 
             // This workflow always runs on PR close, and this job always runs because of always(). 
             // We have limited access to PR context, so check for a universally set param to determine if the PR was merged

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # EA Framework v3
 
+[![NPM version](https://img.shields.io/npm/v/@chainlink/external-adapter-framework.svg?style=flat)](https://www.npmjs.com/package/@chainlink/external-adapter-framework)
+![Coverage](https://img.shields.io/badge/coverage-99.21%25-green)
+
 > **Warning**
 > This framework is in a Beta state, and under active development. While many of the features from version 2 are present, they have not been tested extensively enough to mark this as production ready. You can find v2 in the [External Adapters Monorepo](https://github.com/smartcontractkit/external-adapters-js)
 


### PR DESCRIPTION
[PDI-144](https://smartcontract-it.atlassian.net/browse/PDI-144)
This PR adds two badges to readme, `npm version` and `code coverage`.  
`npm version` is straightforward. Given npm package name, the latest published version will be automatically shown. 

For the `code coverage` badge there are some additional changes. Since we don't store coverage result in third party service like codecov we need to 'manually' update the coverage percentage in README. New workflow step is added to _open-version-bump-pr.yaml_  to automate that process. 
1. Once the tests have been completed and coverage result is available a new step in main workflow will commit coverage result  file in a temporary branch. This is workaround since it is not possible to share files between workflows and we don't want to run all the tests in _open-version-bump-pr.yaml_  again. 
2. When the PR gets merged a new step in _open-version-bump-pr.yaml_  will fetch that temporary branch, get the new coverage information, compare it with current one and update and commit the changes in README. 
3. Regardless if the second step is successful or not the temporary branch will be deleted. 

Since this is a workaround, there are some limitations. The most important one is the order of PR merges. Consider following situation where there are 2 PRs that lead to same version update. The PR  A changes the coverage from 99.2% to 99.8%, the PR B changes from 99.2% to 99.3%. In this case if A is merged first, then B, the coverage in README will be 99.3 which is not right. 
To mitigate this issue we can enforce to rebase feature branches if there changes in base branch in PRs. In that case branch B after rebasing and re-pushing would have 99.9 coverage. 



[PDI-144]: https://smartcontract-it.atlassian.net/browse/PDI-144?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ