### PR TITLE
Fix input validator 0 defaults

### DIFF
--- a/src/validation/input-params.ts
+++ b/src/validation/input-params.ts
@@ -328,7 +328,7 @@ class ProcessedParam<const T extends InputParameter = InputParameter> {
         if (this.definition.required || input != null) {
           throw this.validationError('input value must be a non-empty array')
         } else {
-          return input
+          return []
         }
       }
 

--- a/src/validation/input-params.ts
+++ b/src/validation/input-params.ts
@@ -319,7 +319,7 @@ class ProcessedParam<const T extends InputParameter = InputParameter> {
       throw this.validationError('param is required but no value was provided')
     }
 
-    if (this.definition.default && input == null) {
+    if (this.definition.default != null && input == null) {
       return this.definition.default
     }
 
@@ -328,7 +328,7 @@ class ProcessedParam<const T extends InputParameter = InputParameter> {
         if (this.definition.required || input != null) {
           throw this.validationError('input value must be a non-empty array')
         } else {
-          return []
+          return input
         }
       }
 

--- a/test/validation.test.ts
+++ b/test/validation.test.ts
@@ -518,7 +518,20 @@ test.serial('non-required array param coerces null value to empty array', async 
   }) as unknown as InputParameters<EmptyInputParameters>
 
   const data = t.context.adapterEndpoint.inputParameters.validateInput({})
-  t.deepEqual(data['list'] as unknown, [])
+  t.deepEqual(data['list'] as unknown, undefined)
+})
+
+test.serial('non-required number allows default 0', async (t) => {
+  t.context.adapterEndpoint.inputParameters = new InputParameters({
+    default0: {
+      type: 'number',
+      description: 'stuff',
+      default: 0,
+    },
+  }) as unknown as InputParameters<EmptyInputParameters>
+
+  const data = t.context.adapterEndpoint.inputParameters.validateInput({})
+  t.deepEqual(data['default0'], 0)
 })
 
 test.serial('missing dependency fails validation', async (t) => {

--- a/test/validation.test.ts
+++ b/test/validation.test.ts
@@ -518,7 +518,7 @@ test.serial('non-required array param coerces null value to empty array', async 
   }) as unknown as InputParameters<EmptyInputParameters>
 
   const data = t.context.adapterEndpoint.inputParameters.validateInput({})
-  t.deepEqual(data['list'] as unknown, undefined)
+  t.deepEqual(data['list'] as unknown, [])
 })
 
 test.serial('non-required number allows default 0', async (t) => {


### PR DESCRIPTION
- Fixed default value check not allowing 0 for number types
- Changed array validation logic to return the same value as passed in request. `undefined` doesn't return empty array.
  - Potentially up for discussion if we should change the behavior to this but I'd argue to maintain what it was before. Existing falsy checks on array request params would start failing (i.e. `if (req.addresses)`)