### PR TITLE
Allow EA to read from override of another name

### DIFF
--- a/src/adapter/endpoint.ts
+++ b/src/adapter/endpoint.ts
@@ -110,6 +110,11 @@ export class AdapterEndpoint<T extends EndpointGenerics> implements AdapterEndpo
     }
   }
 
+  getRequestOverrides(data: Record<string, string>, overrides?: Overrides) {
+    const overrideAdapterName = data['adapterNameOverride']
+    return overrides?.[overrideAdapterName] || overrides?.[this.adapterName.toLowerCase()]
+  }
+
   /**
    * Default request transform that takes requests and manipulates base params
    *
@@ -118,9 +123,9 @@ export class AdapterEndpoint<T extends EndpointGenerics> implements AdapterEndpo
    * @returns the modified (or new) request
    */
   symbolOverrider(req: AdapterRequest<TypeFromDefinition<T['Parameters']>>) {
-    const rawRequestBody = req.body as { data?: { overrides?: Overrides } }
-    const requestOverrides = rawRequestBody.data?.overrides?.[this.adapterName.toLowerCase()]
     const data = req.requestContext.data as Record<string, string>
+    const rawRequestBody = req.body as { data?: { overrides?: Overrides } }
+    const requestOverrides = this.getRequestOverrides(data, rawRequestBody.data?.overrides)
     const base = data['base']
     if (requestOverrides?.[base]) {
       // Perform overrides specified in the request payload

--- a/src/adapter/types.ts
+++ b/src/adapter/types.ts
@@ -148,7 +148,10 @@ export interface BaseAdapterEndpointParams<T extends EndpointGenerics> {
   /** Custom function that generates cache keys */
   cacheKeyGenerator?: (data: TypeFromDefinition<T['Parameters']>) => string
 
-  /** Custom input validation. Void function that should throw AdapterInputError on validation errors */
+  /**
+   * Custom input validation. Void function that should throw AdapterInputError on validation errors.
+   * Can be used to pre-transform requests before all the requestTransforms happens
+   */
   customInputValidation?: CustomInputValidator<T>
 
   /** Custom output validation. Void function that should throw AdapterError on validation errors */

--- a/test/overrides.test.ts
+++ b/test/overrides.test.ts
@@ -28,6 +28,10 @@ const inputParameters = new InputParameters({
     description: 'quote',
     required: true,
   },
+  adapterNameOverride: {
+    type: 'string',
+    description: 'adapterNameOverride',
+  },
 })
 
 type TestTransportGenerics = TransportGenerics & {
@@ -175,6 +179,27 @@ test('adapter overrides that resolve field to overridable symbol are not overrid
 
   t.deepEqual(response.json().data, {
     base: 'overriden_1', // Want to check that it's not been overriden twice, which would be 'twice'
+    quote: 'USD',
+  })
+})
+
+test('adapter with overrideAdapterName uses overrideAdapterName', async (t) => {
+  const response = await t.context.testAdapter.request({
+    base: 'OVER2',
+    quote: 'USD',
+    adapterNameOverride: 'overridetest',
+    overrides: {
+      overridetest: {
+        OVER2: 'valid',
+      },
+      test: {
+        OVER2: 'invalid',
+      },
+    },
+  })
+
+  t.deepEqual(response.json().data, {
+    base: 'valid',
     quote: 'USD',
   })
 })


### PR DESCRIPTION
https://smartcontract-it.atlassian.net/browse/DF-20277

### What
Currently single EA can only read override from a single name, for example `cfbenchmarks` and `cfbenchmarks2` can only read override for `cfbenchmarks`. This causes issues on feed where we want to use both but they each have different override values

### How
Leverage `adapterNameOverride` input param, this param is already used to override metric name on response. Here we try to read override from `adapterNameOverride` first, if not available, read from `this.adapterName`, maintaining backward compatibility

### Application
There is no limit on how to define this override, you can
- Put it in as a regular param
- Hard-code it in adapter code: [example](https://github.com/smartcontractkit/external-adapters-js/pull/3528/files)
- Put it in env variable 
