### PR TITLE
Add chainId to PoRTokenAddress

### DIFF
--- a/src/adapter/por.ts
+++ b/src/adapter/por.ts
@@ -22,7 +22,8 @@ export type PoRAddress = Record<string, unknown> & {
 }
 
 export type PoRTokenAddress = Record<string, unknown> & {
-  network: string
+  network?: string
+  chainId?: string
   contractAddress: string
   wallets: string[]
   balanceOfSignature?: string


### PR DESCRIPTION
Use chainId instead of network

The upstream does not have a consistent network naming, hence we will use chainid instead