### PR TITLE
Add makeStub testing util

### DIFF
--- a/src/util/testing-utils.ts
+++ b/src/util/testing-utils.ts
@@ -536,25 +536,27 @@ export const mockWebSocketProvider = (provider: typeof WebSocketClassProvider): 
 //
 // Throws (and logs, in case the error is caught by the code under test):
 // Error: Property 'obj.foo.baz' does not exist
-export function makeStub<T>(name: string, target: T): T {
-  if (target === null || typeof target !== 'object') {
-    return target
+export function makeStub<T>(name: string, obj: T): T {
+  if (obj === null || typeof obj !== 'object') {
+    return obj
   }
-  return new Proxy(target, {
+  return new Proxy(obj, {
     get: (target, prop) => {
       const propName = `${name}.${String(prop)}`
       if (!(prop in target) && !isStubPropAllowedUndefined(prop)) {
         const message = `Property '${propName}' does not exist`
+        // eslint-disable-next-line no-console
         console.error(message)
         throw new Error(message)
       }
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       return makeStub(propName, (target as any)[prop])
     },
   }) as T
 }
 
 // Properties checked by jest which don't need to be defined:
-export let allowedUndefinedStubProps = [
+export const allowedUndefinedStubProps = [
   '$$typeof',
   'nodeType',
   'tagName',
@@ -566,7 +568,7 @@ export let allowedUndefinedStubProps = [
   'then',
 ]
 
-const isStubPropAllowedUndefined = (prop: string | Symbol) => {
+const isStubPropAllowedUndefined = (prop: string | symbol) => {
   if (typeof prop === 'symbol') {
     return true
   }

--- a/src/util/testing-utils.ts
+++ b/src/util/testing-utils.ts
@@ -508,4 +508,69 @@ export const mockWebSocketProvider = (provider: typeof WebSocketClassProvider): 
   // Need to disable typing, the mock-socket impl does not implement the ws interface fully
   provider.set(MockWebSocket as any) // eslint-disable-line @typescript-eslint/no-explicit-any
 }
+
+// Wraps an object such that accessing properties that do not exist will throw
+// an error instead of returning undefined.
+//
+// This is useful during unit test creation, as it makes it clear which
+// properties are missing rather than giving an error later on that undefined
+// doesn't have some other property.
+//
+// Once a test is passing, you can remove the wrapping and the test will still
+// pass. But it might be useful to keep it for when the code under test is
+// changed later on.
+//
+// Example usage:
+//
+// In code under test:
+//
+//   function doThing(obj) {
+//     const baz = obj.foo.baz
+//     ...
+//   }
+//
+// In test code:
+//
+//   const obj = makeStub('obj', { foo: { bar: 1 } })
+//   doThing(obj)
+//
+// Throws (and logs, in case the error is caught by the code under test):
+// Error: Property 'obj.foo.baz' does not exist
+export function makeStub<T>(name: string, target: T): T {
+  if (target === null || typeof target !== 'object') {
+    return target
+  }
+  return new Proxy(target, {
+    get: (target, prop) => {
+      const propName = `${name}.${String(prop)}`
+      if (!(prop in target) && !isStubPropAllowedUndefined(prop)) {
+        const message = `Property '${propName}' does not exist`
+        console.error(message)
+        throw new Error(message)
+      }
+      return makeStub(propName, (target as any)[prop])
+    },
+  }) as T
+}
+
+// Properties checked by jest which don't need to be defined:
+export let allowedUndefinedStubProps = [
+  '$$typeof',
+  'nodeType',
+  'tagName',
+  'hasAttribute',
+  '@@__IMMUTABLE_ITERABLE__@@',
+  '@@__IMMUTABLE_RECORD__@@',
+  'toJSON',
+  'asymmetricMatch',
+  'then',
+]
+
+const isStubPropAllowedUndefined = (prop: string | Symbol) => {
+  if (typeof prop === 'symbol') {
+    return true
+  }
+  return allowedUndefinedStubProps.includes(prop as string)
+}
+
 /* c8 ignore stop */ // eslint-disable-line

--- a/test/util/testing-utils.test.ts
+++ b/test/util/testing-utils.test.ts
@@ -1,0 +1,120 @@
+import test from 'ava'
+import { allowedUndefinedStubProps, makeStub } from '../../src/util/testing-utils'
+
+test('make a stub', async (t) => {
+  const stub = makeStub('stub', {
+    name: 'stub-name',
+    count: 5,
+  })
+
+  t.is(stub.name, 'stub-name')
+  t.is(stub.count, 5)
+})
+
+test('make a stub with nested fields', async (t) => {
+  const stub = makeStub('stub', {
+    name: 'stub-name',
+    nested: {
+      count: 5,
+    },
+  })
+
+  t.is(stub.name, 'stub-name')
+  t.is(stub.nested.count, 5)
+})
+
+test('accessing an absent field should throw an error', async (t) => {
+  const stub = makeStub('stub', {
+    name: 'stub-name',
+    nested: {
+      count: 5,
+    },
+  })
+
+  t.throws(
+    () => {
+      // @ts-ignore
+      stub.count
+    },
+    {
+      message: "Property 'stub.count' does not exist",
+    },
+  )
+})
+
+test('accessing a nested absent field should throw an error', async (t) => {
+  const stub = makeStub('stub', {
+    name: 'stub-name',
+    nested: {
+      count: 5,
+    },
+  })
+
+  t.throws(
+    () => {
+      // @ts-ignore
+      stub.nested.name
+    },
+    {
+      message: "Property 'stub.nested.name' does not exist",
+    },
+  )
+})
+
+test('fields used by jest are allowed to be undefined', async (t) => {
+  const stub = makeStub('stub', {
+    name: 'stub-name',
+    count: 5,
+  })
+
+  // @ts-ignore
+  t.is(stub.nodeType, undefined)
+  // @ts-ignore
+  t.is(stub.tagName, undefined)
+})
+
+test('Symbol props are allowed to be undefined', async (t) => {
+  const stub = makeStub('stub', {
+    name: 'stub-name',
+    count: 5,
+  })
+
+  // @ts-ignore
+  t.is(stub[Symbol('my symbol')], undefined)
+})
+
+test('allowedUndefinedStubProps can be extended and restored', async (t) => {
+  const customProp = 'myCustomProp'
+
+  const stub = makeStub('stub', {
+    name: 'stub-name',
+    count: 5,
+  })
+
+  t.throws(
+    () => {
+      // @ts-ignore
+      stub[customProp]
+    },
+    {
+      message: "Property 'stub.myCustomProp' does not exist",
+    },
+  )
+
+  allowedUndefinedStubProps.push('myCustomProp')
+
+  // @ts-ignore
+  t.is(stub[customProp], undefined)
+
+  allowedUndefinedStubProps.pop()
+
+  t.throws(
+    () => {
+      // @ts-ignore
+      stub[customProp]
+    },
+    {
+      message: "Property 'stub.myCustomProp' does not exist",
+    },
+  )
+})

--- a/test/util/testing-utils.test.ts
+++ b/test/util/testing-utils.test.ts
@@ -33,8 +33,8 @@ test('accessing an absent field should throw an error', async (t) => {
 
   t.throws(
     () => {
-      // @ts-ignore
-      stub.count
+      // @ts-expect-error intended
+      t.is(stub.count, undefined)
     },
     {
       message: "Property 'stub.count' does not exist",
@@ -52,8 +52,8 @@ test('accessing a nested absent field should throw an error', async (t) => {
 
   t.throws(
     () => {
-      // @ts-ignore
-      stub.nested.name
+      // @ts-expect-error intended
+      t.is(stub.nested.name, undefined)
     },
     {
       message: "Property 'stub.nested.name' does not exist",
@@ -67,9 +67,9 @@ test('fields used by jest are allowed to be undefined', async (t) => {
     count: 5,
   })
 
-  // @ts-ignore
+  // @ts-expect-error intended
   t.is(stub.nodeType, undefined)
-  // @ts-ignore
+  // @ts-expect-error intended
   t.is(stub.tagName, undefined)
 })
 
@@ -79,7 +79,7 @@ test('Symbol props are allowed to be undefined', async (t) => {
     count: 5,
   })
 
-  // @ts-ignore
+  // @ts-expect-error intended
   t.is(stub[Symbol('my symbol')], undefined)
 })
 
@@ -93,8 +93,8 @@ test('allowedUndefinedStubProps can be extended and restored', async (t) => {
 
   t.throws(
     () => {
-      // @ts-ignore
-      stub[customProp]
+      // @ts-expect-error intended
+      t.is(stub[customProp], undefined)
     },
     {
       message: "Property 'stub.myCustomProp' does not exist",
@@ -103,15 +103,15 @@ test('allowedUndefinedStubProps can be extended and restored', async (t) => {
 
   allowedUndefinedStubProps.push('myCustomProp')
 
-  // @ts-ignore
+  // @ts-expect-error intended
   t.is(stub[customProp], undefined)
 
   allowedUndefinedStubProps.pop()
 
   t.throws(
     () => {
-      // @ts-ignore
-      stub[customProp]
+      // @ts-expect-error intended
+      t.is(stub[customProp], undefined)
     },
     {
       message: "Property 'stub.myCustomProp' does not exist",


### PR DESCRIPTION
## Description

When writing unit tests it can be useful to pass stub objects.
If a field is missing on such a stub, it will be `undefined`, which then might cause confusing errors later.
So it's useful to know which fields are being accessed to be able to provide them proactively.

This PR adds a `makeStub` testing utility which wraps an object in a `Proxy` and throws an error if an absent property is accessed on object.