### PR TITLE
Add writeTTL to response cache

### DIFF
--- a/src/cache/response.ts
+++ b/src/cache/response.ts
@@ -11,7 +11,11 @@ import {
   makeLogger,
 } from '../util'
 import CensorList from '../util/censor/censor-list'
-import { InputParameters, InputParametersDefinition, TypeFromDefinition } from '../validation/input-params'
+import {
+  InputParameters,
+  InputParametersDefinition,
+  TypeFromDefinition,
+} from '../validation/input-params'
 import { validator } from '../validation/utils'
 import { Cache, calculateCacheKey, calculateFeedId } from './'
 import * as cacheMetrics from './metrics'
@@ -155,7 +159,11 @@ export class ResponseCache<
    * @param params - set of parameters that uniquely relate to the response
    * @param ttl - a new time in milliseconds until the response expires
    */
-  async writeTTL(transportName: string, params:  TypeFromDefinition<T['Parameters']>[], ttl: number): Promise<void> {
+  async writeTTL(
+    transportName: string,
+    params: TypeFromDefinition<T['Parameters']>[],
+    ttl: number,
+  ): Promise<void> {
     for (const param of params) {
       const key = calculateCacheKey({
         transportName: transportName,

--- a/test/cache/response-cache.test.ts
+++ b/test/cache/response-cache.test.ts
@@ -5,7 +5,12 @@ import { Adapter, AdapterEndpoint } from '../../src/adapter'
 import { AdapterConfig, SettingsDefinitionFromConfig } from '../../src/config'
 import { AdapterRequest } from '../../src/util'
 import { TypeFromDefinition } from '../../src/validation/input-params'
-import { NopTransport, TestAdapter, assertEqualResponses, runAllUntilTime } from '../../src/util/testing-utils'
+import {
+  NopTransport,
+  TestAdapter,
+  assertEqualResponses,
+  runAllUntilTime,
+} from '../../src/util/testing-utils'
 import { cacheTestInputParameters, CacheTestTransportTypes } from './helper'
 
 const test = untypedTest as TestFn<{
@@ -151,7 +156,7 @@ test.serial('updates the response cache ttl', async (t) => {
               await this.responseCache.writeTTL(this.name, entries, 120_000)
             }
 
-            if (requestCount === 0 ){
+            if (requestCount === 0) {
               await this.responseCache.write(this.name, [
                 {
                   params: req.requestContext.data,
@@ -178,13 +183,11 @@ test.serial('updates the response cache ttl', async (t) => {
   // First request sets the response in the cache
   await testAdapter.request({ base: 'BTC', factor: 10 })
   // On second request we refresh the cache TTL of a response with factor:10, and set it to 120_000
-  await testAdapter.request({base: 'BTC', factor: 11})
+  await testAdapter.request({ base: 'BTC', factor: 11 })
   // Advancing the clock to make sure that the TTL was updated and we get the response
   await runAllUntilTime(t.context.clock, 110000)
-  const response = await testAdapter.request({base: 'BTC', factor: 10})
+  const response = await testAdapter.request({ base: 'BTC', factor: 10 })
 
   t.is(response.json().statusCode, 200)
   t.is(response.json().result, 1234)
-
 })
-


### PR DESCRIPTION
Added a new `writeTTL`  function to ResponseCache interface. `writeTTL` takes request params and a new ttl value and updates the cache entries with a new ttl. This is mostly needed to simplify how EAs update their cache with a new ttl upon websocket heartbeat. For context see tickets [1](https://smartcontract-it.atlassian.net/browse/DF-19515), [2](https://smartcontract-it.atlassian.net/browse/DF-19487)

There is already an example of EAs doing this, like [TP/ICAP](https://github.com/smartcontractkit/external-adapters-js/blob/main/packages/sources/tp/src/transport/price.ts#L40)

```typescript
 const updateTTL = async (transport: WebSocketTransport<WsTransportTypes>) => {
  // Get current active entries in the subscription set
  const sSet = await transport.subscriptionSet.getAll()
  // For each entry in sSet, calculate the cache key and try to update the ttl of an entry
  sSet.forEach((param) => {
    const key = calculateCacheKey({
      transportName: transport.name,
      data: param,
      adapterName: transport.responseCache.adapterName,
      endpointName: transport.responseCache.endpointName,
      adapterSettings: transport.responseCache.adapterSettings,
    })
    transport.responseCache.cache.setTTL(key, transport.responseCache.adapterSettings.CACHE_MAX_AGE)
  })
}
```

but since we need more EAs to do this, it made sense to delegate cache key generation logic to ResponseCache interface. The updated version will look like 


```typescript
const updateTTL = async (transport: WebSocketTransport<WsTransportTypes>, ttl: number) => {
  const entries = await transport.subscriptionSet.getAll()
  transport.responseCache.writeTTL(transport.name, entries, ttl)
}
```

This not only is shorter but also doesn't directly access nested properties of transrpot.responseCache. 

I had many ideas on whether it makes sense to move this update logic inside websocket transport and enable it via flag or option inside builders, but at the end decided that two important things, 
1. the time. WHEN there should be TTL update and 
2. the assets. WHICH entries should be updated , should be handled by individual EA. 

This gives us more control (maybe we don't want to update all the entries in subscription set, maybe we would have a list of assets, or maybe we want to use custom TTL). Lastly, this is provider specific change and IMO any transport should not include DP specific logic.  

