### PR TITLE
Update dependency eventsource from 2.0.2 to 4.0.0 and remove @types/eventsource

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "ajv": "8.17.1",
     "axios": "1.9.0",
-    "eventsource": "^4.0.0",
+    "eventsource": "4.0.0",
     "fastify": "5.3.3",
     "ioredis": "5.6.1",
     "mock-socket": "9.3.1",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "ajv": "8.17.1",
     "axios": "1.9.0",
-    "eventsource": "2.0.2",
+    "eventsource": "^4.0.0",
     "fastify": "5.3.3",
     "ioredis": "5.6.1",
     "mock-socket": "9.3.1",
@@ -36,7 +36,6 @@
   },
   "devDependencies": {
     "@sinonjs/fake-timers": "14.0.0",
-    "@types/eventsource": "1.1.15",
     "@types/node": "22.15.19",
     "@types/sinonjs__fake-timers": "8.1.5",
     "@types/ws": "8.18.1",

--- a/src/adapter/types.ts
+++ b/src/adapter/types.ts
@@ -1,4 +1,4 @@
-import type EventSource from 'eventsource'
+import type { EventSource } from 'eventsource'
 import Redis from 'ioredis'
 import { Cache } from '../cache'
 import { AdapterConfig, BaseAdapterSettings, SettingsDefinitionMap } from '../config'

--- a/src/transports/sse.ts
+++ b/src/transports/sse.ts
@@ -1,5 +1,5 @@
 import { AxiosRequestConfig } from 'axios'
-import EventSource from 'eventsource'
+import { EventSource, EventSourceInit } from 'eventsource'
 import { EndpointContext } from '../adapter'
 import { calculateHttpRequestKey } from '../cache'
 import { makeLogger, sleep } from '../util'
@@ -13,7 +13,7 @@ const logger = makeLogger('SSETransport')
 
 export interface SSEConfig {
   url: string
-  eventSourceInitDict?: EventSource.EventSourceInitDict
+  eventSourceInitDict?: EventSourceInit
 }
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -374,11 +374,6 @@
   resolved "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz"
   integrity sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==
 
-"@types/eventsource@1.1.15":
-  version "1.1.15"
-  resolved "https://registry.npmjs.org/@types/eventsource/-/eventsource-1.1.15.tgz"
-  integrity sha512-XQmGcbnxUNa06HR3VBVkc9+A2Vpi9ZyLJcdS5dwaQQ/4ZMWFO+5c90FnMUpbtMZwB/FChoYHwuVg8TvkECacTA==
-
 "@types/hast@^3.0.4":
   version "3.0.4"
   resolved "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz"
@@ -1268,10 +1263,17 @@ esutils@^2.0.2, esutils@^2.0.3:
   resolved "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz"
   integrity sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==
 
-eventsource@2.0.2:
-  version "2.0.2"
-  resolved "https://registry.npmjs.org/eventsource/-/eventsource-2.0.2.tgz"
-  integrity sha512-IzUmBGPR3+oUG9dUeXynyNmf91/3zUSJg1lCktzKw47OXuhco54U3r9B7O4XX+Rb1Itm9OZ2b0RkTs10bICOxA==
+eventsource-parser@^3.0.1:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/eventsource-parser/-/eventsource-parser-3.0.2.tgz#0fea1abd26eca8201099ff5212f6c4e7ca2fd5d3"
+  integrity sha512-6RxOBZ/cYgd8usLwsEl+EC09Au/9BcmCKYF2/xbml6DNczf7nv0MQb+7BA2F+li6//I+28VNlQR37XfQtcAJuA==
+
+eventsource@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/eventsource/-/eventsource-4.0.0.tgz#caf02d04143f663a61b09a993d0097e552e2b1d1"
+  integrity sha512-fvIkb9qZzdMxgZrEQDyll+9oJsyaVvY92I2Re+qK0qEJ+w5s0X3dtz+M0VAPOjP1gtU3iqWyjQ0G3nvd5CLZ2g==
+  dependencies:
+    eventsource-parser "^3.0.1"
 
 fast-copy@^3.0.2:
   version "3.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1268,7 +1268,7 @@ eventsource-parser@^3.0.1:
   resolved "https://registry.yarnpkg.com/eventsource-parser/-/eventsource-parser-3.0.2.tgz#0fea1abd26eca8201099ff5212f6c4e7ca2fd5d3"
   integrity sha512-6RxOBZ/cYgd8usLwsEl+EC09Au/9BcmCKYF2/xbml6DNczf7nv0MQb+7BA2F+li6//I+28VNlQR37XfQtcAJuA==
 
-eventsource@^4.0.0:
+eventsource@4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/eventsource/-/eventsource-4.0.0.tgz#caf02d04143f663a61b09a993d0097e552e2b1d1"
   integrity sha512-fvIkb9qZzdMxgZrEQDyll+9oJsyaVvY92I2Re+qK0qEJ+w5s0X3dtz+M0VAPOjP1gtU3iqWyjQ0G3nvd5CLZ2g==


### PR DESCRIPTION
# Description

The [renovate PR](https://github.com/smartcontractkit/ea-framework-js/pull/347) to update `@types/eventsource` to v3 had failures.
While investigating I found that @types/eventsource was [removed](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/71870) because the types are included in `eventsource` starting from version 3.0.0.

# Changes

1. Ran `yarn remove @types/eventsource`.
2. Ran `yarn add eventsource`.
3. Fixed import statements.
4. Changed `EventSource.EventSourceInitDict` to `EventSourceInit`
5. Removed `^` from version after `pinned-dependencies.yaml` failed.