### PR TITLE
DF-20316 add isoTime to standard log line as human readable timestamp

### DIFF
--- a/src/util/logger.ts
+++ b/src/util/logger.ts
@@ -31,6 +31,10 @@ const baseLogger = pino(
         return { level: label }
       },
     },
+    timestamp: () => {
+      const now = new Date();
+      return `,"time":${now.getTime()},"isoTime":"${now.toISOString()}"`
+    },
     hooks: {
       logMethod(inputArgs, method) {
         // Censor each argument of logger

--- a/src/util/logger.ts
+++ b/src/util/logger.ts
@@ -32,7 +32,7 @@ const baseLogger = pino(
       },
     },
     timestamp: () => {
-      const now = new Date();
+      const now = new Date()
       return `,"time":${now.getTime()},"isoTime":"${now.toISOString()}"`
     },
     hooks: {


### PR DESCRIPTION
[DF-20316](https://smartcontract-it.atlassian.net/browse/DF-20316)

Updating logger timestamps to include both epoch time and human readable (ISO) time

[DF-20316]: https://smartcontract-it.atlassian.net/browse/DF-20316?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ