### PR TITLE
Output errors when generating adapter fails

### DIFF
--- a/scripts/generator-adapter/generators/app/index.ts
+++ b/scripts/generator-adapter/generators/app/index.ts
@@ -22,6 +22,18 @@ interface GeneratorEndpointContext {
   normalizedEndpointNameCap: string
 }
 
+const execAsPromise = async (command: string): Promise<string> => {
+  return new Promise(async (resolve, reject) => {
+    exec(command, (error, stdout, stderr) => {
+      if (error.code === 0) {
+        resolve(stdout);
+        return;
+      }
+      reject(error);
+    });
+  });
+};
+
 export default class extends Generator.default {
   props: {
     // Current ea-framework version in package.json
@@ -298,7 +310,7 @@ export default class extends Generator.default {
 
   // install stage is used to run npm or yarn install scripts
   async install() {
-    await exec(`yarn install --cwd ${this.args[0]}/${this.props.adapterName}`);
+    await execAsPromise(`yarn install --cwd ${this.args[0]}/${this.props.adapterName}`);
   }
 
   // end is the last stage. can be used for messages or cleanup


### PR DESCRIPTION
# Description

The `generate-example-adapter` job in the `main` workflow is [currently failing](https://github.com/smartcontractkit/ea-framework-js/actions/runs/13953939458/job/39060268213).
This happens because the generated adapter depends on version 2.2.0 of [@chainlink/external-adapter-framework](https://www.npmjs.com/package/@chainlink/external-adapter-framework?activeTab=versions), which hasn't been published yet because publishing is currently [also failing](https://github.com/smartcontractkit/ea-framework-js/actions/runs/13900915659/job/39054104850).

However, the reason that it's failing is completely unclear from the [logs](https://github.com/smartcontractkit/ea-framework-js/actions/runs/13953939458/job/39060268213), because the generator [ignores the output](https://github.com/smartcontractkit/ea-framework-js/blob/9698054b78450ce4541c90bd58653b62ef5947c2/scripts/generator-adapter/generators/app/index.ts#L301) of the `yarn install` call.

Additionally, it does not actually await the completion of the call because `exec` does not return a promise. So the generator actually outputs the success message before the `yarn install` call has even finished`. I've confirmed this by adding extra logging. Surprisingly this hasn't been an issue so far.

# Changes

1. Add `execAsPromise`, which is async and returns stdout on success and throws on failure.
2. Use `execAsPromise` instead of `exec` to call `yarn install` to make sure that the execution is awaited and errors are thrown.

# Tested

