### PR TITLE
add examples to input parameters

### DIFF
--- a/scripts/generator-adapter/generators/app/templates/src/endpoint/base.ts.ejs
+++ b/scripts/generator-adapter/generators/app/templates/src/endpoint/base.ts.ejs
@@ -12,12 +12,7 @@ export const inputParameters = new InputParameters({
     type: 'string',
     description: 'The symbol of the currency to convert to',
   },
-}, [
-  {
-    base: 'ETH',
-    quote: 'BTC'
-  }
-])
+})
 <% if (includeComments) { %>// Endpoints contain a type parameter that allows specifying relevant types of an endpoint, for example, request payload type, Adapter response type and Adapter configuration (environment variables) type<% } %>
 export type BaseEndpointTypes = {
   Parameters: typeof inputParameters.definition

--- a/scripts/generator-adapter/generators/app/templates/src/endpoint/base.ts.ejs
+++ b/scripts/generator-adapter/generators/app/templates/src/endpoint/base.ts.ejs
@@ -12,7 +12,12 @@ export const inputParameters = new InputParameters({
     type: 'string',
     description: 'The symbol of the currency to convert to',
   },
-})
+}, [
+  {
+    base: 'ETH',
+    quote: 'BTC'
+  }
+])
 <% if (includeComments) { %>// Endpoints contain a type parameter that allows specifying relevant types of an endpoint, for example, request payload type, Adapter response type and Adapter configuration (environment variables) type<% } %>
 export type BaseEndpointTypes = {
   Parameters: typeof inputParameters.definition

--- a/src/validation/input-params.ts
+++ b/src/validation/input-params.ts
@@ -378,7 +378,7 @@ export class InputParameters<const T extends ProperInputParametersDefinition> {
 
   params: ProcessedParam[]
 
-  constructor(public definition: T) {
+  constructor(public definition: T, public examples?: TypeFromDefinition<T>[]) {
     this.params = Object.entries(this.definition).map(
       ([name, param]) => new ProcessedParam(name, param),
     )

--- a/test/validation.test.ts
+++ b/test/validation.test.ts
@@ -784,6 +784,40 @@ test.serial('custom input validation', async (t) => {
   t.is(error.statusCode, 400)
 })
 
+test.serial('examples in input parameters', async (t) => {
+  const inputParameters = new InputParameters({
+    base: {
+      type: 'string',
+      description: 'stuff',
+      required: true,
+    }
+  })
+
+  t.is(inputParameters.examples, undefined)
+
+  const inputParametersWithExamples = new InputParameters({
+    base: {
+      type: 'string',
+      array: true,
+      description: 'stuff',
+      required: true,
+    },
+    quote: {
+      type: 'number',
+      description: 'stuff',
+      required: true,
+    }
+  }, [{
+    base: ['1', '2', '3'],
+    quote: 2
+  }])
+
+  t.deepEqual(inputParametersWithExamples.examples, [{
+    base: ['1', '2', '3'],
+    quote: 2
+  }])
+})
+
 test.serial('limit size of input parameters', async (t) => {
   process.env['MAX_PAYLOAD_SIZE_LIMIT'] = '1048576'
 

--- a/test/validation.test.ts
+++ b/test/validation.test.ts
@@ -790,32 +790,39 @@ test.serial('examples in input parameters', async (t) => {
       type: 'string',
       description: 'stuff',
       required: true,
-    }
+    },
   })
 
   t.is(inputParameters.examples, undefined)
 
-  const inputParametersWithExamples = new InputParameters({
-    base: {
-      type: 'string',
-      array: true,
-      description: 'stuff',
-      required: true,
+  const inputParametersWithExamples = new InputParameters(
+    {
+      base: {
+        type: 'string',
+        array: true,
+        description: 'stuff',
+        required: true,
+      },
+      quote: {
+        type: 'number',
+        description: 'stuff',
+        required: true,
+      },
     },
-    quote: {
-      type: 'number',
-      description: 'stuff',
-      required: true,
-    }
-  }, [{
-    base: ['1', '2', '3'],
-    quote: 2
-  }])
+    [
+      {
+        base: ['1', '2', '3'],
+        quote: 2,
+      },
+    ],
+  )
 
-  t.deepEqual(inputParametersWithExamples.examples, [{
-    base: ['1', '2', '3'],
-    quote: 2
-  }])
+  t.deepEqual(inputParametersWithExamples.examples, [
+    {
+      base: ['1', '2', '3'],
+      quote: 2,
+    },
+  ])
 })
 
 test.serial('limit size of input parameters', async (t) => {


### PR DESCRIPTION
Added second optional argument to InputParameters constructor. It will hold the examples value and ensure that provided examples use correct values in terms of types. 

Input parameter examples are not directly used in framework and are mainly needed for monorepo to generate example requests for Readme files. 

The EA generator will be updated once changes in this PR are deployed to npm