### PR TITLE
export HttpTransportGenerics

### DIFF
--- a/src/transports/http.ts
+++ b/src/transports/http.ts
@@ -18,7 +18,7 @@ const logger = makeLogger('HttpTransport')
  * Helper struct type that will be used to pass types to the generic parameters of a Transport.
  * Extends the common TransportGenerics, adding Provider specific types for this Batch endpoint.
  */
-type HttpTransportGenerics = TransportGenerics & {
+export type HttpTransportGenerics = TransportGenerics & {
   /**
    * Type details for any provider specific interfaces.
    */


### PR DESCRIPTION
# Description

In `por-address-list` in https://github.com/smartcontractkit/external-adapters-js/ I was trying to reuse code between `VirtuneTransport` and `VirtuneTokenTransport` by creating a base class for the two, extending `HttpTransport`. But I couldn't get it to work because it needed a type parameter extending `HttpTransportGenerics` which isn't exported.

I have worked around the issue because I didn't want to wait for a framework release. But if something similar comes up after the next framework release, it would be nice if this was no longer a problem.

# Changes

Export `HttpTransportGenerics`

# Testing

Not tested.