### PR TITLE
Use secrets.NPM_EA_FRAMEWORK_JS to npm publish

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -51,4 +51,4 @@ jobs:
           fi
         working-directory: dist/src
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_EA_FRAMEWORK_JS }}


### PR DESCRIPTION
# Description

The [Publish NPM Package workflow](https://github.com/smartcontractkit/ea-framework-js/actions/workflows/publish.yaml) is currently [failing](https://github.com/smartcontractkit/ea-framework-js/actions/runs/13966446513/job/39097787384).
```
npm notice Publishing to https://registry.npmjs.org/ with tag latest and public access
npm error code E404
npm error 404 Not Found - PUT https://registry.npmjs.org/@chainlink%2fexternal-adapter-framework - Not found
npm error 404
npm error 404  '@chainlink/external-adapter-framework@2.2.1' is not in this registry.
npm error 404
npm error 404 Note that you can also install from a
npm error 404 tarball, folder, http url, or git url.
npm error A complete log of this run can be found in: /home/runner/.npm/_logs/2025-03-20T09_52_01_050Z-debug-0.log
Failed to publish package
```
One possibility is that the access token has expired.
There is a new self-service way of handling access tokens documented here:
https://smartcontract-it.atlassian.net/wiki/spaces/SEC/pages/1097728100/npm+workflows+automation#Repo-configuration-for-publishing-packages

# Changes

I have Slack Access Request to [request](https://smartcontract.at.okta.com/next/requests/1553) a token with:
* Repo: ea-framework-js
* Branch: main
* GH Environment: main
* NPM Packages: external-adapter-framework

After this was approved I got the following answer from Plaid:
> `npm-manager` - Your request was successful. Your GH repo ea-framework-js was configured with secrets that can publish npm packages. Here is a list: {"NPM_EA_FRAMEWORK_JS": ["external-adapter-framework"]}

So I'm using `NPM_EA_FRAMEWORK_JS` as the new access token.

# Testing

Since we can only run the workflow from the main branch, for security, I think we can't know if this works until after it's merged.