### PR TITLE
Add API_TIMEOUT default to the PoR adapter subclass

### DIFF
--- a/src/adapter/por.ts
+++ b/src/adapter/por.ts
@@ -127,7 +127,7 @@ export class PoRAdapter<T extends SettingsDefinitionMap> extends Adapter<T> {
     if (!params.config) {
       params.config = new AdapterConfig(
         {},
-        { envDefaultOverrides: { BACKGROUND_EXECUTE_TIMEOUT: 180_000 } },
+        { envDefaultOverrides: { BACKGROUND_EXECUTE_TIMEOUT: 180_000, API_TIMEOUT: 60_000 } },
       ) as AdapterConfig<T>
     } else {
       params.config.options = {
@@ -136,6 +136,7 @@ export class PoRAdapter<T extends SettingsDefinitionMap> extends Adapter<T> {
           ...(params.config.options?.envDefaultOverrides || {}),
           BACKGROUND_EXECUTE_TIMEOUT:
             params.config.options?.envDefaultOverrides?.BACKGROUND_EXECUTE_TIMEOUT ?? 180_000,
+          API_TIMEOUT: params.config.options?.envDefaultOverrides?.API_TIMEOUT ?? 60_000,
         },
       }
     }


### PR DESCRIPTION
Set `API_TIMEOUT` default for a PoR adapter to the max value