### PR TITLE
Add local cache to redis

### DIFF
--- a/src/cache/factory.ts
+++ b/src/cache/factory.ts
@@ -17,7 +17,7 @@ export class CacheFactory {
         if (!redisClient) {
           throw new Error('Redis client undefined. Cannot create Redis cache')
         }
-        return new RedisCache(redisClient)
+        return new RedisCache(redisClient, maxSizeForLocalCache)
       }
     }
   }

--- a/test/cache/cache-lock.test.ts
+++ b/test/cache/cache-lock.test.ts
@@ -62,7 +62,7 @@ test.serial(
     })
 
     const redisClient = new RedisMock() as unknown as Redis
-    const cache = new RedisCache(redisClient) // Fake redis
+    const cache = new RedisCache(redisClient, 10000) // Fake redis
     const dependencies: Partial<AdapterDependencies> = {
       cache,
       redisClient,
@@ -131,7 +131,7 @@ test.serial(
     })
 
     const redisClient = new RedisMock() as unknown as Redis
-    const cache = new RedisCache(redisClient) // Fake redis
+    const cache = new RedisCache(redisClient, 10000) // Fake redis
     const dependencies: Partial<AdapterDependencies> = {
       cache,
       redisClient,
@@ -195,7 +195,7 @@ test.serial(
     })
 
     const redisClient = new RedisMock() as unknown as Redis
-    let cache: RedisCache | MockCache = new RedisCache(redisClient) // Fake redis
+    let cache: RedisCache | MockCache = new RedisCache(redisClient, 10000) // Fake redis
 
     const dependencies: Partial<AdapterDependencies> = {
       cache,
@@ -270,7 +270,7 @@ test.serial(
     })
 
     const redisClient = new RedisMock() as unknown as Redis
-    const cache = new RedisCache(redisClient) // Fake redis
+    const cache = new RedisCache(redisClient, 10000) // Fake redis
     const dependencies: Partial<AdapterDependencies> = {
       cache,
       redisClient,
@@ -342,7 +342,7 @@ test.serial(
 
     const redisMock = new RedisMock()
     const redisClient = redisMock as unknown as Redis
-    const cache = new RedisCache(redisClient) // Fake redis
+    const cache = new RedisCache(redisClient, 10000) // Fake redis
     const dependencies: Partial<AdapterDependencies> = {
       cache,
       redisClient,

--- a/test/cache/redis.test.ts
+++ b/test/cache/redis.test.ts
@@ -38,7 +38,7 @@ test.beforeEach(async (t) => {
     ],
   })
 
-  const cache = new RedisCache(new RedisMock() as unknown as Redis) // Fake redis
+  const cache = new RedisCache(new RedisMock() as unknown as Redis, 10000) // Fake redis
   const dependencies: Partial<AdapterDependencies> = {
     cache,
   }
@@ -71,7 +71,7 @@ test.serial('redis client is initialized with options', async (t) => {
     ],
   })
 
-  const cache = new RedisCache(new RedisMock() as unknown as Redis) // Fake redis
+  const cache = new RedisCache(new RedisMock() as unknown as Redis, 10000) // Fake redis
   const dependencies: Partial<AdapterDependencies> = {
     cache,
   }
@@ -106,7 +106,7 @@ test.serial('redis client is initialized with url', async (t) => {
     ],
   })
 
-  const cache = new RedisCache(new RedisMock() as unknown as Redis) // Fake redis
+  const cache = new RedisCache(new RedisMock() as unknown as Redis, 10000) // Fake redis
   const dependencies: Partial<AdapterDependencies> = {
     cache,
   }
@@ -151,11 +151,19 @@ test.serial('Test cache factory failure (redis)', async (t) => {
   }
 })
 
+test.serial('Test getting value from redis when it does not exist in local cache', async (t) => {
+  const cache = new RedisCache(new RedisMock() as unknown as Redis, 10000)
+  await cache.set('k1', 'v1', 1000)
+  await cache['localCache'].delete('k1')
+  const value = await cache.get('k1')
+  t.is(value, 'v1')
+})
+
 test.serial('Test cache key collision across adapters', async (t) => {
   const adapterA = buildDiffResultAdapter('TESTA')
   const adapterB = buildDiffResultAdapter('TESTB')
 
-  const cache = new RedisCache(new RedisMock() as unknown as Redis) // Fake redis
+  const cache = new RedisCache(new RedisMock() as unknown as Redis, 10000) // Fake redis
   const dependencies: Partial<AdapterDependencies> = {
     cache,
   }

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -179,7 +179,7 @@ test('Adapter writer mode api disabled', async (t) => {
     ],
   })
 
-  const cache = new RedisCache(new RedisMock() as unknown as Redis) // Fake redis
+  const cache = new RedisCache(new RedisMock() as unknown as Redis, 10000) // Fake redis
   const dependencies: Partial<AdapterDependencies> = {
     cache,
   }
@@ -210,7 +210,7 @@ test('Initialize adapter twice (error)', async (t) => {
     ],
   })
 
-  const cache = new RedisCache(new RedisMock() as unknown as Redis) // Fake redis
+  const cache = new RedisCache(new RedisMock() as unknown as Redis, 10000) // Fake redis
   const dependencies: Partial<AdapterDependencies> = {
     cache,
   }

--- a/test/metrics/redis-metrics.test.ts
+++ b/test/metrics/redis-metrics.test.ts
@@ -42,7 +42,7 @@ test.before(async (t) => {
     ],
   })
 
-  const cache = new RedisCache(new RedisMock() as unknown as Redis) // Fake redis
+  const cache = new RedisCache(new RedisMock() as unknown as Redis, 10000) // Fake redis
   const dependencies: Partial<AdapterDependencies> = {
     cache,
   }


### PR DESCRIPTION
[PDI-68](https://smartcontract-it.atlassian.net/browse/PDI-68)

This PR modifies redis cache logic so that cache entries are not only stored in redis, but also in a local cache. It also changes the read logic so that it tries to get the value from local cache first and only if it doesn't exist it tries to get the value from redis. This will improve the reads if the cache type is redis since for most of the time reads will be from local cache.  The only time when we will need to actually read from redis is when EA restarts with cached values in redis. 

[PDI-68]: https://smartcontract-it.atlassian.net/browse/PDI-68?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ