### PR TITLE
Add filtered URL label to ws_connection_failover_count metrics

### DIFF
--- a/src/metrics/index.ts
+++ b/src/metrics/index.ts
@@ -360,6 +360,6 @@ export const metrics = new Metrics(() => ({
   wsConnectionFailoverCount: new client.Gauge({
     name: 'ws_connection_failover_count',
     help: 'The number of consecutive unresponsive connection detections (no data for WS_SUBSCRIPTION_UNRESPONSIVE_TTL), used to trigger URL failover',
-    labelNames: ['transport_name'] as const,
+    labelNames: ['transport_name', 'url'] as const,
   }),
 }))

--- a/src/transports/websocket.ts
+++ b/src/transports/websocket.ts
@@ -417,9 +417,12 @@ export class WebSocketTransport<
       logger.info(
         `The connection is unresponsive (last message ${timeSinceLastMessage}ms ago), incremented failover counter to ${this.streamHandlerInvocationsWithNoConnection}`,
       )
+      // Filter out query params from the URL to avoid leaking sensitive data
+      // and prevent metric cardinality explosion
+      const filteredUrl = this.currentUrl.split('?')[0]
       metrics
         .get('wsConnectionFailoverCount')
-        .labels({ transport_name: this.name })
+        .labels({ transport_name: this.name, url: filteredUrl })
         .set(this.streamHandlerInvocationsWithNoConnection)
     }
 


### PR DESCRIPTION
Needed to make the metric series unique.

Uses the filtered URL version to not leak URL query params, similar to how `ws_connection_closures ` is produced.