### PR TITLE
fix(deps): update tar from 7.5.7 to 7.5.9

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -2732,9 +2732,9 @@ supports-preserve-symlinks-flag@^1.0.0:
   integrity sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==
 
 tar@^7.4.0:
-  version "7.5.7"
-  resolved "https://registry.yarnpkg.com/tar/-/tar-7.5.7.tgz#adf99774008ba1c89819f15dbd6019c630539405"
-  integrity sha512-fov56fJiRuThVFXD6o6/Q354S7pnWMJIVlDBYijsTNx6jKSE4pvrDTs6lUnmGvNyfJwFQQwWy3owKz1ucIhveQ==
+  version "7.5.9"
+  resolved "https://registry.yarnpkg.com/tar/-/tar-7.5.9.tgz#817ac12a54bc4362c51340875b8985d7dc9724b8"
+  integrity sha512-BTLcK0xsDh2+PUe9F6c2TlRp4zOOBMTkoQHQIWSIzI0R7KG46uEwq4OPk2W7bZcprBMsuaeFsqwYr7pjh6CuHg==
   dependencies:
     "@isaacs/fs-minipass" "^4.0.0"
     chownr "^3.0.0"


### PR DESCRIPTION
## Dependabot Security Alert Fixes

**Repository:** `smartcontractkit/ea-framework-js`
**Ecosystem:** npm (Yarn 1.x)
**Alerts:** 1 open | 1 fixed | 0 blocked

### Fixed Alerts

| # | CVE | Severity | CVSS | Dependency | Fix |
|---|-----|----------|------|------------|-----|
| 66 | CVE-2026-26960 | High | 7.1 | `tar` | Updated 7.5.7 → 7.5.9 in yarn.lock |

**Dependency chain:** `ava` → `@vercel/nft` → `@mapbox/node-pre-gyp` → `tar` (transitive, dev scope)

### How these changes were made

1. Updated `tar` version, resolved URL, and integrity hash directly in `yarn.lock` (3 lines changed).
2. Parent `@mapbox/node-pre-gyp` specifies `^7.4.0`, so 7.5.9 is fully compatible.
3. Verified `yarn install` succeeds and `yarn why tar` confirms 7.5.9.
4. TypeScript compilation passes, all 279 tests pass.

### Pre-existing Issues (unrelated)

- `yarn build` fails on main branch due to `@inquirer/core@11.0.1` requiring Node >= 20.12.0 while local Node is 20.11.0. This affects the generator-adapter sub-package only and is not caused by this change.

### Blocked / Needs Approval

None. All open alerts are resolved.

### Verification

- [x] `yarn install` succeeds
- [x] `yarn why tar` confirms 7.5.9
- [x] TypeScript compilation passes
- [x] All 279 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)