### PR TITLE
fix status_code for metrics

### DIFF
--- a/src/metrics/index.ts
+++ b/src/metrics/index.ts
@@ -67,6 +67,7 @@ export const buildMetricsMiddleware = (
     feedId,
     req.requestContext?.meta?.error,
     req.requestContext?.meta?.metrics?.cacheHit,
+    res.statusCode,
   )
 
   // Record number of requests sent to EA
@@ -128,6 +129,7 @@ export const buildHttpRequestMetricsLabel = (
   feedId: string,
   error?: AdapterError | Error,
   cacheHit?: boolean,
+  responseStatusCode?: number,
 ): Record<string, string | number | undefined> => {
   const labels = {} as Record<(typeof httpRequestsTotalLabels)[number], string | number | undefined>
   labels.method = 'POST'
@@ -143,7 +145,7 @@ export const buildHttpRequestMetricsLabel = (
     labels.status_code = 500
   } else {
     // If no error present, request went as expected
-    labels.status_code = 200
+    labels.status_code = responseStatusCode || 200
     if (cacheHit) {
       labels.type = HttpRequestType.CACHE_HIT
     } else {

--- a/src/validation/index.ts
+++ b/src/validation/index.ts
@@ -135,9 +135,18 @@ export const validatorMiddleware: AdapterMiddlewareBuilder =
 
 export const errorCatchingMiddleware = (err: Error, req: FastifyRequest, res: FastifyReply) => {
   // Add adapter or generic error to request meta for metrics use
-  // There's a chance we have no request context if there was an error during input validation
+  // There's a chance we have no request context if there was an error during input validation,
+  // but we still want to include error in meta for metrics
   if (req.requestContext) {
     req.requestContext.meta = { ...req.requestContext?.meta, error: err }
+  } else {
+    req.requestContext = {
+      cacheKey: '',
+      data: undefined,
+      endpointName: '',
+      transportName: '',
+      meta: { error: err },
+    }
   }
 
   // Add the request context to the error so that we can check things like incoming params, endpoint, etc

--- a/src/validation/index.ts
+++ b/src/validation/index.ts
@@ -140,11 +140,12 @@ export const errorCatchingMiddleware = (err: Error, req: FastifyRequest, res: Fa
   if (req.requestContext) {
     req.requestContext.meta = { ...req.requestContext?.meta, error: err }
   } else {
+    const errorLabel = 'inputValidationError'
     req.requestContext = {
-      cacheKey: '',
+      cacheKey: errorLabel,
       data: undefined,
-      endpointName: '',
-      transportName: '',
+      endpointName: errorLabel,
+      transportName: errorLabel,
       meta: { error: err },
     }
   }

--- a/test/metrics/labels.test.ts
+++ b/test/metrics/labels.test.ts
@@ -20,6 +20,23 @@ test('Generate cache label test', (t) => {
   )
 })
 
+test('Generate http request metrics label test (response status code)', (t) => {
+  const label = buildHttpRequestMetricsLabel(
+    'test-{"base":"eth","quote":"btc"}',
+    undefined,
+    false,
+    400,
+  )
+  const result = {
+    feed_id: 'test-{"base":"eth","quote":"btc"}',
+    method: 'POST',
+    status_code: 400,
+    provider_status_code: 200,
+    type: HttpRequestType.DATA_PROVIDER_HIT,
+  }
+  t.deepEqual(label, result)
+})
+
 test('Generate http request metrics label test (adapter error)', (t) => {
   const label = buildHttpRequestMetricsLabel(
     'test-{"base":"eth","quote":"btc"}',


### PR DESCRIPTION
[PDI-226](https://smartcontract-it.atlassian.net/browse/PDI-2226)
This PR fixes bug with status_code property of http metrics where it  was 200 while response from EA was 4xx. Now the status_code will be the same as response status code if there are no errors. 