### PR TITLE
Fix error check in example generator

### DIFF
--- a/scripts/generator-adapter/generators/app/index.ts
+++ b/scripts/generator-adapter/generators/app/index.ts
@@ -25,11 +25,11 @@ interface GeneratorEndpointContext {
 const execAsPromise = async (command: string): Promise<string> => {
   return new Promise(async (resolve, reject) => {
     exec(command, (error, stdout, stderr) => {
-      if (error.code === 0) {
+      if (error) {
+        reject(error);
+      } else {
         resolve(stdout);
-        return;
       }
-      reject(error);
     });
   });
 };


### PR DESCRIPTION
# Description

https://github.com/smartcontractkit/ea-framework-js/pull/433 added logic to output errors from the `yarn install` command in the adapter generator. But they way it detected an error was wrong and this wasn't noticed because the flow as broken because of a missing npm package.

Now that the npm package issue is fixed, it turns out the example generator still fails because of the incorrect check.

If the command succeeds, there is no `error` response, so we can't check its error code.

# Changes

Check for the presence of the `error` rather than the value of the `error.code`.

# Testing

`generate-example-adapter` now passes on CI.

I also ran
```
git clean -df
yarn build
path_to_generator="$(pwd)/dist/src/generator-adapter/generators/app/index.js"
DEBUG=* yo "$path_to_generator" examples
cd examples/example-adapter
yarn build
yarn test
```
to verify that it works now.

Then I changes the version in `package.json` and ran it again to verify that it still show the error message as before.
