### PR TITLE
Allow logger injection

### DIFF
--- a/src/adapter/types.ts
+++ b/src/adapter/types.ts
@@ -4,7 +4,7 @@ import { Cache } from '../cache'
 import { AdapterConfig, BaseAdapterSettings, SettingsDefinitionMap } from '../config'
 import { AdapterRateLimitTier, RateLimiter } from '../rate-limiting'
 import { Transport, TransportGenerics, TransportRoutes } from '../transports'
-import { AdapterRequest, SubscriptionSetFactory } from '../util'
+import { AdapterRequest, LoggerFactory, SubscriptionSetFactory } from '../util'
 import { Requester } from '../util/requester'
 import { InputParameters } from '../validation'
 import { AdapterError } from '../validation/error'
@@ -38,6 +38,9 @@ export interface AdapterDependencies {
 
   /** Shared instance to handle sending http requests in a centralized fashion */
   requester: Requester
+
+  /** Factory that will provide logger instances for the adapter. */
+  loggerFactory: LoggerFactory
 }
 
 /**

--- a/test/custom-logger.test.ts
+++ b/test/custom-logger.test.ts
@@ -1,0 +1,52 @@
+import test from 'ava'
+import { start } from '../src'
+import { Adapter, AdapterEndpoint } from '../src/adapter'
+import { LoggerFactory } from '../src/util/logger'
+import { NopTransport } from '../src/util/testing-utils'
+
+test('custom logger instance is properly injected', async (t) => {
+  let timesCalled = 0
+
+  const loggerFactory: LoggerFactory = {
+    child: () => {
+      return {
+        fatal: () => {
+          timesCalled++
+        },
+        error: () => {
+          timesCalled++
+        },
+        warn: () => {
+          timesCalled++
+        },
+        info: () => {
+          timesCalled++
+        },
+        debug: () => {
+          timesCalled++
+        },
+        trace: () => {
+          timesCalled++
+        },
+      }
+    },
+  }
+
+  const adapter = new Adapter({
+    name: 'TEST',
+    endpoints: [
+      new AdapterEndpoint({
+        name: 'test',
+        transport: new NopTransport(),
+      }),
+    ],
+  })
+
+  t.is(timesCalled, 0)
+
+  await start(adapter, {
+    loggerFactory,
+  })
+
+  t.true(timesCalled > 0)
+})

--- a/test/metrics/feed-id.test.ts
+++ b/test/metrics/feed-id.test.ts
@@ -1,26 +1,31 @@
 import untypedTest, { TestFn } from 'ava'
 import { calculateFeedId } from '../../src/cache'
 import { AdapterSettings, buildAdapterSettings } from '../../src/config'
+import { LoggerFactoryProvider } from '../../src/util'
 import { InputParameters } from '../../src/validation'
 import { InputParametersDefinition } from '../../src/validation/input-params'
 
-const feedIdTest = untypedTest as TestFn<{
+const test = untypedTest as TestFn<{
   inputParameters: InputParameters<InputParametersDefinition>
   endpointName: string
   adapterSettings: AdapterSettings
 }>
 
-feedIdTest.beforeEach(async (t) => {
+test.before(() => {
+  LoggerFactoryProvider.set()
+})
+
+test.beforeEach(async (t) => {
   t.context.endpointName = 'TEST'
   t.context.inputParameters = new InputParameters({})
   t.context.adapterSettings = buildAdapterSettings({})
 })
 
-feedIdTest.serial('no parameters returns N/A', async (t) => {
+test.serial('no parameters returns N/A', async (t) => {
   t.is(calculateFeedId(t.context, {}), 'N/A')
 })
 
-feedIdTest.serial('builds feed ID correctly from input params', async (t) => {
+test.serial('builds feed ID correctly from input params', async (t) => {
   t.context.inputParameters = new InputParameters({
     base: {
       type: 'string',

--- a/test/subscription-set/subscription-set-factory.test.ts
+++ b/test/subscription-set/subscription-set-factory.test.ts
@@ -1,10 +1,14 @@
 import test from 'ava'
 import Redis from 'ioredis'
 import { buildAdapterSettings } from '../../src/config'
-import { SubscriptionSetFactory } from '../../src/util'
+import { LoggerFactoryProvider, SubscriptionSetFactory } from '../../src/util'
 import { ExpiringSortedSet } from '../../src/util/subscription-set/expiring-sorted-set'
 import { RedisSubscriptionSet } from '../../src/util/subscription-set/redis-sorted-set'
 import { RedisMock } from '../../src/util/testing-utils'
+
+test.before(() => {
+  LoggerFactoryProvider.set()
+})
 
 test('subscription set factory (local cache)', async (t) => {
   process.env['CACHE_TYPE'] = 'local'


### PR DESCRIPTION
Once crucial piece of the EA framework is its logger, used consistently and often throughout the code. Due to the potential for applications that use the framework needing to conditionally modify or filter logs, this PR changes the current implementation to keep a static reference to a logger factory and defers the actual instancing until the first time a child logger is called.

Originally this was planned to be solved by implementing a Dependency Injection framework across all the code, but I've chosen to go with this approach to minify the impact to the current logic. From my research into the current alternatives (tsyringe, inversifyjs, typedi, etc) most of them use Decorators, which are still in an experimental stage and can be painful to work with once the codebase gets large enough.