### PR TITLE
Add GroupRunner to limit concurrent RPCs

### DIFF
--- a/src/util/group-runner.ts
+++ b/src/util/group-runner.ts
@@ -1,0 +1,69 @@
+type Callback<T> = () => Promise<T>
+type Resolve<T> = (arg: T | Promise<T>) => void
+
+// Runs tasks in groups of a fixed size.
+// The next group won't be started until the previous group is finished.
+//
+// Example usage:
+//
+// const fetchBalances(addresses: string[]): Promise<number[]> {
+//    // addresses can contains thousands of addresses
+//    const groupRunner = new GroupRunner<number[]>(10)
+//    const getBalance = groupRunner.wrapFunction(fetchBalance)
+//    const balancePromises: Promise<number>[] = []
+//    for (const address of addresses) {
+//      // There will be at most 10 concurrent calls to fetchBalance.
+//      // fetchBalance might do an RPC and we don't want to get rate limited.
+//      balancePromises.push(getBalance(address)))
+//    }
+//    return Promise.all(balancePromises)
+// }
+//
+//
+// Implementation note:
+// Once the size has been reached, we wait for all previous tasks to finish
+// before running the new task.
+// Alternatively, we could run more tasks as soon as some (rather than all)
+// tasks have finished, to make progress sooner, but the former is what's
+// currently used in multiple places in the external-adapters-js repo so we
+// chose that behavior.
+export class GroupRunner {
+  private currentGroup: Promise<unknown>[] = []
+  private previousStartRunning: Promise<void> = Promise.resolve()
+
+  constructor(private groupSize: number) {}
+
+  // Calls the given callback eventually but makes sure any previous group of
+  // groupSize size has settled before calling and subsequent callbacks.
+  run<T>(callback: Callback<T>): Promise<T> {
+    return new Promise(async (resolve) => {
+      // This creates an implicit queue which guarantees that there are no
+      // concurrent calls into startRunning. This is necessary to avoid having
+      // currentGroup being cleared concurrently.
+      this.previousStartRunning = this.previousStartRunning.then(() => {
+        return this.startRunning(callback, resolve)
+      })
+    })
+  }
+
+  // Waits for a previous group to finish, if necessary, and then runs the
+  // given callback. When this method resolves, the callback has been called
+  // but not necessarily resolved.
+  async startRunning<T>(callback: Callback<T>, resolve: Resolve<T>) {
+    if (this.currentGroup.length >= this.groupSize) {
+      await Promise.allSettled(this.currentGroup)
+      this.currentGroup = []
+    }
+    const promise = callback()
+    this.currentGroup.push(promise)
+    resolve(promise)
+  }
+
+  wrapFunction<Args extends any[], Return>(
+    func: (...args: Args) => Promise<Return>,
+  ): (...args: Args) => Promise<Return> {
+    return (...args: Args) => {
+      return this.run(() => func(...args))
+    }
+  }
+}

--- a/src/util/group-runner.ts
+++ b/src/util/group-runner.ts
@@ -59,7 +59,7 @@ export class GroupRunner {
     resolve(promise)
   }
 
-  wrapFunction<Args extends any[], Return>(
+  wrapFunction<Args extends unknown[], Return>(
     func: (...args: Args) => Promise<Return>,
   ): (...args: Args) => Promise<Return> {
     return (...args: Args) => {

--- a/src/util/group-runner.ts
+++ b/src/util/group-runner.ts
@@ -36,7 +36,7 @@ export class GroupRunner {
   // Calls the given callback eventually but makes sure any previous group of
   // groupSize size has settled before calling and subsequent callbacks.
   run<T>(callback: Callback<T>): Promise<T> {
-    return new Promise(async (resolve) => {
+    return new Promise((resolve) => {
       // This creates an implicit queue which guarantees that there are no
       // concurrent calls into startRunning. This is necessary to avoid having
       // currentGroup being cleared concurrently.

--- a/src/util/group-runner.ts
+++ b/src/util/group-runner.ts
@@ -7,7 +7,7 @@ type Resolve<T> = (arg: T | Promise<T>) => void
 // Example usage:
 //
 // const fetchBalances(addresses: string[]): Promise<number[]> {
-//    // addresses can contains thousands of addresses
+//    // addresses can contain thousands of addresses
 //    const groupRunner = new GroupRunner<number[]>(10)
 //    const getBalance = groupRunner.wrapFunction(fetchBalance)
 //    const balancePromises: Promise<number>[] = []

--- a/src/util/group-runner.ts
+++ b/src/util/group-runner.ts
@@ -8,7 +8,7 @@ type Resolve<T> = (arg: T | Promise<T>) => void
 //
 // const fetchBalances(addresses: string[]): Promise<number[]> {
 //    // addresses can contain thousands of addresses
-//    const groupRunner = new GroupRunner<number[]>(10)
+//    const groupRunner = new GroupRunner(10)
 //    const getBalance = groupRunner.wrapFunction(fetchBalance)
 //    const balancePromises: Promise<number>[] = []
 //    for (const address of addresses) {

--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -115,7 +115,7 @@ export const timeoutPromise = <T>(
   ]).finally(() => clearTimeout(timer))
 }
 
-type DeferredResolve<T> = (value: T) => void
+type DeferredResolve<T> = (value: T | PromiseLike<T>) => void
 type DeferredReject = (reason?: unknown) => void
 
 /**

--- a/test/util/group-runner.test.ts
+++ b/test/util/group-runner.test.ts
@@ -1,0 +1,242 @@
+import { deferredPromise, sleep } from '../../src/util'
+import { GroupRunner } from '../../src/util/group-runner'
+import test from 'ava'
+
+type Task<T> = {
+  promise: Promise<T>
+  resolve: (arg: T) => void
+  reject: (arg: any) => void
+  getCallCount: () => number
+  callback: () => Promise<T>
+}
+
+const createTask = <T>(n: number = -1): Task<T> => {
+  const [promise, resolve, reject] = deferredPromise<T>()
+  let callCount = 0
+  return {
+    promise,
+    resolve,
+    reject,
+    getCallCount: () => callCount,
+    callback: () => {
+      callCount++
+      return promise
+    },
+  }
+}
+
+test('should run tasks', async (t) => {
+  const runner = new GroupRunner(2)
+  const result = 'result'
+  const callback = () => Promise.resolve(result)
+  t.is(await runner.run(callback), result)
+})
+
+test('should wait after group size is reached', async (t) => {
+  const runner = new GroupRunner(2)
+
+  const tasks: Task<void>[] = []
+  for (let i = 0; i < 3; i++) {
+    tasks.push(createTask())
+  }
+
+  runner.run(tasks[0].callback)
+  runner.run(tasks[1].callback)
+  runner.run(tasks[2].callback)
+  await sleep(0)
+  t.is(tasks[0].getCallCount(), 1)
+  t.is(tasks[1].getCallCount(), 1)
+  t.is(tasks[2].getCallCount(), 0)
+})
+
+test('should continue after group has finished', async (t) => {
+  const runner = new GroupRunner(2)
+
+  const tasks: Task<void>[] = []
+  for (let i = 0; i < 3; i++) {
+    tasks.push(createTask())
+  }
+
+  runner.run(tasks[0].callback)
+  runner.run(tasks[1].callback)
+  runner.run(tasks[2].callback)
+
+  await sleep(0)
+  t.is(tasks[2].getCallCount(), 0)
+
+  tasks[0].resolve(undefined)
+
+  await sleep(0)
+  t.is(tasks[2].getCallCount(), 0)
+
+  tasks[1].resolve(undefined)
+
+  await sleep(0)
+  t.is(tasks[2].getCallCount(), 1)
+})
+
+test('should not clear current group concurrently', async (t) => {
+  const runner = new GroupRunner(2)
+
+  const tasks: Task<void>[] = []
+  for (let i = 0; i < 4; i++) {
+    tasks.push(createTask())
+    runner.run(tasks[i].callback)
+  }
+  // Tasks 3 and 4 will both be waiting for tasks 1 and 2 to finish.
+  // When they do, they should not both clear the current group resulting in a
+  // group with only task 4.
+  tasks[0].resolve(undefined)
+  tasks[1].resolve(undefined)
+
+  // If we did end up with a group of 1 after concurrent clearing, then task 5
+  // will run immediately, which it shouldn't because task 3 and 4 are not
+  // finished yet.
+  const task5: Task<void> = createTask()
+  runner.run(task5.callback)
+
+  await sleep(0)
+  t.is(task5.getCallCount(), 0)
+})
+
+test('multiple groups', async (t) => {
+  const runner = new GroupRunner(3)
+
+  const tasks: Task<void>[] = []
+  for (let i = 0; i < 5; i++) {
+    tasks.push(createTask(i))
+    runner.run(tasks[i].callback)
+  }
+
+  await sleep(0)
+  t.is(tasks[0].getCallCount(), 1)
+  t.is(tasks[1].getCallCount(), 1)
+  t.is(tasks[2].getCallCount(), 1)
+  t.is(tasks[3].getCallCount(), 0)
+  t.is(tasks[4].getCallCount(), 0)
+
+  tasks[0].resolve(undefined)
+  tasks[1].resolve(undefined)
+  tasks[2].resolve(undefined)
+
+  await sleep(0)
+  t.is(tasks[3].getCallCount(), 1)
+  t.is(tasks[4].getCallCount(), 1)
+
+  // 5 more tasks for a total of 10:
+  for (let i = 5; i < 10; i++) {
+    tasks.push(createTask(i))
+    runner.run(tasks[i].callback)
+  }
+
+  await sleep(0)
+  t.is(tasks[5].getCallCount(), 1)
+  t.is(tasks[6].getCallCount(), 0)
+  t.is(tasks[7].getCallCount(), 0)
+  t.is(tasks[8].getCallCount(), 0)
+  t.is(tasks[9].getCallCount(), 0)
+
+  tasks[3].resolve(undefined)
+  tasks[4].resolve(undefined)
+  tasks[5].resolve(undefined)
+
+  await sleep(0)
+  t.is(tasks[6].getCallCount(), 1)
+  t.is(tasks[7].getCallCount(), 1)
+  t.is(tasks[8].getCallCount(), 1)
+  t.is(tasks[9].getCallCount(), 0)
+
+  tasks[6].resolve(undefined)
+  tasks[7].resolve(undefined)
+  tasks[8].resolve(undefined)
+
+  await sleep(0)
+  t.is(tasks[9].getCallCount(), 1)
+})
+
+test('multiple return values', async (t) => {
+  const runner = new GroupRunner(3)
+
+  const tasks: Task<number>[] = []
+  const promises: Promise<number>[] = []
+  for (let i = 0; i < 10; i++) {
+    tasks.push(createTask(i))
+    promises.push(runner.run(tasks[i].callback))
+  }
+
+  await sleep(0)
+  for (let i = 0; i < 10; i++) {
+    tasks[i].resolve(i)
+  }
+
+  await sleep(0)
+  for (let i = 0; i < 10; i++) {
+    t.is(await promises[i], i)
+  }
+})
+
+test('rejecting promises', async (t) => {
+  const runner = new GroupRunner(2)
+
+  const tasks: Task<void>[] = []
+  for (let i = 0; i < 3; i++) {
+    tasks.push(createTask())
+  }
+
+  runner.run(tasks[0].callback).catch(() => {
+    /* ignore */
+  })
+  runner.run(tasks[1].callback).catch(() => {
+    /* ignore */
+  })
+  runner.run(tasks[2].callback)
+
+  await sleep(0)
+  t.is(tasks[2].getCallCount(), 0)
+
+  tasks[0].reject(undefined)
+
+  await sleep(0)
+  t.is(tasks[2].getCallCount(), 0)
+
+  await sleep(0)
+  tasks[1].reject(undefined)
+
+  await sleep(0)
+  t.is(tasks[2].getCallCount(), 1)
+})
+
+test('wrap function', async (t) => {
+  const runner = new GroupRunner(2)
+
+  const tasks: Task<number>[] = []
+  for (let i = 0; i < 3; i++) {
+    tasks.push(createTask())
+  }
+
+  const f = runner.wrapFunction((i) => tasks[i].callback())
+
+  const promise0 = f(0)
+  const promise1 = f(1)
+  const promise2 = f(2)
+
+  await sleep(0)
+  t.is(tasks[2].getCallCount(), 0)
+
+  tasks[0].resolve(0)
+
+  await sleep(0)
+  t.is(tasks[2].getCallCount(), 0)
+
+  await sleep(0)
+  tasks[1].resolve(1)
+
+  await sleep(0)
+  t.is(tasks[2].getCallCount(), 1)
+
+  tasks[2].resolve(2)
+
+  t.is(await promise0, 0)
+  t.is(await promise1, 1)
+  t.is(await promise2, 2)
+})

--- a/test/util/group-runner.test.ts
+++ b/test/util/group-runner.test.ts
@@ -214,7 +214,7 @@ test('wrap function', async (t) => {
     tasks.push(createTask())
   }
 
-  const f = runner.wrapFunction((i) => tasks[i].callback())
+  const f = runner.wrapFunction((i: number) => tasks[i].callback())
 
   const promise0 = f(0)
   const promise1 = f(1)

--- a/test/util/group-runner.test.ts
+++ b/test/util/group-runner.test.ts
@@ -5,12 +5,12 @@ import test from 'ava'
 type Task<T> = {
   promise: Promise<T>
   resolve: (arg: T) => void
-  reject: (arg: any) => void
+  reject: (arg: unknown) => void
   getCallCount: () => number
   callback: () => Promise<T>
 }
 
-const createTask = <T>(n: number = -1): Task<T> => {
+const createTask = <T>(): Task<T> => {
   const [promise, resolve, reject] = deferredPromise<T>()
   let callCount = 0
   return {
@@ -104,7 +104,7 @@ test('multiple groups', async (t) => {
 
   const tasks: Task<void>[] = []
   for (let i = 0; i < 5; i++) {
-    tasks.push(createTask(i))
+    tasks.push(createTask())
     runner.run(tasks[i].callback)
   }
 
@@ -125,7 +125,7 @@ test('multiple groups', async (t) => {
 
   // 5 more tasks for a total of 10:
   for (let i = 5; i < 10; i++) {
-    tasks.push(createTask(i))
+    tasks.push(createTask())
     runner.run(tasks[i].callback)
   }
 
@@ -160,7 +160,7 @@ test('multiple return values', async (t) => {
   const tasks: Task<number>[] = []
   const promises: Promise<number>[] = []
   for (let i = 0; i < 10; i++) {
-    tasks.push(createTask(i))
+    tasks.push(createTask())
     promises.push(runner.run(tasks[i].callback))
   }
 
@@ -184,10 +184,10 @@ test('rejecting promises', async (t) => {
   }
 
   runner.run(tasks[0].callback).catch(() => {
-    /* ignore */
+    /* Ignore */
   })
   runner.run(tasks[1].callback).catch(() => {
-    /* ignore */
+    /* Ignore */
   })
   runner.run(tasks[2].callback)
 


### PR DESCRIPTION
## Description

In https://github.com/smartcontractkit/external-adapters-js we have at least 5 different places where we limit the number of concurrent RPCs:
1. [dlc-btc-por](https://github.com/smartcontractkit/external-adapters-js/blob/8ebcbd74baaa377344fcceb900ddd880e8fc3165/packages/sources/dlc-btc-por/src/transport/proof-of-reserves.ts#L99-L115)
2. [eth-beacon](https://github.com/smartcontractkit/external-adapters-js/blob/8ebcbd74baaa377344fcceb900ddd880e8fc3165/packages/sources/eth-beacon/src/transport/balance.ts#L127-L139)
3. [polkadot-balance](https://github.com/smartcontractkit/external-adapters-js/blob/8ebcbd74baaa377344fcceb900ddd880e8fc3165/packages/sources/polkadot-balance/src/transport/balance.ts#L81-L97)
4. [por-address-list](https://github.com/smartcontractkit/external-adapters-js/blob/8ebcbd74baaa377344fcceb900ddd880e8fc3165/packages/sources/por-address-list/src/transport/addressManager.ts#L29-L48)
5. [stader-balance](https://github.com/smartcontractkit/external-adapters-js/blob/8ebcbd74baaa377344fcceb900ddd880e8fc3165/packages/sources/stader-balance/src/transport/balance.ts#L175-L196)

And we want to also do this in the token-balance EA. The existing places are all implemented in slightly different ways.

This PR adds a utility to take care of grouping "tasks" (which can be RPCs or anything else) which can then be used in each of those 5 existing places as well as the new places where we want to group RPCs.

## Changes

1. Add `GroupRunner` which manages running tasks in groups and waiting for the previous group to finish before starting the next group.
2. Add tests.
3. Fix `type DeferredResolve<T>` to allow passing in promises to resolve functions.

# Testing

```
yarn test test/util/group-runner.test.ts
```
I've also tested using it in the EAs listed above and will create PRs for those after this is merged.