### PR TITLE
Cache lock fix: deferring lock acquisition

### DIFF
--- a/src/adapter/basic.ts
+++ b/src/adapter/basic.ts
@@ -143,8 +143,9 @@ export class Adapter<CustomSettingsDefinition extends SettingsDefinitionMap = Se
               this.config.settings.CACHE_LOCK_RETRIES,
               this.shutdownNotifier,
             ))
-        } catch (e) {
-          lockAcquiredReject(e)
+        } catch (error) {
+          lockAcquiredReject(error)
+          return
         }
         lockAcquiredResolve(true)
       }, this.config.settings.CACHE_LOCK_DEFERRAL_MS)

--- a/src/adapter/basic.ts
+++ b/src/adapter/basic.ts
@@ -21,6 +21,7 @@ import {
   LoggerFactoryProvider,
   SubscriptionSetFactory,
   censorLogs,
+  deferredPromise,
   makeLogger,
 } from '../util'
 import { Requester } from '../util/requester'
@@ -64,6 +65,9 @@ export class Adapter<CustomSettingsDefinition extends SettingsDefinitionMap = Se
 
   /** Used on api shutdown for testing purposes*/
   shutdownNotifier: EventEmitter
+
+  /** Promise that will resolve once the adapter cache has acquired a lock */
+  lockAcquiredPromise?: Promise<boolean>
 
   /** Bootstrap function that will run when initializing the adapter */
   private readonly bootstrap?: (adapter: Adapter<CustomSettingsDefinition>) => Promise<void>
@@ -120,16 +124,30 @@ export class Adapter<CustomSettingsDefinition extends SettingsDefinitionMap = Se
     this.dependencies = this.initializeDependencies(dependencies)
 
     if (this.config.settings.EA_MODE !== 'reader' && this.dependencies.cache.lock) {
+      const [lockAcquiredPromise, lockAcquiredResolve, lockAcquiredReject] =
+        deferredPromise<boolean>()
+      this.lockAcquiredPromise = lockAcquiredPromise
       const cacheLockKey = this.config.settings.CACHE_PREFIX
         ? `${this.config.settings.CACHE_PREFIX}-${this.name}`
         : this.name
 
-      await this.dependencies.cache.lock(
-        cacheLockKey,
-        this.config.settings.CACHE_LOCK_DURATION,
-        this.config.settings.CACHE_LOCK_RETRIES,
-        this.shutdownNotifier,
-      )
+      // We need to defer the locking to support rollout strategies where the old container for an
+      // adapter is still running while the new one is starting up, and we don't want to block the
+      // old container from serving requests while the new one is starting up.
+      setTimeout(async () => {
+        try {
+          await (this.dependencies.cache.lock &&
+            this.dependencies.cache.lock(
+              cacheLockKey,
+              this.config.settings.CACHE_LOCK_DURATION,
+              this.config.settings.CACHE_LOCK_RETRIES,
+              this.shutdownNotifier,
+            ))
+        } catch (e) {
+          lockAcquiredReject(e)
+        }
+        lockAcquiredResolve(true)
+      }, this.config.settings.CACHE_LOCK_DEFERRAL_MS)
     }
 
     for (const endpoint of this.endpoints) {

--- a/src/cache/redis.ts
+++ b/src/cache/redis.ts
@@ -125,6 +125,11 @@ export class RedisCache<T = unknown> implements Cache<T> {
       retryCount: 0,
     })
 
+    // Close redis to allow adapter to shutdown if lock is not acquired
+    shutdownNotifier.on('onClose', () => {
+      this.client.quit()
+    })
+
     const acquireLock = async () => {
       // For the number of retries, try to acquire the lock
       for (let retryAttempt = 1; retryAttempt <= retryCount; retryAttempt++) {

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -35,6 +35,11 @@ export const BaseSettingsDefinition = {
     type: 'number',
     default: 10,
   },
+  CACHE_LOCK_DEFERRAL_MS: {
+    description: 'The amount of time (in ms) to wait before attempting to lock the cache',
+    type: 'number',
+    default: 60000,
+  },
   CACHE_MAX_AGE: {
     description: 'Maximum amount of time (in ms) that a response will stay cached',
     type: 'number',

--- a/src/index.ts
+++ b/src/index.ts
@@ -171,6 +171,11 @@ export const expose = async <T extends SettingsDefinitionMap>(
   await exposeApp(api, adapter.config.settings.EA_PORT)
   await exposeApp(metricsApi, adapter.config.settings.METRICS_PORT)
 
+  // Make sure the cache lock has been acquired before returning
+  if (adapter.lockAcquiredPromise) {
+    await adapter.lockAcquiredPromise
+  }
+
   // We return only the main API to maintain backwards compatibility
   return api
 }

--- a/src/util/testing-utils.ts
+++ b/src/util/testing-utils.ts
@@ -158,6 +158,12 @@ export class RedisMock {
       return 0
     }
   }
+
+  // For cache lock tests - naive implementation as the necessary error will
+  // already have been thrown the test will end the process
+  quit() {
+    return
+  }
 }
 
 class CommandChainMock {

--- a/src/util/testing-utils.ts
+++ b/src/util/testing-utils.ts
@@ -160,7 +160,7 @@ export class RedisMock {
   }
 
   // For cache lock tests - naive implementation as the necessary error will
-  // already have been thrown the test will end the process
+  // already have been thrown and the test will end the process
   quit() {
     return
   }

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -163,6 +163,7 @@ test('Adapter writer mode api disabled', async (t) => {
     {
       envDefaultOverrides: {
         EA_MODE: 'writer',
+        CACHE_LOCK_DEFERRAL_MS: 0,
       },
     },
   )


### PR DESCRIPTION
- Ran into an issue in staging with the cache lock. When adapters are updated, new pods are spun up and the old ones don't close until the new ones are ready via a health check. This causes the second adapter to try and fail to acquire the cache lock.
- Now, by default there is a 60 second delay before an adapter tries to acquire the lock while the rest of the adapter startup continues as usual. This allows the second adapter to pass its health check, cause the first one to close, and then make it possible for the second adapter to acquire the lock.