### PR TITLE
Add extra test for overrideAdapterName

### DIFF
--- a/test/overrides.test.ts
+++ b/test/overrides.test.ts
@@ -203,3 +203,21 @@ test('adapter with overrideAdapterName uses overrideAdapterName', async (t) => {
     quote: 'USD',
   })
 })
+
+test('adapter with overrideAdapterName uses original name if no override specified for overrideAdapterName', async (t) => {
+  const response = await t.context.testAdapter.request({
+    base: 'OVER2',
+    quote: 'USD',
+    adapterNameOverride: 'overridetest',
+    overrides: {
+      test: {
+        OVER2: 'overridden',
+      },
+    },
+  })
+
+  t.deepEqual(response.json().data, {
+    base: 'overridden',
+    quote: 'USD',
+  })
+})


### PR DESCRIPTION
# Description

https://github.com/smartcontractkit/ea-framework-js/pull/283 added the possibility of specifying a different adapter name to use (via `adapterNameOverride ` on the request context) as a key for request overrides.

The way this is implemented, if `adapterNameOverride` is used to specify a different adapter name, but no overrides are provided for that name, but overrides *are* provided for the real adapter name, then those overrides are used instead.

This could be surprising and/or intended, but it is not covered by unit tests so it could be accidentally changed without us realizing which could be a breaking change.

# Changes

Added a unit test for the case where no overrides are given for the `adapterNameOverride` name but overrides are given for the real adapter name.

