### PR TITLE
Chore/update GitHub actions

### DIFF
--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -3,7 +3,7 @@ description: 'Sets up the project, installs dependencies, caches results'
 runs:
   using: 'composite'
   steps:
-    - uses: actions/setup-node@v3
+    - uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
       with:
         node-version: 16.x
         registry-url: https://registry.npmjs.org

--- a/.github/workflows/add-or-validate-labels.yaml
+++ b/.github/workflows/add-or-validate-labels.yaml
@@ -57,7 +57,7 @@ jobs:
           body-includes: NPM Publishing labels
 
       - name: Create or update comment
-        uses: peter-evans/create-or-update-comment@v2
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
         with:
           comment-id: ${{ steps.fc.outputs.comment-id }}
           issue-number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/add-or-validate-labels.yaml
+++ b/.github/workflows/add-or-validate-labels.yaml
@@ -49,7 +49,7 @@ jobs:
           echo "MESSAGE=$MESSAGE" >> $GITHUB_OUTPUT
 
       - name: Find previous comment
-        uses: peter-evans/find-comment@v2
+        uses: peter-evans/find-comment@3eae4d37986fb5a8592848f6a574fdf654e61f9e # v3.1.0
         id: fc
         with:
           issue-number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/add-or-validate-labels.yaml
+++ b/.github/workflows/add-or-validate-labels.yaml
@@ -20,7 +20,7 @@ jobs:
     outputs:
       VERSION_INSTRUCTION: ${{ steps.validate.outputs.VERSION_INSTRUCTION }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
       - name: Validate that version bump labels are on the PR
         id: validate
         uses: ./.github/actions/validate-version-labels

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -58,7 +58,7 @@ jobs:
     steps:
       - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
       - uses: ./.github/actions/setup
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
         with:
           name: coverage-reports
       - run: yarn code-coverage

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -13,7 +13,7 @@ jobs:
     concurrency: build-${{ github.ref}}
     if: ${{ !startsWith(github.head_ref, 'version-bump') }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
       - uses: ./.github/actions/setup
       - run: yarn build
   lint:
@@ -21,7 +21,7 @@ jobs:
     concurrency: lint-${{ github.ref }}
     if: ${{ !startsWith(github.head_ref, 'version-bump') }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
       - uses: ./.github/actions/setup
       - run: yarn lint
       - run: yarn prettier --check "**/*.{ts,md}"
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ !startsWith(github.head_ref, 'version-bump') }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
       - uses: ./.github/actions/setup
       - run: |
           # Check for test.only() in test files
@@ -56,7 +56,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ !startsWith(github.head_ref, 'version-bump') }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
       - uses: ./.github/actions/setup
       - uses: actions/download-artifact@v3
         with:
@@ -79,7 +79,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ !startsWith(github.head_ref, 'version-bump') }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
       - uses: ./.github/actions/setup
       - name: Generate new adapter, build, run the tests
         run: |

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -44,7 +44,7 @@ jobs:
             exit 1
           fi
       - run: yarn test
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
         with:
           name: coverage-reports
           path: |

--- a/.github/workflows/open-version-bump-pr.yaml
+++ b/.github/workflows/open-version-bump-pr.yaml
@@ -305,10 +305,10 @@ jobs:
       - createVersionBumpPR
     steps:
       - name: Post success or failure comment to PR
-        uses: actions/github-script@v6
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
           script: |
-            // `needs` isn't loaded into `actions/github-script@v6`.context, so we have to read it from the outer context
+            // `needs` isn't loaded into `actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1`.context, so we have to read it from the outer context
             // Using toJSON will dump a string representation of the object verbatim, which effective generates code for the `needs` javascript variable below
             const needs = ${{ toJSON(needs) }}
 

--- a/.github/workflows/open-version-bump-pr.yaml
+++ b/.github/workflows/open-version-bump-pr.yaml
@@ -26,7 +26,7 @@ jobs:
     steps:
       - id: set-job-name
         run: echo "JOB_NAME=${{ github.job }}" >> $GITHUB_OUTPUT
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
       - id: validate
         name: Validate that version bump labels are on the PR
         uses: ./.github/actions/validate-version-labels
@@ -46,7 +46,7 @@ jobs:
     steps:
       - id: set-job-name
         run: echo "JOB_NAME=${{ github.job }}" >> $GITHUB_OUTPUT
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
         with:
           ref: ${{ github.base_ref || github.ref }} # Explicit ref required to push from PR because of github internals
       - uses: ./.github/actions/set-git-credentials

--- a/.github/workflows/pinned-dependencies.yaml
+++ b/.github/workflows/pinned-dependencies.yaml
@@ -7,7 +7,7 @@ jobs:
     steps:
       - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
       - name: Extract all versions from package.json
-        uses: sergeysova/jq-action@v2
+        uses: sergeysova/jq-action@a3f0d4ff59cc1dddf023fc0b325dd75b10deec58 # v2.3.0
         id: versions
         with:
           cmd: "jq '[getpath([\"dependencies\"],[\"devDependencies\"],[\"optionalDependencies\"])] | del(..|nulls) | map(.[]) | join(\",\")' package.json -r"

--- a/.github/workflows/pinned-dependencies.yaml
+++ b/.github/workflows/pinned-dependencies.yaml
@@ -5,7 +5,7 @@ jobs:
   check-dependencies:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
       - name: Extract all versions from package.json
         uses: sergeysova/jq-action@v2
         id: versions

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -20,7 +20,7 @@ jobs:
     outputs:
       VERSION_TAG: ${{ steps.get-version-tag.outputs.VERSION_TAG }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
       - id: version-check
         run: |
           PACKAGE_VERSION=$(cat package.json \


### PR DESCRIPTION
Description
https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/

Updated all GH actions to newer versions that support Node20