### PR TITLE
Cast mock logger factory for Pino update

### DIFF
--- a/test/custom-logger.test.ts
+++ b/test/custom-logger.test.ts
@@ -30,7 +30,7 @@ test('custom logger instance is properly injected', async (t) => {
         },
       }
     },
-  }
+  } as unknown as LoggerFactory
 
   const adapter = new Adapter({
     name: 'TEST',


### PR DESCRIPTION
# Description

https://github.com/smartcontractkit/ea-framework-js/pull/534 is an automated update PR by Renovate which tries to update Pino from 9.7.0 to 9.9.0.
It results in a [test compilation failure](https://github.com/smartcontractkit/ea-framework-js/actions/runs/17040067194/job/48301410789?pr=534) because a mock logger factory no longer matches the `LoggerFactory` type because it now needs to have a `msgPrefix` field.
I can reproduce this locally with
```
yarn && yarn test
```
The `msgPrefix` field is no relevant for the test so we can simply cast the mock to `LoggerFactory` for the test to work again.
I've tested this in the update PR but am making this a separate PR so the update PR can remain automated without manual changes.

# Changes

Cast mock logger factory to `LoggerFactory`.