### PR TITLE
Introduce exponential backoff for subscription errors

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -37,7 +37,7 @@ jobs:
           set +e
             files=$(find ${{ github.workspace }}/test -name "*.test.ts" | xargs grep -l 'test.only')
           set -e
-          
+
           if [[ -n $files ]]; then
             echo "Error: Found /test.only/ in following test files:"
             echo "$files"

--- a/.github/workflows/pinned-dependencies.yaml
+++ b/.github/workflows/pinned-dependencies.yaml
@@ -10,7 +10,7 @@ jobs:
         uses: sergeysova/jq-action@a3f0d4ff59cc1dddf023fc0b325dd75b10deec58 # v2.3.0
         id: versions
         with:
-          cmd: "jq '[getpath([\"dependencies\"],[\"devDependencies\"],[\"optionalDependencies\"])] | del(..|nulls) | map(.[]) | join(\",\")' package.json -r"
+          cmd: 'jq ''[getpath(["dependencies"],["devDependencies"],["optionalDependencies"])] | del(..|nulls) | map(.[]) | join(",")'' package.json -r'
           multiline: true
       - name: Check for un-pinned versions
         run: |

--- a/.github/workflows/pinned-dependencies.yaml
+++ b/.github/workflows/pinned-dependencies.yaml
@@ -10,7 +10,7 @@ jobs:
         uses: sergeysova/jq-action@a3f0d4ff59cc1dddf023fc0b325dd75b10deec58 # v2.3.0
         id: versions
         with:
-          cmd: 'jq ''[getpath(["dependencies"],["devDependencies"],["optionalDependencies"])] | del(..|nulls) | map(.[]) | join(",")'' package.json -r'
+          cmd: "jq '[getpath([\"dependencies\"],[\"devDependencies\"],[\"optionalDependencies\"])] | del(..|nulls) | map(.[]) | join(\",\")' package.json -r"
           multiline: true
       - name: Check for un-pinned versions
         run: |

--- a/src/background-executor.ts
+++ b/src/background-executor.ts
@@ -92,10 +92,10 @@ export async function callBackgroundExecutes(adapter: Adapter, apiShutdownPromis
       // This background execute loop is no longer the one to determine the sleep between bg execute calls.
       // That is now instead responsibility of each transport, to allow for custom ones to implement their own timings.
       logger.trace(
-        `Finished background execute for endpoint "${endpoint.name}", calling it again in 10ms...`,
+        `Finished background execute for endpoint "${endpoint.name}", calling it again in ${adapter.config.settings.BACKGROUND_EXECUTE_BUFFER_INTERVAL_MS}ms...`,
       )
       metricsTimer()
-      timeoutsMap[endpoint.name] = setTimeout(handler, 10)
+      timeoutsMap[endpoint.name] = setTimeout(handler, adapter.config.settings.BACKGROUND_EXECUTE_BUFFER_INTERVAL_MS)
     }
 
     // Start recursive async calls

--- a/src/background-executor.ts
+++ b/src/background-executor.ts
@@ -92,10 +92,10 @@ export async function callBackgroundExecutes(adapter: Adapter, apiShutdownPromis
       // This background execute loop is no longer the one to determine the sleep between bg execute calls.
       // That is now instead responsibility of each transport, to allow for custom ones to implement their own timings.
       logger.trace(
-        `Finished background execute for endpoint "${endpoint.name}", calling it again in ${adapter.config.settings.BACKGROUND_EXECUTE_BUFFER_INTERVAL_MS}ms...`,
+        `Finished background execute for endpoint "${endpoint.name}", calling it again in 10ms...`,
       )
       metricsTimer()
-      timeoutsMap[endpoint.name] = setTimeout(handler, adapter.config.settings.BACKGROUND_EXECUTE_BUFFER_INTERVAL_MS)
+      timeoutsMap[endpoint.name] = setTimeout(handler, 10) // 10ms
     }
 
     // Start recursive async calls

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -316,12 +316,6 @@ export const BaseSettingsDefinition = {
     default: 200,
     validate: validator.integer({ min: 1, max: 2000 }),
   },
-  BACKGROUND_EXECUTE_BUFFER_INTERVAL_MS: {
-    description: 'Minimum buffer time added between background execute loops for all transports',
-    type: 'number',
-    default: 10,
-    validate: validator.integer({ min: 1, max: 1000 }),
-  },
   BACKGROUND_EXECUTE_MS_SSE: {
     description: "Time in milliseconds to sleep between SSE transports' background execute calls",
     type: 'number',

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -102,23 +102,23 @@ export const BaseSettingsDefinition = {
     type: 'string',
     default: '',
   },
-  SUBSCRIPTION_RETRY_MAX_MS: {
+  STREAM_HANDLER_RETRY_MAX_MS: {
     type: 'number',
     description:
-      'The maximum time (ms) to wait before trying to subscribe again (takes precedent over SUBSCRIPTION_RETRY_MIN_MS',
+      'The maximum time (ms) to wait before running the stream handler (takes precedent over STREAM_HANDLER_RETRY_MIN_MS',
     default: 20 * 60 * 1000,
     validate: validator.integer({ min: 3_000, max: 24 * 60 * 60 * 1000 }),
   },
-  SUBSCRIPTION_RETRY_MIN_MS: {
+  STREAM_HANDLER_RETRY_MIN_MS: {
     type: 'number',
-    description: 'The minimum/base time (ms) to wait before trying to subscribe again',
+    description: 'The minimum/base time (ms) to wait before trying to run the stream handler',
     default: 100,
     validate: validator.integer({ min: 100, max: 10_000 }),
   },
-  SUBSCRIPTION_RETRY_EXP_FACTOR: {
+  STREAM_HANDLER_RETRY_EXP_FACTOR: {
     type: 'number',
     description:
-      'The factor for exponential back-off to wait before trying to subscribe again (1 = no change from SUBSCRIPTION_RETRY_MIN_MS)',
+      'The factor for exponential back-off to wait before running the stream handler (1 = no change from STREAM_HANDLER_RETRY_MIN_MS)',
     default: 3,
     validate: validator.integer({ min: 1, max: 10 }),
   },

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -2,11 +2,6 @@ import CensorList, { CensorKeyValue } from '../util/censor/censor-list'
 import { Validator, validator } from '../validation/utils'
 
 export const BaseSettingsDefinition = {
-  // V2 compat
-  // ADAPTER_URL: {
-  //   description: 'The URL of another adapter from which data needs to be retrieved',
-  //   type: 'string',
-  // },
   API_TIMEOUT: {
     description:
       'The number of milliseconds a request can be pending before returning a timeout error for data provider request',
@@ -63,11 +58,6 @@ export const BaseSettingsDefinition = {
     type: 'string',
     default: '127.0.0.1',
   },
-  // CACHE_REDIS_MAX_QUEUED_ITEMS: {
-  //   description: 'Maximum length of the client internal command queue',
-  //   type: 'number',
-  //   default: 500,
-  // },
   CACHE_REDIS_MAX_RECONNECT_COOLDOWN: {
     description: 'Max cooldown (in ms) before attempting redis reconnection',
     type: 'number',
@@ -112,6 +102,18 @@ export const BaseSettingsDefinition = {
     type: 'string',
     default: '',
   },
+  SUBSCRIPTION_RETRY_BASE_MS: {
+    type: 'number',
+    description: 'The base time to wait before trying to subscribe again',
+    default: 100,
+    validate: validator.integer({ min: 1, max: 10000 }),
+  },
+  SUBSCRIPTION_RETRY_EXP_FACTOR: {
+    type: 'number',
+    description: 'The factor for exponential back-off to wait before trying to subscribe again',
+    default: 3,
+    validate: validator.integer({ min: 2, max: 10 }),
+  },
   SUBSCRIPTION_SET_MAX_ITEMS: {
     type: 'number',
     description: 'The maximum number of subscriptions set',
@@ -123,20 +125,11 @@ export const BaseSettingsDefinition = {
     type: 'boolean',
     default: true,
   },
-  // DATA_PROVIDER_URL: {
-  //   description: 'Legacy variable that has the same functionality as ADAPTER_URL',
-  //   type: 'string',
-  // },
   DEBUG: {
     description: 'Toggles debug mode',
     type: 'boolean',
     default: false,
   },
-  // DEFAULT_WS_HEARTBEAT_INTERVAL: {
-  //   description: 'Interval between WS heartbeat pings (ms)',
-  //   type: 'number',
-  //   default: 30000,
-  // },
   EA_PORT: {
     description:
       'Port through which the EA will listen for REST requests (if mode is set to "reader" or "reader-writer")',
@@ -144,9 +137,6 @@ export const BaseSettingsDefinition = {
     default: 8080,
     validate: validator.port(),
   },
-  // ERROR_CAPACITY: {
-  //   type: 'number',
-  // },
   EXPERIMENTAL_METRICS_ENABLED: {
     description:
       'Flag to specify whether or not to collect metrics. Used as fallback for METRICS_ENABLED',
@@ -250,12 +240,6 @@ export const BaseSettingsDefinition = {
     default: 10_000,
     validate: validator.integer({ min: 500, max: 30_000 }),
   },
-  // WS_TIME_UNTIL_HANDLE_NEXT_MESSAGE_OVERRIDE: {
-  //   description: 'Time to wait until adapter should handle next WS message',
-  //   type: 'number',
-  // },
-
-  // V3
   CACHE_POLLING_MAX_RETRIES: {
     description:
       'Max amount of times to attempt to find EA response in the cache after the Transport has been set up',
@@ -331,6 +315,12 @@ export const BaseSettingsDefinition = {
     type: 'number',
     default: 200,
     validate: validator.integer({ min: 1, max: 2000 }),
+  },
+  BACKGROUND_EXECUTE_BUFFER_INTERVAL_MS: {
+    description: "Minimum buffer time added between background execute loops for all transports",
+    type: 'number',
+    default: 10,
+    validate: validator.integer({ min: 1, max: 1000 })
   },
   BACKGROUND_EXECUTE_MS_SSE: {
     description: "Time in milliseconds to sleep between SSE transports' background execute calls",

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -104,7 +104,8 @@ export const BaseSettingsDefinition = {
   },
   SUBSCRIPTION_RETRY_MAX_MS: {
     type: 'number',
-    description: 'The maximum time (ms) to wait before trying to subscribe again (takes precedent over SUBSCRIPTION_RETRY_MIN_MS',
+    description:
+      'The maximum time (ms) to wait before trying to subscribe again (takes precedent over SUBSCRIPTION_RETRY_MIN_MS',
     default: 20 * 60 * 1000,
     validate: validator.integer({ min: 3_000, max: 24 * 60 * 60 * 1000 }),
   },
@@ -116,7 +117,8 @@ export const BaseSettingsDefinition = {
   },
   SUBSCRIPTION_RETRY_EXP_FACTOR: {
     type: 'number',
-    description: 'The factor for exponential back-off to wait before trying to subscribe again (1 = no change from SUBSCRIPTION_RETRY_MIN_MS)',
+    description:
+      'The factor for exponential back-off to wait before trying to subscribe again (1 = no change from SUBSCRIPTION_RETRY_MIN_MS)',
     default: 3,
     validate: validator.integer({ min: 1, max: 10 }),
   },

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -317,10 +317,10 @@ export const BaseSettingsDefinition = {
     validate: validator.integer({ min: 1, max: 2000 }),
   },
   BACKGROUND_EXECUTE_BUFFER_INTERVAL_MS: {
-    description: "Minimum buffer time added between background execute loops for all transports",
+    description: 'Minimum buffer time added between background execute loops for all transports',
     type: 'number',
     default: 10,
-    validate: validator.integer({ min: 1, max: 1000 })
+    validate: validator.integer({ min: 1, max: 1000 }),
   },
   BACKGROUND_EXECUTE_MS_SSE: {
     description: "Time in milliseconds to sleep between SSE transports' background execute calls",

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -102,17 +102,23 @@ export const BaseSettingsDefinition = {
     type: 'string',
     default: '',
   },
-  SUBSCRIPTION_RETRY_BASE_MS: {
+  SUBSCRIPTION_RETRY_MAX_MS: {
     type: 'number',
-    description: 'The base time to wait before trying to subscribe again',
+    description: 'The maximum time (ms) to wait before trying to subscribe again (takes precedent over SUBSCRIPTION_RETRY_MIN_MS',
+    default: 20 * 60 * 1000,
+    validate: validator.integer({ min: 3_000, max: 24 * 60 * 60 * 1000 }),
+  },
+  SUBSCRIPTION_RETRY_MIN_MS: {
+    type: 'number',
+    description: 'The minimum/base time (ms) to wait before trying to subscribe again',
     default: 100,
-    validate: validator.integer({ min: 1, max: 10000 }),
+    validate: validator.integer({ min: 100, max: 10_000 }),
   },
   SUBSCRIPTION_RETRY_EXP_FACTOR: {
     type: 'number',
-    description: 'The factor for exponential back-off to wait before trying to subscribe again',
+    description: 'The factor for exponential back-off to wait before trying to subscribe again (1 = no change from SUBSCRIPTION_RETRY_MIN_MS)',
     default: 3,
-    validate: validator.integer({ min: 2, max: 10 }),
+    validate: validator.integer({ min: 1, max: 10 }),
   },
   SUBSCRIPTION_SET_MAX_ITEMS: {
     type: 'number',

--- a/src/metrics/index.ts
+++ b/src/metrics/index.ts
@@ -242,11 +242,6 @@ export const metrics = new Metrics(() => ({
     help: 'A histogram bucket of the distribution of background execute durations',
     labelNames: ['adapter_endpoint', 'transport'] as const,
   }),
-  bgHandlerErrors: new client.Counter({
-    name: 'bg_handler_errors',
-    help: 'The number of background handler errors per endpoint x transport',
-    labelNames: ['adapter_endpoint', 'transport'] as const,
-  }),
   cacheDataGetCount: new client.Counter({
     name: 'cache_data_get_count',
     help: 'A counter that increments every time a value is fetched from the cache',
@@ -298,6 +293,11 @@ export const metrics = new Metrics(() => ({
     name: 'redis_commands_sent_count',
     help: 'The number of redis commands sent',
     labelNames: ['status', 'function_name'],
+  }),
+  streamHandlerErrors: new client.Counter({
+    name: 'stream_handler_errors',
+    help: 'The number of stream handler errors per endpoint x transport',
+    labelNames: ['adapter_endpoint', 'transport'] as const,
   }),
   cacheWarmerCount: new client.Gauge({
     name: 'cache_warmer_get_count',

--- a/src/metrics/index.ts
+++ b/src/metrics/index.ts
@@ -242,6 +242,11 @@ export const metrics = new Metrics(() => ({
     help: 'A histogram bucket of the distribution of background execute durations',
     labelNames: ['adapter_endpoint', 'transport'] as const,
   }),
+  bgHandlerErrors: new client.Counter({
+    name: 'bg_handler_errors',
+    help: 'The number of background handler errors per endpoint x transport',
+    labelNames: ['adapter_endpoint', 'transport'] as const,
+  }),
   cacheDataGetCount: new client.Counter({
     name: 'cache_data_get_count',
     help: 'A counter that increments every time a value is fetched from the cache',

--- a/src/transports/abstract/subscription.ts
+++ b/src/transports/abstract/subscription.ts
@@ -84,8 +84,9 @@ export abstract class SubscriptionTransport<const T extends TransportGenerics>
     } catch (e) {
       logger.error(`Error with subscriptions in the backgroundHandler: ${e}`)
       const timeout = Math.min(
-        context.adapterSettings.SUBSCRIPTION_RETRY_MIN_MS * (context.adapterSettings.SUBSCRIPTION_RETRY_EXP_FACTOR ** this.retryCount),
-        context.adapterSettings.SUBSCRIPTION_RETRY_MAX_MS
+        context.adapterSettings.SUBSCRIPTION_RETRY_MIN_MS *
+          context.adapterSettings.SUBSCRIPTION_RETRY_EXP_FACTOR ** this.retryCount,
+        context.adapterSettings.SUBSCRIPTION_RETRY_MAX_MS,
       )
       this.retryTime = Date.now() + timeout
       this.retryCount += 1

--- a/src/transports/abstract/subscription.ts
+++ b/src/transports/abstract/subscription.ts
@@ -83,7 +83,10 @@ export abstract class SubscriptionTransport<const T extends TransportGenerics>
       this.retryCount = 0
     } catch (e) {
       logger.error(`Error with subscriptions in the backgroundHandler: ${e}`)
-      const timeout = context.adapterSettings.SUBSCRIPTION_RETRY_BASE_MS * (context.adapterSettings.SUBSCRIPTION_RETRY_EXP_FACTOR ** this.retryCount)
+      const timeout = Math.min(
+        context.adapterSettings.SUBSCRIPTION_RETRY_MIN_MS * (context.adapterSettings.SUBSCRIPTION_RETRY_EXP_FACTOR ** this.retryCount),
+        context.adapterSettings.SUBSCRIPTION_RETRY_MAX_MS
+      )
       this.retryTime = Date.now() + timeout
       this.retryCount += 1
       logger.info(`Waiting ${timeout}ms before backgroundHandler retry #${this.retryCount}`)

--- a/test/transports/websocket.test.ts
+++ b/test/transports/websocket.test.ts
@@ -520,7 +520,7 @@ test.serial(
 
     const metrics = await testAdapter.getMetrics()
     metrics.assert(t, {
-      name: 'bg_execute_errors',
+      name: 'bg_handler_errors',
       labels: {
         adapter_endpoint: 'test',
         transport: 'default_single_transport',
@@ -776,7 +776,7 @@ test.serial('does not hang the background execution if the open handler hangs', 
 
   const metrics = await testAdapter.getMetrics()
   metrics.assert(t, {
-    name: 'bg_execute_errors',
+    name: 'bg_handler_errors',
     labels: {
       adapter_endpoint: 'test',
       transport: 'default_single_transport',

--- a/test/transports/websocket.test.ts
+++ b/test/transports/websocket.test.ts
@@ -520,7 +520,7 @@ test.serial(
 
     const metrics = await testAdapter.getMetrics()
     metrics.assert(t, {
-      name: 'bg_handler_errors',
+      name: 'stream_handler_errors',
       labels: {
         adapter_endpoint: 'test',
         transport: 'default_single_transport',
@@ -776,7 +776,7 @@ test.serial('does not hang the background execution if the open handler hangs', 
 
   const metrics = await testAdapter.getMetrics()
   metrics.assert(t, {
-    name: 'bg_handler_errors',
+    name: 'stream_handler_errors',
     labels: {
       adapter_endpoint: 'test',
       transport: 'default_single_transport',


### PR DESCRIPTION
- Add configurable `STREAM_HANDLER_RETRY_MIN_MS`, `STREAM_HANDLER_RETRY_MAX_MS` and `STREAM_HANDLER_RETRY_EXP_FACTOR` for exponential retries for subscription handlers. Default to `100ms * 3^retryCount` (100ms, 300ms, ~1s, 3s, 8s, 24s, ..., 20m) 
- Remove commented config vars that don't seem to be used at the moment