### PR TITLE
Improve error messaging

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -637,7 +637,7 @@ export class AdapterConfig<T extends SettingsDefinitionMap = SettingsDefinitionM
 
     if (validationErrors.length > 0) {
       throw new Error(
-        `Validation failed for the following variables:\n ${validationErrors.join('\n')}`,
+        `Validation failed for the following variables:\n${validationErrors.join('\n')}`,
       )
     }
   }

--- a/src/transports/http.ts
+++ b/src/transports/http.ts
@@ -268,7 +268,9 @@ export class HttpTransport<T extends HttpTransportGenerics> extends Subscription
       if (e instanceof AdapterDataProviderError && e.cause instanceof AxiosError) {
         const err = e as AdapterDataProviderError
         const cause = err.cause as AxiosError
-        const errorMessage = `Provider request failed with status ${cause.status}: "${cause.response?.data}"`
+        const errorMessage = `Provider request failed with status ${cause.status}: ${JSON.stringify(
+          cause.response?.data,
+        )}`
         censorLogs(() => logger.info(errorMessage))
         return {
           results: requestConfig.params.map((entry) => ({


### PR DESCRIPTION
Previously

```
"errorMessage": "Provider request failed with status undefined: \"[object Object]\"",
```

Now

```
"errorMessage": "Provider request failed with status undefined: \"{\"message\":\"Forbidden\"}\"",
```