### PR TITLE
move test utils to src

### DIFF
--- a/src/util/testing-utils.ts
+++ b/src/util/testing-utils.ts
@@ -475,7 +475,6 @@ export const mockWebSocketProvider = (provider: typeof WebSocketClassProvider): 
   provider.set(MockWebSocket as any) // eslint-disable-line @typescript-eslint/no-explicit-any
 }
 
-
 export function setEnvVariables(envVariables: NodeJS.ProcessEnv): void {
   for (const key in envVariables) {
     process.env[key] = envVariables[key]

--- a/src/util/testing-utils.ts
+++ b/src/util/testing-utils.ts
@@ -4,19 +4,19 @@ import { FastifyInstance } from 'fastify'
 import { ReplyError } from 'ioredis'
 import { WebSocket } from 'mock-socket'
 import * as client from 'prom-client'
-import { start } from '../src'
-import { Adapter, AdapterDependencies } from '../src/adapter'
-import { Cache, LocalCache } from '../src/cache'
-import { ResponseCache } from '../src/cache/response'
-import { EmptyCustomSettings, SettingsDefinitionMap } from '../src/config'
+import { start } from '../index'
+import { Adapter, AdapterDependencies } from '../adapter'
+import { Cache, LocalCache } from '../cache'
+import { ResponseCache } from '../cache/response'
+import { EmptyCustomSettings, SettingsDefinitionMap } from '../config'
 import {
   Transport,
   TransportDependencies,
   TransportGenerics,
   WebSocketClassProvider,
-} from '../src/transports'
-import { AdapterRequest, AdapterResponse, PartialAdapterResponse, sleep } from '../src/util'
-import { EmptyInputParameters, TypeFromDefinition } from '../src/validation/input-params'
+} from '../transports'
+import { AdapterRequest, AdapterResponse, PartialAdapterResponse, sleep } from './index'
+import { EmptyInputParameters, TypeFromDefinition } from '../validation/input-params'
 
 export type NopTransportTypes = {
   Parameters: EmptyInputParameters
@@ -27,6 +27,7 @@ export type NopTransportTypes = {
   Settings: EmptyCustomSettings
 }
 
+/* c8 ignore start */ // eslint-disable-line
 export class NopTransport<T extends TransportGenerics = NopTransportTypes> implements Transport<T> {
   name!: string
   responseCache!: ResponseCache<T>
@@ -473,3 +474,11 @@ export const mockWebSocketProvider = (provider: typeof WebSocketClassProvider): 
   // Need to disable typing, the mock-socket impl does not implement the ws interface fully
   provider.set(MockWebSocket as any) // eslint-disable-line @typescript-eslint/no-explicit-any
 }
+
+
+export function setEnvVariables(envVariables: NodeJS.ProcessEnv): void {
+  for (const key in envVariables) {
+    process.env[key] = envVariables[key]
+  }
+}
+/* c8 ignore stop */ // eslint-disable-line

--- a/test/adapter.test.ts
+++ b/test/adapter.test.ts
@@ -1,7 +1,7 @@
 import test from 'ava'
 import { expose, start } from '../src'
 import { Adapter, AdapterEndpoint } from '../src/adapter'
-import { NopTransport, TestAdapter } from './util'
+import { NopTransport, TestAdapter } from '../src/util/testing-utils'
 
 test('duplicate endpoint names throw error on startup', async (t) => {
   const adapter = new Adapter({

--- a/test/background-executor.test.ts
+++ b/test/background-executor.test.ts
@@ -4,7 +4,7 @@ import { start } from '../src'
 import { Adapter, AdapterEndpoint, EndpointContext } from '../src/adapter'
 import { metrics as eaMetrics } from '../src/metrics'
 import { deferredPromise, sleep } from '../src/util'
-import { NopTransport, NopTransportTypes, TestAdapter } from './util'
+import { NopTransport, NopTransportTypes, TestAdapter } from '../src/util/testing-utils'
 
 const test = untypedTest as TestFn<{
   testAdapter: TestAdapter

--- a/test/cache/cache-key.test.ts
+++ b/test/cache/cache-key.test.ts
@@ -5,7 +5,7 @@ import { AdapterConfig, BaseAdapterSettings, BaseSettingsDefinition } from '../.
 import { AdapterRequest, AdapterResponse } from '../../src/util'
 import { InputParameters } from '../../src/validation'
 import { InputParametersDefinition } from '../../src/validation/input-params'
-import { NopTransport, NopTransportTypes, TestAdapter } from '../util'
+import { NopTransport, NopTransportTypes, TestAdapter } from '../../src/util/testing-utils'
 
 const test = untypedTest as TestFn<{
   testAdapter: TestAdapter

--- a/test/cache/helper.ts
+++ b/test/cache/helper.ts
@@ -5,7 +5,7 @@ import { EmptyCustomSettings } from '../../src/config'
 import { AdapterRequest } from '../../src/util'
 import { InputParameters } from '../../src/validation'
 import { TypeFromDefinition } from '../../src/validation/input-params'
-import { NopTransport, NopTransportTypes, TestAdapter } from '../util'
+import { NopTransport, NopTransportTypes, TestAdapter } from '../../src/util/testing-utils'
 
 export const test = untypedTest as TestFn<{
   cache: Cache

--- a/test/cache/local.test.ts
+++ b/test/cache/local.test.ts
@@ -4,7 +4,7 @@ import { Adapter, AdapterDependencies, AdapterEndpoint } from '../../src/adapter
 import { Cache, CacheFactory, LocalCache } from '../../src/cache'
 import { AdapterConfig } from '../../src/config'
 import { PartialAdapterResponse } from '../../src/util'
-import { NopTransport, TestAdapter, runAllUntilTime } from '../util'
+import { NopTransport, TestAdapter, runAllUntilTime } from '../../src/util/testing-utils'
 import { BasicCacheSetterTransport, cacheTestInputParameters } from './helper'
 
 const test = untypedTest as TestFn<{

--- a/test/cache/redis.test.ts
+++ b/test/cache/redis.test.ts
@@ -2,7 +2,7 @@ import Redis from 'ioredis'
 import { Adapter, AdapterDependencies, AdapterEndpoint } from '../../src/adapter'
 import { CacheFactory, RedisCache } from '../../src/cache'
 import { AdapterConfig } from '../../src/config'
-import { NopTransport, RedisMock, TestAdapter } from '../util'
+import { NopTransport, RedisMock, TestAdapter } from '../../src/util/testing-utils'
 import {
   BasicCacheSetterTransport,
   buildDiffResultAdapter,

--- a/test/cache/response-cache.test.ts
+++ b/test/cache/response-cache.test.ts
@@ -5,7 +5,7 @@ import { Adapter, AdapterEndpoint } from '../../src/adapter'
 import { AdapterConfig, SettingsDefinitionFromConfig } from '../../src/config'
 import { AdapterRequest } from '../../src/util'
 import { TypeFromDefinition } from '../../src/validation/input-params'
-import { NopTransport, TestAdapter, assertEqualResponses } from '../util'
+import { NopTransport, TestAdapter, assertEqualResponses } from '../../src/util/testing-utils'
 import { CacheTestTransportTypes } from './helper'
 
 const test = untypedTest as TestFn<{

--- a/test/correlation.test.ts
+++ b/test/correlation.test.ts
@@ -2,7 +2,7 @@ import untypedTest, { ExecutionContext, TestFn } from 'ava'
 import { Adapter, AdapterEndpoint } from '../src/adapter'
 import { AdapterResponse, sleep } from '../src/util'
 import { Store, asyncLocalStorage } from '../src/util/logger'
-import { NopTransport, NopTransportTypes, TestAdapter } from './util'
+import { NopTransport, NopTransportTypes, TestAdapter } from '../src/util/testing-utils'
 
 type TestContext = {
   testAdapter: TestAdapter

--- a/test/error.test.ts
+++ b/test/error.test.ts
@@ -11,7 +11,7 @@ import {
   AdapterRateLimitError,
   AdapterTimeoutError,
 } from '../src/validation/error'
-import { NopTransport, NopTransportTypes, TestAdapter, assertEqualResponses } from './util'
+import { NopTransport, NopTransportTypes, TestAdapter, assertEqualResponses } from '../src/util/testing-utils'
 
 type TestContext = {
   testAdapter: TestAdapter

--- a/test/error.test.ts
+++ b/test/error.test.ts
@@ -11,7 +11,12 @@ import {
   AdapterRateLimitError,
   AdapterTimeoutError,
 } from '../src/validation/error'
-import { NopTransport, NopTransportTypes, TestAdapter, assertEqualResponses } from '../src/util/testing-utils'
+import {
+  NopTransport,
+  NopTransportTypes,
+  TestAdapter,
+  assertEqualResponses,
+} from '../src/util/testing-utils'
 
 type TestContext = {
   testAdapter: TestAdapter

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -2,7 +2,7 @@ import untypedTest, { TestFn } from 'ava'
 import { expose, start } from '../src'
 import { Adapter, AdapterEndpoint } from '../src/adapter'
 import { AdapterConfig } from '../src/config'
-import { NopTransport, TestAdapter } from './util'
+import { NopTransport, TestAdapter } from '../src/util/testing-utils'
 
 const test = untypedTest as TestFn<{
   testAdapter: TestAdapter

--- a/test/logger.test.ts
+++ b/test/logger.test.ts
@@ -4,7 +4,7 @@ import { Adapter, AdapterEndpoint } from '../src/adapter'
 import { AdapterConfig, SettingsDefinitionMap } from '../src/config'
 import CensorList from '../src/util/censor/censor-list'
 import { COLORS, censor, colorFactory } from '../src/util/logger'
-import { NopTransport } from './util'
+import { NopTransport } from '../src/util/testing-utils'
 
 test.before(async () => {
   const customSettings = {

--- a/test/metrics/metrics.test.ts
+++ b/test/metrics/metrics.test.ts
@@ -7,7 +7,7 @@ import { AdapterConfig, EmptyCustomSettings } from '../../src/config'
 import { Metrics, retrieveCost } from '../../src/metrics'
 import { HttpTransport } from '../../src/transports'
 import { InputParameters } from '../../src/validation'
-import { TestAdapter } from '../util'
+import { TestAdapter } from '../../src/util/testing-utils'
 
 const test = untypedTest as TestFn<{
   testAdapter: TestAdapter

--- a/test/metrics/polling-metrics.test.ts
+++ b/test/metrics/polling-metrics.test.ts
@@ -1,6 +1,6 @@
 import FakeTimers, { InstalledClock } from '@sinonjs/fake-timers'
 import untypedTest, { TestFn } from 'ava'
-import { TestAdapter } from '../util'
+import { TestAdapter } from '../../src/util/testing-utils'
 import { buildHttpAdapter } from './helper'
 import MockAdapter from 'axios-mock-adapter'
 import axios from 'axios'

--- a/test/metrics/redis-metrics.test.ts
+++ b/test/metrics/redis-metrics.test.ts
@@ -4,7 +4,7 @@ import { Adapter, AdapterDependencies, AdapterEndpoint, EndpointGenerics } from 
 import { Cache, RedisCache } from '../../src/cache'
 import { AdapterConfig } from '../../src/config'
 import { BasicCacheSetterTransport, cacheTestInputParameters } from '../cache/helper'
-import { NopTransport, RedisMock, TestAdapter } from '../util'
+import { NopTransport, RedisMock, TestAdapter } from '../../src/util/testing-utils'
 
 export const test = untypedTest as TestFn<{
   testAdapter: TestAdapter

--- a/test/metrics/warmer-metrics.test.ts
+++ b/test/metrics/warmer-metrics.test.ts
@@ -2,7 +2,7 @@ import FakeTimers, { InstalledClock } from '@sinonjs/fake-timers'
 import untypedTest, { TestFn } from 'ava'
 import axios from 'axios'
 import MockAdapter from 'axios-mock-adapter'
-import { runAllUntilTime, TestAdapter } from '../util'
+import { runAllUntilTime, TestAdapter } from '../../src/util/testing-utils'
 import { buildHttpAdapter } from './helper'
 
 const test = untypedTest as TestFn<{

--- a/test/metrics/ws-metrics.test.ts
+++ b/test/metrics/ws-metrics.test.ts
@@ -5,7 +5,7 @@ import { Adapter, AdapterEndpoint } from '../../src/adapter'
 import { AdapterConfig, EmptyCustomSettings } from '../../src/config'
 import { WebSocketClassProvider, WebSocketTransport } from '../../src/transports'
 import { InputParameters } from '../../src/validation'
-import { TestAdapter, mockWebSocketProvider } from '../util'
+import { TestAdapter, mockWebSocketProvider } from '../../src/util/testing-utils'
 
 export const test = untypedTest as TestFn<{
   adapterEndpoint: AdapterEndpoint<WebSocketEndpointTypes>

--- a/test/overrides.test.ts
+++ b/test/overrides.test.ts
@@ -5,7 +5,7 @@ import { Transport, TransportGenerics } from '../src/transports'
 import { AdapterRequest } from '../src/util'
 import { InputParameters } from '../src/validation'
 import { TypeFromDefinition } from '../src/validation/input-params'
-import { TestAdapter } from './util'
+import { TestAdapter } from '../src/util/testing-utils'
 
 const test = untypedTest as TestFn<{
   testAdapter: TestAdapter

--- a/test/price.test.ts
+++ b/test/price.test.ts
@@ -15,7 +15,7 @@ import { HttpTransport, Transport } from '../src/transports'
 import { AdapterRequest, AdapterResponse, SingleNumberResultResponse } from '../src/util'
 import { InputParameters } from '../src/validation'
 import { TypeFromDefinition } from '../src/validation/input-params'
-import { NopTransport, TestAdapter } from './util'
+import { NopTransport, TestAdapter } from '../src/util/testing-utils'
 
 type TestContext = {
   testAdapter: TestAdapter

--- a/test/rate-limit-config.test.ts
+++ b/test/rate-limit-config.test.ts
@@ -8,7 +8,7 @@ import {
   highestRateLimitTiers,
 } from '../src/rate-limiting'
 import { RateLimiterFactory, RateLimitingStrategy } from '../src/rate-limiting/factory'
-import { NopTransport } from './util'
+import { NopTransport } from '../src/util/testing-utils'
 
 test('empty tiers in rate limiting fails on startup', async (t) => {
   const adapter = new Adapter({

--- a/test/subscription-set/redis-subscription-set.test.ts
+++ b/test/subscription-set/redis-subscription-set.test.ts
@@ -8,7 +8,7 @@ import { AdapterConfig, EmptyCustomSettings } from '../../src/config'
 import { HttpTransport, TransportRoutes } from '../../src/transports'
 import { SingleNumberResultResponse } from '../../src/util'
 import { InputParameters } from '../../src/validation'
-import { TestAdapter, assertEqualResponses, runAllUntilTime } from '../util'
+import { TestAdapter, assertEqualResponses, runAllUntilTime } from '../../src/util/testing-utils'
 
 export const test = untypedTest as TestFn<{
   testAdapter: TestAdapter

--- a/test/subscription-set/subscription-set-factory.test.ts
+++ b/test/subscription-set/subscription-set-factory.test.ts
@@ -4,7 +4,7 @@ import { buildAdapterSettings } from '../../src/config'
 import { SubscriptionSetFactory } from '../../src/util'
 import { ExpiringSortedSet } from '../../src/util/subscription-set/expiring-sorted-set'
 import { RedisSubscriptionSet } from '../../src/util/subscription-set/redis-sorted-set'
-import { RedisMock } from '../util'
+import { RedisMock } from '../../src/util/testing-utils'
 
 test('subscription set factory (local cache)', async (t) => {
   process.env['CACHE_TYPE'] = 'local'

--- a/test/transports/http.test.ts
+++ b/test/transports/http.test.ts
@@ -11,7 +11,13 @@ import { RateLimitingStrategy } from '../../src/rate-limiting/factory'
 import { HttpTransport } from '../../src/transports'
 import { ProviderResult, SingleNumberResultResponse, sleep } from '../../src/util'
 import { InputParameters } from '../../src/validation'
-import { MockCache, TestAdapter, assertEqualResponses, runAllUntil, runAllUntilTime } from '../util'
+import {
+  MockCache,
+  TestAdapter,
+  assertEqualResponses,
+  runAllUntil,
+  runAllUntilTime,
+} from '../../src/util/testing-utils'
 
 const test = untypedTest as TestFn<{
   clock: InstalledClock

--- a/test/transports/routing.test.ts
+++ b/test/transports/routing.test.ts
@@ -17,7 +17,7 @@ import {
   WebSocketTransport,
 } from '../../src/transports'
 import { InputParameters } from '../../src/validation'
-import { TestAdapter, mockWebSocketProvider } from '../util'
+import { TestAdapter, mockWebSocketProvider } from '../../src/util/testing-utils'
 
 const test = untypedTest as TestFn<{
   testAdapter: TestAdapter<SettingsDefinitionFromConfig<typeof adapterConfig>>

--- a/test/transports/sse.test.ts
+++ b/test/transports/sse.test.ts
@@ -7,7 +7,7 @@ import { AdapterConfig, EmptyCustomSettings } from '../../src/config'
 import { SSEConfig, SseTransport } from '../../src/transports'
 import { ProviderResult, SingleNumberResultResponse } from '../../src/util'
 import { InputParameters } from '../../src/validation'
-import { TestAdapter } from '../util'
+import { TestAdapter } from '../../src/util/testing-utils'
 const { MockEvent, EventSource } = require('mocksse') // eslint-disable-line
 
 const URL = 'http://test.com'

--- a/test/transports/websocket.test.ts
+++ b/test/transports/websocket.test.ts
@@ -11,7 +11,7 @@ import {
 } from '../../src/transports'
 import { SingleNumberResultResponse } from '../../src/util'
 import { InputParameters } from '../../src/validation'
-import { TestAdapter, mockWebSocketProvider, runAllUntilTime } from '../util'
+import { TestAdapter, mockWebSocketProvider, runAllUntilTime } from '../../src/util/testing-utils'
 
 export const test = untypedTest as TestFn<{
   testAdapter: TestAdapter

--- a/test/validation.test.ts
+++ b/test/validation.test.ts
@@ -6,7 +6,7 @@ import { InputParameters } from '../src/validation'
 import { AdapterInputError } from '../src/validation/error'
 import { EmptyInputParameters } from '../src/validation/input-params'
 import { validator } from '../src/validation/utils'
-import { NopTransport, NopTransportTypes, TestAdapter } from './util'
+import { NopTransport, NopTransportTypes, TestAdapter } from '../src/util/testing-utils'
 
 const test = untypedTest as TestFn<{
   testAdapter: TestAdapter


### PR DESCRIPTION
This PR moves `test/utils.ts` file to `src/util/testing-utils.ts` and updates all the references. The change is required so that the testing utils are exported and can be used in EA integration tests in monorepo. 
The new `src/util/testing-utils.ts` is set to be excluded from testing coverage since the previous file was never part of a coverage and the functions in the file are used only in tests, not in src. 