### PR TITLE
change the logic of version-bump pr workflow

### DIFF
--- a/.github/WORKFLOW-README.MD
+++ b/.github/WORKFLOW-README.MD
@@ -10,17 +10,9 @@ Runs yarn install, then yarn build. Split into an action to avoid boilerplate in
 Checks that all PRs have a version bump label (major, minor, patch, or none). Used as a part of our basic chechs and when we close a PR
 
 ### set-git-credentials
-Sets a common git configuration for the rare instances where we need to run raw git commands, such as when pushing tags after `npm --version`
-
-### publish
-Publishes the package to NPM. This action does not manage versions, so you need to run a workflow that automatically bumps the version, or bump the version by hand directly on the branch.
+Sets a common git configuration for the rare instances where we need to run raw git commands, such as when pushing tags after `npm --version
 
 ## Workflows
-
-### [open-pr.yaml](workflows/open-pr.yaml)
-Adds labels to a PR, including version bump labels, based on the branch name.
-
-Labels are applied automatically only when a PR is opened. If it applies the wrong label (ex: your improvement is a minor ver, or some PR is a major ver), you can fix it by hand
 
 
 ### [main](workflows/main.yaml)
@@ -28,44 +20,25 @@ Builds, tests, and lints the code. Triggered by any pull request action or a pus
 
 This workflow does not run against branches prefixed with version-bump/**. Those branches, which are automatically created by close-pr.yaml, have their own validation method.
 
-### [change-pr_validate-labels](workflows/change-pr_validate-labels.yaml)
+### [pinned-dependencies](workflows/pinned-dependencies.yaml)
+Checks for un-pinned versions of dependencies in package.json file and reports errors if any are found. 
+It helps ensure that all dependencies have explicit version constraints, promoting reproducibility and stability in the project.
+
+### [publish](workflows/publish.yaml)
+The workflow is triggered either manually or when a push event occurs on the "main" branch with modified "package.json" file. It compares the current version of the package with the published version on NPM and proceeds with publishing if they're different.
+
+### [add-or-validate-labels](workflows/add-or-validate-labels.yaml)
 Checks if the PR contains version bump instructions. Triggered by any changes to a PR's labels.
 
 This validation work is captured outside of `main` because `main` doesn't reliably execute after open-pr is complete. This can be fixed later.
 
-
-#### Label mappings:
-Please refer to [open-pr.yaml](workflows/open-pr.yaml) for an authoritative list of labels. For your convenience, here are some of the most common branch prefixes and their labels:
-
-| Branch Prefix  | Resulting label(s)  | Version bump                                                                    |
-|----------------|---------------------|---------------------------------------------------------------------------------|
-| release        | release, major      | major                                                                           |
-| feature/       | feature, minor      | minor                                                                           |
-| bugfix/        | bugfix, patch       | patch                                                                           |
-| hotfix/        | hotfix, patch       | patch                                                                           |
-| fix/           | hotpix, patch       | patch                                                                           |
-| chore/         | chore, patch        | patch                                                                           |
-| improvement/   | improvement, patch  | patch                                                                           |
-| documentation/ | documentation, none | none                                                                            |
-| version-bump/  | version-bump        | (Special behavior) Results in a publish on merge                                |
-| (no prefix)    |                     | <p style="color:#e31c3d"><b>Should fail validation. Will error on merge</b></p> |
-
-
-### [validate-version-bump-pr.yaml](workflows/validate-version-bump-pr.yaml)
-This is essentially main for version-bump/** branches. It checks that the version-bump PR meets all of the following criteria:
-1. Contains precisely one changed file from the target branch, package.json
-2. package.json contains precisely one changed line (one add and one sub from git diff)
-3. That one changed line matches the following regex: `^\s*"version": "\d+\.\d+\.\d+",$`
-
-The main purpose of this is that if it passes, the reviewer can assume that it's safe to merge after basic DD.
-
-### [close-pr.yaml](workflows/close-pr.yaml)
-Runs when any PR is closed by merging with the base branch. Does one of two things depending on the branch prefix:
-1. Anything but version-bump/**
-    1. Creates a new branch called version-bump/NEW_VERSION from main (remember, the original PR is merged at this point) and runs NPM version with the original PR's version label
-    2. Creates a new PR from this new branch consisting of precisely one change to package.json, a version tick
-2. Any branch prefixed with version-bump/**
-    1. Publishes the package to NPM. **Requires** an engineer to approve the use of production credentials.
+### [open-version-bump-pr.yaml](workflows/open-version-bump-pr.yaml)
+Runs when any PR is closed by merging with the base branch.Does the following things
+1. Checks if there is existing branch named 'version-bump', if not creates it from main (remember, the original PR is merged at this point) and runs NPM version with the original PR's version label. 
+2. Compares the version of package.json from 'version-bump' branch with new version change produced by NPM version command. If the exsiting version in 'version-bump' is equal or higher, it skips the third and fifth steps.
+3. Creates a new commit in package.json with version change.
+4. Checks and updates the code-coverage badge in Readme.md if the coverage report from original PR is different from the coverage report in 'version-bump' branch.
+5. Creates or updates the PR from 'version-bump' branch to 'main'. 
 
 ## Testing
 Most workflows have the manual_dispatch flag, which lets you trigger a manual run in the UI or, preferably, the GitHub cli.  

--- a/.github/workflows/open-version-bump-pr.yaml
+++ b/.github/workflows/open-version-bump-pr.yaml
@@ -80,7 +80,7 @@ jobs:
           echo "VERSION_TAG=$PACKAGE_VERSION" >> $GITHUB_OUTPUT
       - name: Create commit
         id: create-commit
-        if: inputs.dry-run != 'true'
+        if: inputs.dry-run != 'true' && ${{ steps.tick-version.outputs.VERSION_TAG != '' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           FILE_TO_COMMIT: package.json
@@ -174,6 +174,7 @@ jobs:
           fi
           echo "VERSION_BRANCH=$VERSION_BRANCH" >> $GITHUB_OUTPUT
       - name: Update code coverage badge
+        if: ${{ steps.tick-version.outputs.VERSION_TAG != '' }}
         continue-on-error: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -224,7 +225,7 @@ jobs:
           fi
       - name: Create PR
         id: create-pr
-        if: inputs.dry-run != 'true'
+        if: inputs.dry-run != 'true' && ${{ steps.tick-version.outputs.VERSION_TAG != '' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/.github/workflows/open-version-bump-pr.yaml
+++ b/.github/workflows/open-version-bump-pr.yaml
@@ -84,41 +84,93 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           FILE_TO_COMMIT: package.json
-          VERSION_BRANCH: 'version-bump/${{ steps.tick-version.outputs.VERSION_TAG }}'
+          VERSION_BRANCH: "version-bump"
         run: |
-          # start with creating new branch 'version-bump/VERSION_TAG', also update the reference to the origin if it doesn't exist
+          # start with creating new branch 'version-bump', also update the reference to the origin if it doesn't exist
           git checkout -b $VERSION_BRANCH
           if ! gh api -X GET /repos/:owner/:repo/git/ref/heads/$VERSION_BRANCH >/dev/null 2>&1; then
-            echo "creating new branch"
+            echo "creating new branch $VERSION_BRANCH"
             gh api -X POST /repos/:owner/:repo/git/refs -f ref="refs/heads/main" -f sha="$GITHUB_SHA" -f "ref=refs/heads/$VERSION_BRANCH"
-
-            # move the branch pointer one commit backwards so that we can manually commit changes done by 'npm version ...' command
+          fi
+          
+          # get the content of package.json from $VERSION_BRANCH to get the current bump version
+          PACKAGE_JSON_CONTENT=$(gh api --method GET /repos/:owner/:repo/contents/$FILE_TO_COMMIT \
+              -f "ref=refs/heads/$VERSION_BRANCH" \
+              | jq -r '.content' \
+              | base64 -d)
+          
+          BUMP_VERSION=$(echo "$PACKAGE_JSON_CONTENT" | jq -r '.version')
+          NEW_VERSION="${{ steps.tick-version.outputs.VERSION_TAG }}"
+          
+          echo "BUMP_VERSION $BUMP_VERSION"
+          echo "NEW_VERSION $NEW_VERSION"
+          
+          #We need to compare and update the package version in version bump PR only if the new version is higher then current bump version. 
+          #For example if PR labeled as 'minor' is merged, then only 'major' labeled PR will overwrite the version change, not the 'patch' or 'minor' labeled PRs. 
+          
+          # Split versions into major, minor, and patch components
+          IFS='.' read -r -a bump <<< "$BUMP_VERSION"
+          IFS='.' read -r -a new <<< "$NEW_VERSION"
+          
+          HIGHEST_VERSION="equal"
+          
+          # Compare major version number
+          if (( bump[0] > new[0] )); then
+            HIGHEST_VERSION="bump"
+          elif (( bump[0] < new[0] )); then
+            HIGHEST_VERSION="new"
+          else
+            # Compare minor version number
+            if (( bump[1] > new[1] )); then
+              HIGHEST_VERSION="bump"
+            elif (( bump[1] < new[1] )); then
+              HIGHEST_VERSION="new"
+            else
+              # Compare patch version number
+              if (( bump[2] > new[2] )); then
+                HIGHEST_VERSION="bump"
+              elif (( bump[2] < new[2] )); then
+                HIGHEST_VERSION="new"
+              fi
+            fi
+          fi
+          
+          if [[ "$HIGHEST_VERSION" == "new" ]]; then
+           #new version is greater than current bump version, creating new commit 
+          
+           # move the branch pointer one commit backwards so that we can manually commit changes done by 'npm version ...' command
             git reset HEAD~
-
+          
             # create a commit with content of package.json. This will give us 'verified' commit label from github actions bot
             MESSAGE="${{ steps.tick-version.outputs.VERSION_TAG }}"
-            SHA=$( git rev-parse $VERSION_BRANCH:$FILE_TO_COMMIT )
+            SHA=$(gh api --method GET /repos/:owner/:repo/contents/$FILE_TO_COMMIT \
+                -f "ref=refs/heads/$VERSION_BRANCH" \
+                --jq '.sha')
+          
             CONTENT=$( base64 -i $FILE_TO_COMMIT )
+          
             NEW_COMMIT_SHA=$(gh api --method PUT /repos/:owner/:repo/contents/$FILE_TO_COMMIT \
              --field message="$MESSAGE" \
              --field content="$CONTENT" \
             --field encoding="base64" \
             --field branch="$VERSION_BRANCH" \
             --field sha="$SHA" | jq -r '.commit.sha')
-
+          
+            echo "UPDATED_VERSION_TAG=$NEW_VERSION" >> $GITHUB_OUTPUT
+          
             # create a tag from VERSION_TAG
             TAG_RESPONSE=$(gh api --method POST /repos/:owner/:repo/git/tags \
             --field tag="v${{ steps.tick-version.outputs.VERSION_TAG }}" \
             --field message="${{ steps.tick-version.outputs.VERSION_TAG }}" \
             --field object="$NEW_COMMIT_SHA" \
             --field type="commit")
-
+          
             NEW_TAG_SHA=$(echo "$TAG_RESPONSE" | jq -r '.sha')
-
+          
             # update the reference so that the tag is visible in github
             gh api --method POST /repos/:owner/:repo/git/refs \
             --field ref="refs/tags/v${{ steps.tick-version.outputs.VERSION_TAG }}" \
-            --field sha="$NEW_TAG_SHA"
+            --field sha="$NEW_TAG_SHA"  
           fi
           echo "VERSION_BRANCH=$VERSION_BRANCH" >> $GITHUB_OUTPUT
       - name: Update code coverage badge
@@ -176,9 +228,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # at this point either new branch with one new commit is created so we open PR, or we get the open PR and set the outputs
+          # at this point either new branch with new commit is created so we open PR, or we get the open PR and set the outputs
           pullRequest=$(gh api --method GET "/repos/:owner/:repo/pulls" --jq ".[] | select(.head.ref == \"${{ steps.create-commit.outputs.VERSION_BRANCH }}\" and .state == \"open\") | {url: .html_url, number: .number}")
-
+          
           if [[ -z "$pullRequest" ]]; then
             echo "No pull requests found for branch ${{ steps.create-commit.outputs.VERSION_BRANCH }}, creating new PR"
             response=$(gh api --method POST /repos/:owner/:repo/pulls \
@@ -186,20 +238,30 @@ jobs:
             --field body="This PR bumps the version to ${{ steps.tick-version.outputs.VERSION_TAG }}" \
             --field head="${{ steps.create-commit.outputs.VERSION_BRANCH }}" \
             --field base="${{ github.base_ref || 'main' }}")
-
+          
             pr_url=$(echo $response | jq -r '.html_url')
             pr_number=$(echo $response | jq -r '.number')
-
+          
             echo "pull-request-number=$pr_number" >> $GITHUB_OUTPUT
             echo "pull-request-url=$pr_url" >> $GITHUB_OUTPUT
-
+          
             # as a last step we create a label for PR
             gh api --method POST "/repos/:owner/:repo/issues/$pr_number/labels" -F "labels[]=version-bump"
           else
             echo "Pull requests found for branch ${{ steps.create-commit.outputs.VERSION_BRANCH }}, setting outputs"
+          
             pr_url=$(echo "$pullRequest" | jq -r '.url')
             pr_number=$(echo "$pullRequest" | jq -r '.number')
-
+          
+           #update the title and description of PR if there is new version bump commit 
+           if [ "${{ steps.create-commit.outputs.UPDATED_VERSION_TAG }}" != "" ]; then
+            echo "Found new version tag ${{ steps.create-commit.outputs.UPDATED_VERSION_TAG }} for PR, updating title and description"
+          
+            gh api --method PATCH /repos/:owner/:repo/pulls/$pr_number \
+            --field title="Bump version to ${{ steps.create-commit.outputs.UPDATED_VERSION_TAG }}" \
+            --field body="This PR bumps the version to ${{ steps.create-commit.outputs.UPDATED_VERSION_TAG }}"
+           fi
+          
             echo "pull-request-number=$pr_number" >> $GITHUB_OUTPUT
             echo "pull-request-url=$pr_url" >> $GITHUB_OUTPUT
           fi


### PR DESCRIPTION
[PDI-2099](https://smartcontract-it.atlassian.net/browse/PDI-2099)
This PR changes the logic for version-bump pr workflow. Previously each different labeled PR merges would create different Version bump PRs. For example given current version of 1.0.0, PR `A` labeled as `major` and PR `B` labeled as `patch` after the merge would create two version bump PRs, `version-bump/2.0.0-main` and `version-bump/1.0.1-main` respectively.

With the new logic a PR merge would create  just one version bump PR from  'version-bump' branch. In this case if other PRs are merged it will compare the versions and update the version bump PR if there is higher version change. 
The same example now. Given current version of 1.0.0, PR `A` is labeled as `major` and PR `B` labeled as `patch`. If `A` is merged first, version bump PR is created with version change from 1.0.0 to 2.0.0. After that `B` is merged, but since we already have a PR and version change from `B` (1.0.0 -> 1.0.1) is not higher (2.0.0) it will skip the step. 
If the `B` is merged first and then `A` then there will be two commits in the version bump PR, one changing version from 1.0.0 to 1.0.1 and second from 1.0.1 to 2.0.0.

The PR also modifies WORKFLOW-README.MD as there was outdated information about current actions and workflow

[PDI-2099]: https://smartcontract-it.atlassian.net/browse/PDI-2099?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ