### PR TITLE
PDI-63: Add startup check to verify that cache type is shareable when not setting EA to RW

### DIFF
--- a/src/adapter/basic.ts
+++ b/src/adapter/basic.ts
@@ -215,6 +215,13 @@ export class Adapter<CustomSettingsDefinition extends SettingsDefinitionMap = Se
   initializeDependencies(inputDependencies?: Partial<AdapterDependencies>): AdapterDependencies {
     const dependencies = inputDependencies || {}
 
+    if (
+      this.config.settings.EA_MODE !== 'reader-writer' &&
+      this.config.settings.CACHE_TYPE === 'local'
+    ) {
+      throw new Error(`EA mode cannot be ${this.config.settings.EA_MODE} while cache type is local`)
+    }
+
     if (this.config.settings.CACHE_TYPE === 'redis' && !dependencies.redisClient) {
       const maxCooldown = this.config.settings.CACHE_REDIS_MAX_RECONNECT_COOLDOWN
       const redisOptions = {


### PR DESCRIPTION
- Framework now throws an error if an EA is not in reader-writer mode while the cache type is set to local
- Added test for this check