### PR TITLE
Removed caching from fg transport template

### DIFF
--- a/scripts/generator-adapter/generators/app/templates/src/transport/customfg.ts.ejs
+++ b/scripts/generator-adapter/generators/app/templates/src/transport/customfg.ts.ejs
@@ -51,7 +51,7 @@ export class CustomTransport implements Transport<CustomTransportTypes> {
   // request, process it,save it in the cache and return to user.
 <% } -%>
   async foregroundExecute(
-    req: AdapterRequest<typeof inputParameters.validated>
+    _: AdapterRequest<typeof inputParameters.validated>
   ): Promise<AdapterResponse<CustomTransportTypes['Response']>> {
 
     // Custom transport logic
@@ -68,16 +68,6 @@ export class CustomTransport implements Transport<CustomTransportTypes> {
         providerIndicatedTimeUnixMs: undefined,
       },
     }
-<% if (includeComments) { -%>
-    // Once the response object is ready, write it to the cache. Use the transport name, request payload and constructed response. Once cache is
-    // saved, return the response to the user.
-<% } -%>
-    await this.responseCache.write(this.name, [
-      {
-        params: req.requestContext.data,
-        response,
-      },
-    ])
 
     return response
   }


### PR DESCRIPTION
Removed writing to a cache in a `foregroundExecute` transport template. 
foregroundExecute should not be used generally, but it's intended for simple request-response type of transports. If we cache the value before returning, the value might become stale during the duration of cache TTL. By removing it the transport's code will be executed on every request. 