### PR TITLE
remove duplicated metric capture

### DIFF
--- a/src/cache/redis.ts
+++ b/src/cache/redis.ts
@@ -108,22 +108,6 @@ export class RedisCache<T = unknown> implements Cache<T> {
 
     await chain.exec()
 
-    // Loop again, but this time to record these in metrics
-    const now = Date.now()
-    for (const entry of entries) {
-      // Only record metrics if feed Id is present, otherwise assuming value is not adapter response to record
-      const response = entry.value as unknown as AdapterResponse
-      const feedId = response.meta?.metrics?.feedId
-      if (feedId) {
-        const providerTime = response.timestamps?.providerIndicatedTimeUnixMs
-        const timeDelta = providerTime ? now - providerTime : undefined
-
-        // Record cache set count, max age, and staleness (set to 0 for cache set)
-        const label = cacheMetricsLabel(entry.key, feedId, CacheTypes.Redis)
-        cacheSet(label, ttl, timeDelta)
-      }
-    }
-
     // Record exec command sent to Redis
     recordRedisCommandMetric(CMD_SENT_STATUS.SUCCESS, 'exec')
   }

--- a/src/cache/redis.ts
+++ b/src/cache/redis.ts
@@ -2,9 +2,9 @@ import EventEmitter from 'events'
 import Redis, { Result } from 'ioredis'
 import Redlock from 'redlock'
 import { CMD_SENT_STATUS, recordRedisCommandMetric } from '../metrics'
-import { AdapterResponse, censorLogs, makeLogger, sleep } from '../util'
+import { censorLogs, makeLogger, sleep } from '../util'
 import { Cache, CacheEntry, LocalCache } from './index'
-import { CacheTypes, cacheMetricsLabel, cacheSet } from './metrics'
+import { CacheTypes } from './metrics'
 
 declare module 'ioredis' {
   interface RedisCommander<Context> {


### PR DESCRIPTION
Cache metrics are being set twice here when using redis cache type:

Response cache will call `setMany`[here](https://github.com/smartcontractkit/ea-framework-js/blob/6b83e6d61932a5c8b4f6d92e969c584e6942866d/src/cache/response.ts#L135)

In the Redis implementation that tracks various metrics [here](https://github.com/smartcontractkit/ea-framework-js/blob/6b83e6d61932a5c8b4f6d92e969c584e6942866d/src/cache/redis.ts#L112-L125)

Once `setMany` returns - we track the metrics again [here](https://github.com/smartcontractkit/ea-framework-js/blob/6b83e6d61932a5c8b4f6d92e969c584e6942866d/src/cache/response.ts#L137-L150)