### PR TITLE
add websocket connection attempt metric

### DIFF
--- a/src/metrics/index.ts
+++ b/src/metrics/index.ts
@@ -304,6 +304,10 @@ export const metrics = new Metrics(() => ({
     help: 'The number of cache warmers running',
     labelNames: ['isBatched'] as const,
   }),
+  wsConnectionAttempt: new client.Counter({
+    name: 'ws_connection_attempt',
+    help: 'The number of open connection attempts',
+  }),
   wsConnectionActive: new client.Gauge({
     name: 'ws_connection_active',
     help: 'The number of active connections',

--- a/src/transports/websocket.ts
+++ b/src/transports/websocket.ts
@@ -244,6 +244,7 @@ export class WebSocketTransport<
     )
 
     // Attempt to establish the connection
+    metrics.get('wsConnectionAttempt').inc()
     try {
       await timeoutPromise(
         'WS Open Handler',


### PR DESCRIPTION
We should be able to monitor the WS connection attempt metric as necessary to understand if the EA request rate against a provider WS endpoint is within expected ranges