### PR TITLE
Added support for transport overrides

### DIFF
--- a/src/adapter/endpoint.ts
+++ b/src/adapter/endpoint.ts
@@ -170,13 +170,19 @@ export class AdapterEndpoint<T extends EndpointGenerics> implements AdapterEndpo
   }
 
   /**
-   * Default routing strategy. Will try and use the transport input parameter if present in the request body.
+   * Default routing strategy. Will try and use the transport override if present
+   * or transport input parameter in the request body.
    *
    * @param req - The current adapter request
-   * @returns the transport param if present
+   * @returns the transport param or override if present
    */
   private defaultRouter(req: AdapterRequest<TypeFromDefinition<T['Parameters']>>) {
     const rawRequestBody = req.body as unknown as { data: AdapterRequestData }
+    const requestOverrides = rawRequestBody.data?.overrides?.[this.adapterName.toLowerCase()]
+    // Transport override
+    if (requestOverrides?.['__TRANSPORT__']) {
+      return requestOverrides['__TRANSPORT__']
+    }
     return rawRequestBody.data?.transport
   }
 }

--- a/src/adapter/endpoint.ts
+++ b/src/adapter/endpoint.ts
@@ -180,8 +180,8 @@ export class AdapterEndpoint<T extends EndpointGenerics> implements AdapterEndpo
     const rawRequestBody = req.body as unknown as { data: AdapterRequestData }
     const requestOverrides = rawRequestBody.data?.overrides?.[this.adapterName.toLowerCase()]
     // Transport override
-    if (requestOverrides?.['__TRANSPORT__']) {
-      return requestOverrides['__TRANSPORT__']
+    if (requestOverrides?.['transport']) {
+      return requestOverrides['transport']
     }
     return rawRequestBody.data?.transport
   }

--- a/src/util/types.ts
+++ b/src/util/types.ts
@@ -106,7 +106,7 @@ export interface AdapterMetricsMeta {
 export type Overrides = {
   [adapterName: string]: {
     [symbol: string]: string
-    __TRANSPORT__: string
+    transport: string
   }
 }
 

--- a/src/util/types.ts
+++ b/src/util/types.ts
@@ -33,7 +33,7 @@ export type AdapterRequestContext<T> = {
   /** Name of the endpoint this payload should be directed to */
   endpointName: string
 
-  /** Name of the endpoint this payload should be directed to */
+  /** Name of the transport this payload should be directed to */
   transportName: string
 
   /** Precalculated cache key used to get and set corresponding values from the cache and subscription sets */
@@ -101,11 +101,12 @@ export interface AdapterMetricsMeta {
 }
 
 /**
- * Map of overrides objects (symbol -\> symbol) per adapter name
+ * Map of overrides objects (symbol -\> symbol and request transport) per adapter name
  */
 export type Overrides = {
   [adapterName: string]: {
     [symbol: string]: string
+    __TRANSPORT__: string
   }
 }
 

--- a/src/validation/index.ts
+++ b/src/validation/index.ts
@@ -125,7 +125,7 @@ export const validatorMiddleware: AdapterMiddlewareBuilder =
 
       req.requestContext.cacheKey = `${cachePrefix}${cacheKey}`
     } else {
-      const transportName = endpoint.getTransportNameForRequest(req, adapter.config.settings)
+      const transportName = req.requestContext.transportName
       req.requestContext.cacheKey = calculateCacheKey({
         data: req.requestContext.data,
         adapterName: adapter.name,

--- a/test/transports/routing.test.ts
+++ b/test/transports/routing.test.ts
@@ -311,11 +311,12 @@ test.beforeEach(async (t) => {
 })
 
 test.afterEach(() => {
-  ;(transports.get('batch') as unknown as { registerRequestCalls: number }).registerRequestCalls = 0
-  ;(
-    transports.get('websocket') as unknown as { registerRequestCalls: number }
-  ).registerRequestCalls = 0
-  ;(transports.get('sse') as unknown as { registerRequestCalls: number }).registerRequestCalls = 0
+  const batchTransport = transports.get('batch') as unknown as { registerRequestCalls: number }
+  const wsTransport = transports.get('websocket') as unknown as { registerRequestCalls: number }
+  const sseTransport = transports.get('sse') as unknown as { registerRequestCalls: number }
+  batchTransport.registerRequestCalls = 0
+  wsTransport.registerRequestCalls = 0
+  sseTransport.registerRequestCalls = 0
 })
 
 test.serial('endpoint routing errors on invalid transport', async (t) => {

--- a/test/transports/routing.test.ts
+++ b/test/transports/routing.test.ts
@@ -704,7 +704,7 @@ test.serial('transport override routes to correct Transport', async (t) => {
     transport: 'websocket',
     overrides: {
       test: {
-        __TRANSPORT__: 'batch',
+        transport: 'batch',
       },
     },
   })
@@ -740,7 +740,7 @@ test.serial('invalid transport override is skipped', async (t) => {
     overrides: {
       // Invalid adapter name
       XXXX: {
-        __TRANSPORT__: 'batch',
+        transport: 'batch',
       },
     },
   })
@@ -809,7 +809,7 @@ test.serial(
       transport: 'sse',
       overrides: {
         test: {
-          __TRANSPORT__: 'websocket',
+          transport: 'websocket',
         },
       },
     })


### PR DESCRIPTION
[DF-19825](https://smartcontract-it.atlassian.net/browse/DF-19825)

Added a support for providing override for `transport` input parameter. Somewhat similar to symbol overrides, the value of the transport can be changed if provided in the request. 

Syntax is the same as with symbol overrides, but to override the transport `transport` is used with a value of transport
```json
{
  "data": {
    "base": "ETH",
    "quote": "USD",
    "transport": "ws",
    "overrides": {
        "tiingo": {
	    "ETH":"ethereuem",
             "transport": "rest"
        }
    }
  } 
}
```

In this example although the transport is set to `ws` in the request body, since there is an override, the `rest` transport will be used. 


Some notes on the changes. 

1. The keyword and placement of the override. 
Alternatively the key can be outside overrides object, most likely inside a new property, like 
```json
{
  "data": {
    "base": "ETH",
    "quote": "USD",
    "transport": "ws",
    "overrides": {
        "tiingo": {
            "ETH":"ethereuem"
        }
    },
    "transportOverride": {
        "tiingo": "rest"
    }
  } 
}
```

Or any other variation. Personally i think ‘overrides’, as the name says, should contain all the overrides, regardless symbol or request. Ideally i would move symbol overrides inside ‘symbols’ keyword and have `transport` on the top, but this would be a braking change for most feeds. Open to suggestions

2. The overridden value (if exists) is set in `defaultRouter`. 

Initially i wanted to make the transport override in the same [requestTransformer](https://github.com/smartcontractkit/ea-framework-js/blob/main/src/adapter/endpoint.ts#L117) that transforms the base symbols, but realized that the defaultRouter is much better place. The symbol overrider and transport overrider are similar only conceptually, technically those have many differences. It is very important to get the name of the transport that should be used, before any request transformation or input validation. 

3. Custom router still has higher priority even if override is provided. 
The idea of `customRouter` is to actually use the settings and the raw request body to resolve the transport name (ignoring default priorities used by the framework). Saying that even if the request has a transport override and a customRouter, whether the override is respected or not will only depend on the code in customRouter. 

Example scenario. Following request
```json
{
  "data": {
    "base": "ETH",
    "quote": "USD",
    "transport": "ws",
    "overrides": {
        "tiingo": {
	    "ETH":"ethereuem"
            "transport":"sse"
        }
    }
  } 
}
```

and the endpoint has a custom router 

```typescript
customRouter: (req, adapterConfig) => {
    const { base, quote } = req.requestContext.data
    if (CONDITION) {
      return 'rest'
    } 
  }
```

When request comes in and the endpoint supports multiple transports, customRouter runs to get the transport name. In this case if the CONDITION is true, `rest` is returned which will be used as a transport (ignoring both transport in the request and the override). 

However if the condition is falsy (customRouter returns falsy value), the defaultRouter runs, which first checks the override and returns it if found, if not, defaults to transport property in the request data. So in this case `sse` will be used.


This ensures consistent and predictable behavior as the transportName will be resolved as fast as possible, before running any request modifications (which anyway should not change it). 

We would need to review the EA’s that have custom router and want to use transport overrides to make sure that the customRouter is not blocking or  even if it can be removed. 

[DF-19825]: https://smartcontract-it.atlassian.net/browse/DF-19825?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ