### PR TITLE
Make cacheKeyGenerator type specific to input params

### DIFF
--- a/src/adapter/endpoint.ts
+++ b/src/adapter/endpoint.ts
@@ -28,7 +28,7 @@ export class AdapterEndpoint<T extends EndpointGenerics> implements AdapterEndpo
   transportRoutes: TransportRoutes<T>
   inputParameters: InputParameters<T['Parameters']>
   rateLimiting?: EndpointRateLimitingConfig | undefined
-  cacheKeyGenerator?: (data: Record<string, unknown>) => string
+  cacheKeyGenerator?: (data: TypeFromDefinition<T['Parameters']>) => string
   customInputValidation?: CustomInputValidator<T>
   requestTransforms: RequestTransform<T>[]
   overrides?: Record<string, string> | undefined

--- a/src/adapter/types.ts
+++ b/src/adapter/types.ts
@@ -140,7 +140,7 @@ export interface BaseAdapterEndpointParams<T extends EndpointGenerics> {
   rateLimiting?: EndpointRateLimitingConfig
 
   /** Custom function that generates cache keys */
-  cacheKeyGenerator?: (data: Record<string, unknown>) => string
+  cacheKeyGenerator?: (data: TypeFromDefinition<T['Parameters']>) => string
 
   /** Custom input validation. Void function that should throw AdapterInputError on validation errors */
   customInputValidation?: CustomInputValidator<T>


### PR DESCRIPTION
Narrow the type for the cacheKeyGenerator function 'data' param to be specific to the input parameters. This allows cacheKeyGenerator implementations to safely know the structure of the data passed in.