### PR TITLE
Provide requestTransform's with adapter settings.

### DIFF
--- a/src/adapter/endpoint.ts
+++ b/src/adapter/endpoint.ts
@@ -98,9 +98,12 @@ export class AdapterEndpoint<T extends EndpointGenerics> implements AdapterEndpo
    * @param req - the current adapter request
    * @returns the request after passing through all request transforms
    */
-  runRequestTransforms(req: AdapterRequest<TypeFromDefinition<T['Parameters']>>): void {
+  runRequestTransforms(
+    req: AdapterRequest<TypeFromDefinition<T['Parameters']>>,
+    settings: T['Settings'],
+  ): void {
     for (const transform of this.requestTransforms) {
-      transform(req)
+      transform(req, settings)
     }
   }
 

--- a/src/adapter/types.ts
+++ b/src/adapter/types.ts
@@ -68,6 +68,7 @@ export interface AdapterRateLimitingConfig {
  */
 export type RequestTransform<T extends EndpointGenerics> = (
   req: AdapterRequest<TypeFromDefinition<T['Parameters']>>,
+  settings: T['Settings'],
 ) => void
 
 /**

--- a/src/validation/index.ts
+++ b/src/validation/index.ts
@@ -88,7 +88,7 @@ export const validatorMiddleware: AdapterMiddlewareBuilder =
 
     // Run any request transforms that might have been defined in the adapter.
     // This is the last time modifications are supposed to happen to the request.
-    endpoint.runRequestTransforms(req)
+    endpoint.runRequestTransforms(req, adapter.config.settings)
 
     if (
       adapter.config.settings.METRICS_ENABLED &&


### PR DESCRIPTION
* Provide requestTransform's with adapter settings.
* This is useful in situations where the adapter should transform requests differently based on the adapter settings, e.g. picking a different default exchange to fetch data for. 