### PR TITLE
Bump websocket connect timeout

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -246,7 +246,7 @@ export const BaseSettingsDefinition = {
       'The maximum amount of time in milliseconds to wait for the websocket connection to open (including custom open handler)',
     type: 'number',
     default: 10_000,
-    validate: validator.integer({ min: 500, max: 30_000 }),
+    validate: validator.integer({ min: 500, max: 180000 }),
   },
   CACHE_POLLING_MAX_RETRIES: {
     description:

--- a/src/transports/websocket.ts
+++ b/src/transports/websocket.ts
@@ -157,7 +157,7 @@ export class WebSocketTransport<
     return {
       // Called when the WS connection is opened
       open: async (event: WebSocket.Event) => {
-        logger.debug(`Opened websocket connection. (event type ${event.type})`)
+        logger.info(`Opened websocket connection. (event type ${event.type})`)
         if (this.config.handlers.open) {
           await this.config.handlers.open(connection, context)
           logger.debug('Successfully executed connection opened handler')


### PR DESCRIPTION
We need to be able to adjust the timeout level to be longer if some EA's are under heavy load we can still connect without doing multiple re-attempts