### PR TITLE
Override meta.adapterName

### DIFF
--- a/src/cache/index.ts
+++ b/src/cache/index.ts
@@ -152,6 +152,27 @@ const calculateKey = <T extends EndpointGenerics>({
   return `${endpointName}-${transportName}-${paramsKey}`
 }
 
+export const calculateAdapterName = (
+  adapterName: string,
+  data: Record<string, unknown>,
+): string => {
+  if (Object.keys(data).length === 0) {
+    logger.trace('Cannot generate Adapter Name without data, using default')
+    return adapterName
+  }
+
+  if (data && typeof data !== 'object') {
+    logger.trace('Cannot generate Adapter Name without valid data, using default')
+    return adapterName
+  }
+
+  if (data['adapterNameOverride'] && typeof data['adapterNameOverride'] === 'string') {
+    return data['adapterNameOverride'].toUpperCase()
+  } else {
+    return adapterName
+  }
+}
+
 export const calculateFeedId = <T extends EndpointGenerics>(
   {
     adapterSettings,

--- a/src/cache/response.ts
+++ b/src/cache/response.ts
@@ -17,7 +17,7 @@ import {
   TypeFromDefinition,
 } from '../validation/input-params'
 import { validator } from '../validation/utils'
-import { Cache, calculateCacheKey, calculateFeedId } from './'
+import { Cache, calculateCacheKey, calculateFeedId, calculateAdapterName } from './'
 import * as cacheMetrics from './metrics'
 
 const logger = makeLogger('ResponseCache')
@@ -99,7 +99,7 @@ export class ResponseCache<
         this.adapterSettings.EXPERIMENTAL_METRICS_ENABLED
       ) {
         response.meta = {
-          adapterName: this.adapterName,
+          adapterName: calculateAdapterName(this.adapterName, r.params),
           metrics: {
             feedId: calculateFeedId(
               {


### PR DESCRIPTION
TP and ICAP now comes from a single EA, causing confusion on dashboard: https://chainlink-core.slack.com/archives/C02FM5ZP2TC/p1728310901092909?thread_ts=1724330144.138549&cid=C02FM5ZP2TC

The metric comes from `adapterName` here we override this value based on EA param `adapterNameOverride`