### PR TITLE
(workaround) Put logs that would expose the input parameters object behind a feature flag

### DIFF
--- a/src/adapter/basic.ts
+++ b/src/adapter/basic.ts
@@ -215,6 +215,10 @@ export class Adapter<CustomSettingsDefinition extends SettingsDefinitionMap = Se
   initializeDependencies(inputDependencies?: Partial<AdapterDependencies>): AdapterDependencies {
     const dependencies = inputDependencies || {}
 
+    if (this.config.settings.LOG_INPUT_PARAMS === true) {
+      process.env['LOG_INPUT_PARAMS'] = 'true'
+    }
+
     if (
       this.config.settings.EA_MODE !== 'reader-writer' &&
       this.config.settings.CACHE_TYPE === 'local'

--- a/src/adapter/basic.ts
+++ b/src/adapter/basic.ts
@@ -14,7 +14,13 @@ import {
   highestRateLimitTiers,
 } from '../rate-limiting'
 import { RateLimiterFactory, RateLimitingStrategy } from '../rate-limiting/factory'
-import { AdapterRequest, AdapterResponse, SubscriptionSetFactory, makeLogger } from '../util'
+import {
+  AdapterRequest,
+  AdapterResponse,
+  SubscriptionSetFactory,
+  censorLogs,
+  makeLogger,
+} from '../util'
 import { Requester } from '../util/requester'
 import { AdapterTimeoutError } from '../validation/error'
 import { EmptyInputParameters } from '../validation/input-params'
@@ -215,8 +221,8 @@ export class Adapter<CustomSettingsDefinition extends SettingsDefinitionMap = Se
   initializeDependencies(inputDependencies?: Partial<AdapterDependencies>): AdapterDependencies {
     const dependencies = inputDependencies || {}
 
-    if (this.config.settings.LOG_INPUT_PARAMS === true) {
-      process.env['LOG_INPUT_PARAMS'] = 'true'
+    if (this.config.settings.LOG_CENSOR === false) {
+      process.env['LOG_CENSOR'] = 'false'
     }
 
     if (
@@ -394,7 +400,7 @@ export class Adapter<CustomSettingsDefinition extends SettingsDefinitionMap = Se
           // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
           return await transport.registerRequest!(req, this.config.settings)
         } catch (err) {
-          logger.error(`Error registering request: ${err}`)
+          censorLogs(() => logger.error(`Error registering request: ${err}`))
           requestRegistrationError = err as Error
         }
       }

--- a/src/adapter/basic.ts
+++ b/src/adapter/basic.ts
@@ -221,10 +221,6 @@ export class Adapter<CustomSettingsDefinition extends SettingsDefinitionMap = Se
   initializeDependencies(inputDependencies?: Partial<AdapterDependencies>): AdapterDependencies {
     const dependencies = inputDependencies || {}
 
-    if (this.config.settings.LOG_CENSOR === false) {
-      process.env['LOG_CENSOR'] = 'false'
-    }
-
     if (
       this.config.settings.EA_MODE !== 'reader-writer' &&
       this.config.settings.CACHE_TYPE === 'local'

--- a/src/background-executor.ts
+++ b/src/background-executor.ts
@@ -1,7 +1,7 @@
 import { Adapter, AdapterEndpoint, EndpointContext, EndpointGenerics } from './adapter'
 import { metrics } from './metrics'
 import { Transport, TransportGenerics } from './transports'
-import { asyncLocalStorage, makeLogger, timeoutPromise } from './util'
+import { asyncLocalStorage, censorLogs, makeLogger, timeoutPromise } from './util'
 
 const logger = makeLogger('BackgroundExecutor')
 
@@ -82,7 +82,7 @@ export async function callBackgroundExecutes(adapter: Adapter, apiShutdownPromis
           adapter.config.settings.BACKGROUND_EXECUTE_TIMEOUT,
         )
       } catch (error) {
-        logger.error(error, (error as Error).stack)
+        censorLogs(() => logger.error(error, (error as Error).stack))
         metrics
           .get('bgExecuteErrors')
           .labels({ adapter_endpoint: endpoint.name, transport: transportName })

--- a/src/cache/index.ts
+++ b/src/cache/index.ts
@@ -1,6 +1,6 @@
 import crypto from 'crypto'
 import { EndpointContext, EndpointGenerics } from '../adapter'
-import { AdapterResponse, makeLogger, sleep } from '../util'
+import { AdapterResponse, censorLogs, makeLogger, sleep } from '../util'
 import { CacheTypes as CacheType } from './metrics'
 
 export * from './factory'
@@ -82,7 +82,7 @@ export const calculateCacheKey = <T extends EndpointGenerics>({
     transportName,
   })
   const cacheKey = `${adapterName}-${calculatedKey}`
-  logger.trace(`Generated cache key for request: "${cacheKey}"`)
+  censorLogs(() => logger.trace(`Generated cache key for request: "${cacheKey}"`))
   return cacheKey
 }
 
@@ -102,7 +102,7 @@ export const calculateHttpRequestKey = <T extends EndpointGenerics>({
     adapterSettings: context.adapterSettings,
     endpointName: context.endpointName,
   })
-  logger.trace(`Generated HTTP request queue key: "${key}"`)
+  censorLogs(() => logger.trace(`Generated HTTP request queue key: "${key}"`))
   return key
 }
 

--- a/src/cache/response.ts
+++ b/src/cache/response.ts
@@ -2,12 +2,13 @@ import { AdapterDependencies } from '../adapter'
 import { AdapterSettings } from '../config'
 import {
   AdapterResponse,
-  censor,
-  makeLogger,
   ResponseGenerics,
   TimestampedAdapterResponse,
   TimestampedProviderErrorResponse,
   TimestampedProviderResult,
+  censor,
+  censorLogs,
+  makeLogger,
 } from '../util'
 import CensorList from '../util/censor/censor-list'
 import { InputParameters, InputParametersDefinition } from '../validation/input-params'
@@ -75,7 +76,7 @@ export class ResponseCache<
             T['Response']
           >
         } catch (error) {
-          logger.error(`Error censoring response: ${error}`)
+          censorLogs(() => logger.error(`Error censoring response: ${error}`))
           censoredResponse = {
             statusCode: 502,
             errorMessage: 'Response could not be censored due to an error',
@@ -110,7 +111,7 @@ export class ResponseCache<
         const timestampValidator = validator.responseTimestamp()
         const error = timestampValidator.fn(response.timestamps?.providerIndicatedTimeUnixMs)
         if (error) {
-          logger.warn(`Provider indicated time is invalid: ${error}`)
+          censorLogs(() => logger.warn(`Provider indicated time is invalid: ${error}`))
         }
       }
 

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -138,6 +138,11 @@ export const BaseSettingsDefinition = {
     type: 'string',
     default: 'info',
   },
+  LOG_INPUT_PARAMS: {
+    description: 'Controls whether logging of the input parameters object is enabled or disabled',
+    type: 'boolean',
+    default: true,
+  },
   MAX_PAYLOAD_SIZE_LIMIT: {
     description: 'Max payload size limit for the Fastify server',
     type: 'number',

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -138,10 +138,10 @@ export const BaseSettingsDefinition = {
     type: 'string',
     default: 'info',
   },
-  LOG_INPUT_PARAMS: {
-    description: 'Controls whether logging of the input parameters object is enabled or disabled',
+  LOG_CENSOR: {
+    description: 'Controls whether the logging of sensitive information is enabled or disabled',
     type: 'boolean',
-    default: true,
+    default: false,
   },
   MAX_PAYLOAD_SIZE_LIMIT: {
     description: 'Max payload size limit for the Fastify server',

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -138,7 +138,7 @@ export const BaseSettingsDefinition = {
     type: 'string',
     default: 'info',
   },
-  LOG_CENSOR: {
+  CENSOR_SENSITIVE_LOGS: {
     description: 'Controls whether the logging of sensitive information is enabled or disabled',
     type: 'boolean',
     default: false,

--- a/src/metrics/index.ts
+++ b/src/metrics/index.ts
@@ -3,7 +3,7 @@ import { join } from 'path'
 import * as client from 'prom-client'
 import { AdapterSettings } from '../config'
 import { getTLSOptions, httpsOptions } from '../index'
-import { AdapterRequest, makeLogger } from '../util'
+import { AdapterRequest, censorLogs, makeLogger } from '../util'
 import { AdapterError } from '../validation/error'
 import { EmptyInputParameters } from '../validation/input-params'
 import { HttpRequestType, requestDurationBuckets } from './constants'
@@ -74,7 +74,7 @@ export const buildMetricsMiddleware = (
 
   // Record response time of request through entire EA
   metrics.get('httpRequestDurationSeconds').observe(res.getResponseTime() / 1000)
-  logger.debug(`Response time for ${feedId}: ${res.getResponseTime()}ms`)
+  censorLogs(() => logger.debug(`Response time for ${feedId}: ${res.getResponseTime()}ms`))
   done()
 }
 

--- a/src/transports/abstract/streaming.ts
+++ b/src/transports/abstract/streaming.ts
@@ -1,6 +1,6 @@
 import { TransportGenerics } from '..'
 import { EndpointContext } from '../../adapter'
-import { makeLogger } from '../../util'
+import { censorLogs, makeLogger } from '../../util'
 import { TypeFromDefinition } from '../../validation/input-params'
 import { SubscriptionTransport } from './subscription'
 
@@ -56,10 +56,10 @@ export abstract class StreamingTransport<
       `${subscriptions.new.length} new subscriptions; ${subscriptions.stale.length} to unsubscribe`,
     )
     if (subscriptions.new.length) {
-      logger.trace(`Will subscribe to: ${JSON.stringify(subscriptions.new)}`)
+      censorLogs(() => logger.trace(`Will subscribe to: ${JSON.stringify(subscriptions.new)}`))
     }
     if (subscriptions.stale.length) {
-      logger.trace(`Will unsubscribe to: ${JSON.stringify(subscriptions.stale)}`)
+      censorLogs(() => logger.trace(`Will unsubscribe to: ${JSON.stringify(subscriptions.stale)}`))
     }
 
     await this.streamHandler(context, subscriptions)

--- a/src/transports/abstract/subscription.ts
+++ b/src/transports/abstract/subscription.ts
@@ -2,7 +2,7 @@ import { Transport, TransportDependencies, TransportGenerics } from '..'
 import { EndpointContext } from '../../adapter'
 import { ResponseCache } from '../../cache/response'
 import { metrics } from '../../metrics'
-import { SubscriptionSet, makeLogger } from '../../util'
+import { SubscriptionSet, censorLogs, makeLogger } from '../../util'
 import { AdapterRequest } from '../../util/types'
 import { TypeFromDefinition } from '../../validation/input-params'
 
@@ -38,8 +38,10 @@ export abstract class SubscriptionTransport<const T extends TransportGenerics>
     req: AdapterRequest<TypeFromDefinition<T['Parameters']>>,
     _: T['Settings'],
   ): Promise<void> {
-    logger.debug(
-      `Adding entry to subscription set (ttl ${this.subscriptionTtl}): [${req.requestContext.cacheKey}] = ${req.requestContext.data}`,
+    censorLogs(() =>
+      logger.debug(
+        `Adding entry to subscription set (ttl ${this.subscriptionTtl}): [${req.requestContext.cacheKey}] = ${req.requestContext.data}`,
+      ),
     )
 
     // This might need coalescing to avoid too frequent ttl updates

--- a/src/transports/http.ts
+++ b/src/transports/http.ts
@@ -3,7 +3,7 @@ import { TransportDependencies, TransportGenerics } from '.'
 import { EndpointContext } from '../adapter'
 import { calculateHttpRequestKey } from '../cache'
 import { metrics, retrieveCost } from '../metrics'
-import { makeLogger, sleep } from '../util'
+import { censorLogs, makeLogger, sleep } from '../util'
 import { Requester } from '../util/requester'
 import { PartialSuccessfulResponse, ProviderResult, TimestampedProviderResult } from '../util/types'
 import { AdapterDataProviderError, AdapterRateLimitError } from '../validation/error'
@@ -259,7 +259,7 @@ export class HttpTransport<T extends HttpTransportGenerics> extends Subscription
         const err = e as AdapterDataProviderError
         const cause = err.cause as AxiosError
         const errorMessage = `Provider request failed with status ${cause.status}: "${cause.response?.data}"`
-        logger.info(errorMessage)
+        censorLogs(() => logger.info(errorMessage))
         return {
           results: requestConfig.params.map((entry) => ({
             params: entry,
@@ -272,7 +272,7 @@ export class HttpTransport<T extends HttpTransportGenerics> extends Subscription
         }
       } else if (e instanceof AdapterRateLimitError) {
         const err = e as AdapterRateLimitError
-        logger.info(err.message)
+        censorLogs(() => logger.info(err.message))
         return {
           results: requestConfig.params.map((entry) => ({
             params: entry,
@@ -289,7 +289,7 @@ export class HttpTransport<T extends HttpTransportGenerics> extends Subscription
           msUntilNextExecution: err.msUntilNextExecution,
         }
       } else {
-        logger.error(e)
+        censorLogs(() => logger.error(e))
         return { results: [] }
       }
     }

--- a/src/transports/websocket.ts
+++ b/src/transports/websocket.ts
@@ -315,7 +315,7 @@ export class WebSocketTransport<
       const reason = urlChanged
         ? `Websocket url has changed from ${this.currentUrl} to ${urlFromConfig}, closing connection...`
         : `Last message was received ${timeSinceLastMessage} ago, exceeding the threshold of ${context.adapterSettings.WS_SUBSCRIPTION_UNRESPONSIVE_TTL}ms, closing connection...`
-      logger.info(reason)
+      censorLogs(() => logger.info(reason))
 
       // Check if connection was opened very recently; if so, wait a bit before continuing.
       // This is so if we just opened the connection and are waiting to receive some messages,
@@ -330,10 +330,12 @@ export class WebSocketTransport<
       connectionClosed = true
 
       if (subscriptions.desired.length) {
-        logger.trace(
-          `Connection will be reopened and will subscribe to new and resubscribe to existing: ${JSON.stringify(
-            subscriptions.desired,
-          )}`,
+        censorLogs(() =>
+          logger.trace(
+            `Connection will be reopened and will subscribe to new and resubscribe to existing: ${JSON.stringify(
+              subscriptions.desired,
+            )}`,
+          ),
         )
       }
     }

--- a/src/util/logger.ts
+++ b/src/util/logger.ts
@@ -156,7 +156,7 @@ export function censor(obj: any, censorList: CensorKeyValue[], throwOnError = fa
 }
 
 export const censorLogs = (logFunc: () => void) => {
-  if (process.env['LOG_INPUT_PARAMS'] === 'true') {
+  if (process.env['LOG_CENSOR'] === 'false') {
     logFunc()
   }
   return

--- a/src/util/logger.ts
+++ b/src/util/logger.ts
@@ -156,8 +156,8 @@ export function censor(obj: any, censorList: CensorKeyValue[], throwOnError = fa
 }
 
 export const censorLogs = (logFunc: () => void) => {
-  if (process.env['LOG_CENSOR'] === 'false') {
-    logFunc()
+  if (process.env['CENSOR_SENSITIVE_LOGS'] === 'true') {
+    return
   }
-  return
+  logFunc()
 }

--- a/src/util/logger.ts
+++ b/src/util/logger.ts
@@ -154,3 +154,10 @@ export function censor(obj: any, censorList: CensorKeyValue[], throwOnError = fa
   })
   return JSON.parse(result)
 }
+
+export const censorLogs = (logFunc: () => void) => {
+  if (process.env['LOG_INPUT_PARAMS'] === 'true') {
+    logFunc()
+  }
+  return
+}

--- a/src/validation/error.ts
+++ b/src/validation/error.ts
@@ -10,6 +10,15 @@ type ErrorFull = ErrorBasic & {
   cause: string
 }
 
+export type ErrorWithContext = {
+  error: {
+    name: string
+    stack: string | undefined
+    message: string
+  }
+  reqBody?: unknown
+}
+
 export type AdapterErrorResponse = {
   status: string
   statusCode: number

--- a/src/validation/error.ts
+++ b/src/validation/error.ts
@@ -10,15 +10,6 @@ type ErrorFull = ErrorBasic & {
   cause: string
 }
 
-export type ErrorWithContext = {
-  error: {
-    name: string
-    stack: string | undefined
-    message: string
-  }
-  reqBody?: unknown
-}
-
 export type AdapterErrorResponse = {
   status: string
   statusCode: number


### PR DESCRIPTION
- Added an optional CENSOR_SENSITIVE_LOGS setting that defaults to false
- If set to true, sensitive logs will not be run


Linked ticket: https://smartcontract-it.atlassian.net/browse/PDI-2152