### PR TITLE
Fix bug where inversed requests can alter the cached response

### DIFF
--- a/src/adapter/price.ts
+++ b/src/adapter/price.ts
@@ -165,7 +165,10 @@ export class PriceAdapter<
 
     if (this.includesMap && req.requestContext.priceMeta?.inverse) {
       // We need to search in the reverse order (quote -> base) because the request transform will have inverted the pair
-      const cloneResponse = { ...response }
+
+      // Deep clone the response, as it may contain objects which won't be cloned by simply destructuring
+      const cloneResponse = JSON.parse(JSON.stringify(response))
+
       const inverseResult = 1 / (cloneResponse.result as number)
       cloneResponse.result = inverseResult
       // Check if response data has a result within it


### PR DESCRIPTION
* Bug was due to us shallow copying the response object, so modifying internal objects would modify the original response object.
* This meant that when we inverted the `data.result` property, we also caused future non-inverted requests that use the same cache object to receive an incorrect response (`result` would be the correct result, whereas `data.result` would be inverted).
* Fixed by replacing our shallow object copy with deep copying (using `JSON.parse(JSON.stringify(...))`)
* Added test that failed before adding this fix