### PR TITLE
Compile tests before running

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "lint": "eslint --max-warnings=0 . && prettier --check ./src/**/*.ts ./test/**/*.ts ./*.{json,yaml}",
     "portal-path": "echo \"portal:$(readlink -f ./dist/src)\"",
     "test-debug": "EA_HOST=localhost LOG_LEVEL=trace DEBUG=true EA_PORT=0 c8 ava --verbose",
-    "test": "EA_HOST=localhost LOG_LEVEL=error EA_PORT=0 c8 ava",
+    "test": "tsc -p test/tsconfig.json --noEmit && yarn ava",
+    "ava": "EA_HOST=localhost LOG_LEVEL=error EA_PORT=0 c8 ava",
     "verify": "yarn lint && yarn build && yarn build -p ./test/tsconfig.json && yarn test && yarn code-coverage",
     "code-coverage": "c8 check-coverage --statements 95 --lines 95 --functions 95 --branches 90"
   },


### PR DESCRIPTION
# Description

I found that trying to run tests when there are type errors, gives very unhelpful errors:
```
$ yarn test test/transports/routing.test.ts
yarn run v1.22.22
$ EA_HOST=localhost LOG_LEVEL=error EA_PORT=0 c8 ava test/transports/routing.test.ts

  Uncaught exception in test/transports/routing.test.ts

  TSError {
    diagnosticCodes: [
      7006,
    ],
  }

  ✘ test/transports/routing.test.ts exited with a non-zero exit code: 1
  ─

  1 uncaught exception
----------|---------|----------|---------|---------|-------------------
File      | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
----------|---------|----------|---------|---------|-------------------
All files |       0 |        0 |       0 |       0 |                   
----------|---------|----------|---------|---------|-------------------
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

By compiling tests before running them, we can get helpful errors:
```
$ yarn test test/transports/routing.test.ts
yarn run v1.22.22
$ tsc -p test/tsconfig.json --noEmit && yarn ava test/transports/routing.test.ts
test/transports/routing.test.ts:278:34 - error TS7006: Parameter 'req' implicitly has an 'any' type.

278   const customInputValidation = (req) => undefined
                                     ~~~


Found 1 error in test/transports/routing.test.ts:278

error Command failed with exit code 2.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

Compiling takes only about 1.5 seconds so I think it's worth the extra clarity.
But if you want to skip compilation, I've added an extra option to just run the tests with `yarn ava`.
Parameters seem to be passed correctly because you can still run an individual test the same way as before.

# Changes

In `scripts` in `package.json`:

1. Renamed `test` to `ava`.
2. Added `test` which first compiles with `tsc -p test/tsconfig.json --noEmit` and then runs `yarn ava`.