### PR TITLE
Allow hyphen in override adapter name

### DIFF
--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -176,3 +176,34 @@ export const groupArrayByKey = <T extends Record<string, string>, K extends keyo
     {} as Record<T[K], T[]>,
   )
 }
+
+/**
+ * Returns adapter name in lower case and with hyphens replaced by underscores.
+ * Types are declared such that the output type is defined iff the input type
+ * is defined.
+ * @param  name - The name to canonicalize
+ * @returns The canonical name
+ */
+export function getCanonicalAdapterName(name: string): string
+export function getCanonicalAdapterName(name: undefined): undefined
+export function getCanonicalAdapterName(name: string | undefined): string | undefined {
+  return name?.toLowerCase().replace(/-/g, '_')
+}
+
+type StringKeys<T> = { [key: string]: T }
+
+/**
+ * Returns the record with adapter names as keys after canonicalizing the keys.
+ * @param  obj - The record with adapter names as keys
+ * @returns The record with canonicalized adapter names as keys
+ */
+export const canonicalizeAdapterNameKeys = <T>(
+  obj: StringKeys<T> | undefined,
+): StringKeys<T> | undefined => {
+  if (obj === undefined) {
+    return undefined
+  }
+  return Object.fromEntries(
+    Object.entries(obj).map(([key, value]) => [getCanonicalAdapterName(key), value]),
+  )
+}

--- a/test/overrides.test.ts
+++ b/test/overrides.test.ts
@@ -248,7 +248,7 @@ test('adapter name in overrides can have hyphen', async (t) => {
     base: 'OVER2',
     quote: 'USD',
     overrides: {
-      "test-adapter": {
+      'test-adapter': {
         OVER2: 'qweqwe',
       },
     },

--- a/test/overrides.test.ts
+++ b/test/overrides.test.ts
@@ -259,3 +259,20 @@ test('adapter name in overrides can have hyphen', async (t) => {
     quote: 'USD',
   })
 })
+
+test('adapter name in overrides can use upper case', async (t) => {
+  const response = await t.context.testAdapter.request({
+    base: 'OVER2',
+    quote: 'USD',
+    overrides: {
+      TEST_ADAPTER: {
+        OVER2: 'qweqwe',
+      },
+    },
+  })
+
+  t.deepEqual(response.json().data, {
+    base: 'qweqwe',
+    quote: 'USD',
+  })
+})

--- a/test/overrides.test.ts
+++ b/test/overrides.test.ts
@@ -68,7 +68,7 @@ class OverrideTestTransport implements Transport<TestTransportGenerics> {
 
 test.beforeEach(async (t) => {
   const adapter = new Adapter({
-    name: 'TEST',
+    name: 'TEST_ADAPTER',
     defaultEndpoint: 'test-endpoint',
     endpoints: [
       new AdapterEndpoint({
@@ -103,7 +103,7 @@ test('request overrides are respected', async (t) => {
     base: 'OVER2',
     quote: 'USD',
     overrides: {
-      test: {
+      test_adapter: {
         OVER2: 'qweqwe',
       },
     },
@@ -137,7 +137,7 @@ test('request overrides take precedence over adapter hardcoded ones', async (t) 
     base: 'OVER1',
     quote: 'USD',
     overrides: {
-      test: {
+      test_adapter: {
         OVER1: 'priority',
       },
     },
@@ -154,7 +154,7 @@ test('request overrides that resolve field to overridable symbol are not overrid
     base: 'OVER2',
     quote: 'USD',
     overrides: {
-      test: {
+      test_adapter: {
         OVER2: 'OVER1',
       },
     },
@@ -204,13 +204,34 @@ test('adapter with overrideAdapterName uses overrideAdapterName', async (t) => {
   })
 })
 
+test('adapterNameOverride can use hyphen', async (t) => {
+  const response = await t.context.testAdapter.request({
+    base: 'OVER2',
+    quote: 'USD',
+    adapterNameOverride: 'override-test',
+    overrides: {
+      override_test: {
+        OVER2: 'valid',
+      },
+      test: {
+        OVER2: 'invalid',
+      },
+    },
+  })
+
+  t.deepEqual(response.json().data, {
+    base: 'valid',
+    quote: 'USD',
+  })
+})
+
 test('adapter with overrideAdapterName uses original name if no override specified for overrideAdapterName', async (t) => {
   const response = await t.context.testAdapter.request({
     base: 'OVER2',
     quote: 'USD',
     adapterNameOverride: 'overridetest',
     overrides: {
-      test: {
+      test_adapter: {
         OVER2: 'overridden',
       },
     },
@@ -218,6 +239,23 @@ test('adapter with overrideAdapterName uses original name if no override specifi
 
   t.deepEqual(response.json().data, {
     base: 'overridden',
+    quote: 'USD',
+  })
+})
+
+test('adapter name in overrides can have hyphen', async (t) => {
+  const response = await t.context.testAdapter.request({
+    base: 'OVER2',
+    quote: 'USD',
+    overrides: {
+      "test-adapter": {
+        OVER2: 'qweqwe',
+      },
+    },
+  })
+
+  t.deepEqual(response.json().data, {
+    base: 'qweqwe',
     quote: 'USD',
   })
 })

--- a/test/transports/routing.test.ts
+++ b/test/transports/routing.test.ts
@@ -291,7 +291,7 @@ test.beforeEach(async (t) => {
   })
 
   const sampleAdapter = new Adapter({
-    name: 'TEST',
+    name: 'TEST_ADAPTER',
     defaultEndpoint: 'price',
     config: customConfig,
     endpoints: [sampleEndpoint],
@@ -704,7 +704,42 @@ test.serial('transport override routes to correct Transport', async (t) => {
     to,
     transport: 'websocket',
     overrides: {
-      test: {
+      test_adapter: {
+        transport: 'batch',
+      },
+    },
+  })
+
+  t.is(error.statusCode, 504)
+  const internalTransport = transports.get('batch') as unknown as MockHttpTransport
+  t.assert(internalTransport.registerRequestCalls > 0)
+})
+
+test.serial('transport override adapter name can use hyphen', async (t) => {
+  axiosMock
+    .onPost(`${restUrl}/price`, {
+      pairs: [
+        {
+          base: from,
+          quote: to,
+        },
+      ],
+    })
+    .reply(200, {
+      prices: [
+        {
+          pair: `${from}/${to}`,
+          price,
+        },
+      ],
+    })
+
+  const error = await t.context.testAdapter.request({
+    from,
+    to,
+    transport: 'websocket',
+    overrides: {
+      'test-adapter': {
         transport: 'batch',
       },
     },

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -1,4 +1,9 @@
-import { groupArrayByKey, splitArrayIntoChunks, getCanonicalAdapterName, canonicalizeAdapterNameKeys } from '../src/util'
+import {
+  groupArrayByKey,
+  splitArrayIntoChunks,
+  getCanonicalAdapterName,
+  canonicalizeAdapterNameKeys,
+} from '../src/util'
 import test from 'ava'
 
 test('Test splitArrayIntoChunks function', async (t) => {
@@ -49,17 +54,20 @@ test('Test getCanonicalAdapterName', async (t) => {
 
 test('Test canonicalizeAdapterNameKeys', async (t) => {
   t.deepEqual(canonicalizeAdapterNameKeys(undefined), undefined)
-  t.deepEqual(canonicalizeAdapterNameKeys({
-    'test': 1,
-    'TEST2': 2,
-    'TEST-adapter': 3,
-    'TEST_ADAPTER2': 4,
-    'A-B-C-D-e-f': 5,
-  }), {
-    test: 1,
-    test2: 2,
-    test_adapter: 3,
-    test_adapter2: 4,
-    a_b_c_d_e_f: 5,
-  })
+  t.deepEqual(
+    canonicalizeAdapterNameKeys({
+      test: 1,
+      TEST2: 2,
+      'TEST-adapter': 3,
+      TEST_ADAPTER2: 4,
+      'A-B-C-D-e-f': 5,
+    }),
+    {
+      test: 1,
+      test2: 2,
+      test_adapter: 3,
+      test_adapter2: 4,
+      a_b_c_d_e_f: 5,
+    },
+  )
 })

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -1,4 +1,4 @@
-import { groupArrayByKey, splitArrayIntoChunks } from '../src/util'
+import { groupArrayByKey, splitArrayIntoChunks, getCanonicalAdapterName, canonicalizeAdapterNameKeys } from '../src/util'
 import test from 'ava'
 
 test('Test splitArrayIntoChunks function', async (t) => {
@@ -35,5 +35,31 @@ test('Test groupArrayByKey function', async (t) => {
     ETH: [{ base: 'BTC', quote: 'ETH' }],
     USD: [{ base: 'BTC', quote: 'USD' }],
     DASH: [{ base: 'LTC', quote: 'DASH' }],
+  })
+})
+
+test('Test getCanonicalAdapterName', async (t) => {
+  t.is(getCanonicalAdapterName(undefined), undefined)
+  t.is(getCanonicalAdapterName('test'), 'test')
+  t.is(getCanonicalAdapterName('TEST'), 'test')
+  t.is(getCanonicalAdapterName('TEST-adapter'), 'test_adapter')
+  t.is(getCanonicalAdapterName('TEST_ADAPTER'), 'test_adapter')
+  t.is(getCanonicalAdapterName('A-B-C-D-e-f'), 'a_b_c_d_e_f')
+})
+
+test('Test canonicalizeAdapterNameKeys', async (t) => {
+  t.deepEqual(canonicalizeAdapterNameKeys(undefined), undefined)
+  t.deepEqual(canonicalizeAdapterNameKeys({
+    'test': 1,
+    'TEST2': 2,
+    'TEST-adapter': 3,
+    'TEST_ADAPTER2': 4,
+    'A-B-C-D-e-f': 5,
+  }), {
+    test: 1,
+    test2: 2,
+    test_adapter: 3,
+    test_adapter2: 4,
+    a_b_c_d_e_f: 5,
   })
 })


### PR DESCRIPTION
[DF-21153](https://smartcontract-it.atlassian.net/browse/DF-21153)

# Description

The name of an adapter can refer to 2 different things:
1. The name of the package that implements the adapter
2. The name field in the definition of the adapter.

These are typically (but not necessarily) related but there are difference:
1. The package name is typically lower case while the name field is required to be upper case.
2. The package name typically uses a hyphen as separator while the name field typically uses an underscore as separator.

See for example the [name field](https://github.com/smartcontractkit/external-adapters-js/blob/cb6a8a287e311fd17697810c0accd2e2a093e43b/packages/sources/blocksize-capital/src/index.ts#L7) of the `blocksize-capital` adapter which has value `BLOCKSIZE_CAPITAL`.

This causes confusion when specifying request overrides for an adapter because the adapter name key used has to match the name field of the adapter but in lower case. Usually this is the same as the package name, except when that would have a hyphen, it has to be an underscore.

To avoid confusion, we want to allow both hyphen and underscore to be used, to make it more likely that the package name will work as override key.

# Changes

1. Add `getCanonicalAdapterName` which will convert an adapter name to lower case and replace hyphens with underscores.
2. Add `canonicalizeAdapterNameKeys` which will take a record with adapter names as keys and canonicalize all the keys.
3. In `getRequestOverrides` canonicalize both the lookup key and the keys in the request overrides.
4. In `defaultRouter` reuse `getRequestOverrides` so the canonicalizing logic doesn't need to be duplicated. Note that when  `defaultRouter` is called, `adapterNameOverride` is not available yet, so it can't reuse the full logic of `getRequestOverrides`.

# Testing

1. In `test/overrides.test.ts` and `test/transports/routing.test.ts` change the test adapter name from `TEST` to `TEST_ADAPTER` to allow testing with hyphens.
2. Add tests for overriding base assets and transport with a hyphen.
3. Add unit tests for the utility functions.
4. Tested manually in `external-adapters-js` by using a [portal dependency](https://github.com/smartcontractkit/external-adapters-js/blob/main/CONTRIBUTING.md#framework-development) and using the following request while running the `blocksize-capital` EA:
```
$ curl -X POST http://localhost:8080 -H "Content-Type: application/json" -d '{   "data": {
    "endpoint": "price",
    "base": "XEUX",
    "quote": "EUR", "overrides": { "blocksize-capital": {"XEUX": "ETH"} } 
  }
}'
{"result":1826.8472848996678,"data":{"result":1826.8472848996678},"timestamps":{"providerDataStreamEstablishedUnixMs":1742544459255,"providerDataReceivedUnixMs":1742544459370,"providerIndicatedTimeUnixMs":1742544458872},"statusCode":200,"meta":{"adapterName":"BLOCKSIZE_CAPITAL","metrics":{"feedId":"{\"base\":\"eth\",\"quote\":\"eur\"}"}}}
``` 

[DF-21153]: https://smartcontract-it.atlassian.net/browse/DF-21153?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ