### PR TITLE
Added setTTL function to cache

### DIFF
--- a/src/cache/index.ts
+++ b/src/cache/index.ts
@@ -62,6 +62,15 @@ export interface Cache<T = unknown> {
   delete: (key: string) => Promise<void>
 
   /**
+   * Updates the TTL value for an entry
+   *
+   * @param key - the key of the entry to be updated
+   * @param ttl - a new time in milliseconds until the entry expires
+   * @returns an empty Promise that resolves when the entry has been updated
+   */
+  setTTL: (key: string, ttl: number) => Promise<void>
+
+  /**
    * Sets a lock on the Cache.
    *
    * @param key - the key used to identify the lock, composed of the cache prefix (if set) and adapter name

--- a/src/cache/local.ts
+++ b/src/cache/local.ts
@@ -108,7 +108,7 @@ export class LocalCache<T = unknown> implements Cache<T> {
     }
   }
 
-  async setTTL(key: string, ttl: number):  Promise<void> {
+  async setTTL(key: string, ttl: number): Promise<void> {
     censorLogs(() => logger.trace(`Updating key ${key} with a new ttl ${ttl}`))
     if (this.cache.has(key)) {
       const node = this.cache.get(key) as LinkedListNode<LocalCacheEntry<T>>

--- a/src/cache/redis.ts
+++ b/src/cache/redis.ts
@@ -131,7 +131,7 @@ export class RedisCache<T = unknown> implements Cache<T> {
     this.localCache.setTTL(key, ttl)
 
     // Record set command sent to Redis
-    recordRedisCommandMetric(CMD_SENT_STATUS.SUCCESS, 'updateTTL')
+    recordRedisCommandMetric(CMD_SENT_STATUS.SUCCESS, 'setTTL')
   }
 
   async lock(

--- a/src/cache/redis.ts
+++ b/src/cache/redis.ts
@@ -125,6 +125,15 @@ export class RedisCache<T = unknown> implements Cache<T> {
     recordRedisCommandMetric(CMD_SENT_STATUS.SUCCESS, 'exec')
   }
 
+  async setTTL(key: string, ttl: number): Promise<void> {
+    censorLogs(() => logger.trace(`Updating key ${key} with a new ttl ${ttl}`))
+    await this.client.pexpire(key, ttl)
+    this.localCache.setTTL(key, ttl)
+
+    // Record set command sent to Redis
+    recordRedisCommandMetric(CMD_SENT_STATUS.SUCCESS, 'updateTTL')
+  }
+
   async lock(
     key: string,
     cacheLockDuration: number,

--- a/src/util/testing-utils.ts
+++ b/src/util/testing-utils.ts
@@ -159,6 +159,10 @@ export class RedisMock {
     }
   }
 
+  pexpire() {
+    return
+  }
+
   // For cache lock tests - naive implementation as the necessary error will
   // already have been thrown and the test will end the process
   quit() {

--- a/test/cache/local.test.ts
+++ b/test/cache/local.test.ts
@@ -114,3 +114,22 @@ test.serial('error responses are not overwriting successful cache entries', asyn
   const value4 = await cache.get(cacheKey)
   t.is(value4, errorResponse2)
 })
+
+test.serial('Test setting ttl for a cached value', async (t) => {
+  const cache = CacheFactory.buildCache({
+    cacheType: 'local',
+    maxSizeForLocalCache: 10000,
+  }) as LocalCache<PartialAdapterResponse>
+  const cacheKey = 'KEY'
+  const response = { result: 1, data: { result: 1 } }
+
+  await cache.set(cacheKey, response, 10000)
+  await cache.setTTL(cacheKey, 20000)
+  await runAllUntilTime(t.context.clock, 15000)
+  let value = await cache.get(cacheKey)
+  t.is(value, response)
+  // Advance the clock an additional 6000 ms so that cache expires
+  await runAllUntilTime(t.context.clock, 6000)
+  value = await cache.get(cacheKey)
+  t.is(value, undefined)
+})


### PR DESCRIPTION
This PR is part of [DF-19487](https://smartcontract-it.atlassian.net/browse/DF-19487)

Added a new `setTTL()` function to the cache interface that updates the time to live value for a key. 

[DF-19487]: https://smartcontract-it.atlassian.net/browse/DF-19487?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ