### PR TITLE
Replace all hyphens in adapter name with underscore

### DIFF
--- a/scripts/generator-adapter/generators/app/templates/src/index.ts.ejs
+++ b/scripts/generator-adapter/generators/app/templates/src/index.ts.ejs
@@ -9,7 +9,7 @@ export const adapter = new Adapter({
 <% } -%><%= ' ' %> defaultEndpoint: <%= defaultEndpoint.normalizedEndpointName %>.name,
 <% if (includeComments) { -%>
   // Adapter name
-<% } -%><%= ' ' %> name: '<%= adapterName.toUpperCase().replace('-', '_') %>',
+<% } -%><%= ' ' %> name: '<%= adapterName.toUpperCase().replaceAll('-', '_') %>',
 <% if (includeComments) { -%>
   // Adapter configuration (environment variables)
 <% } -%><%= ' ' %> config,


### PR DESCRIPTION
# Description

When using `yarn new` in [external-adapters-js](https://github.com/smartcontractkit/external-adapters-js/tree/main) to create a new adapter, if the adapter name has a hyphen in it, this hyphen gets replaced with an underscore, as well as the letter turned to upper case, to determine the name of the adapter object.

See for example ["generic-api" became "GENERIC_API"](https://github.com/smartcontractkit/external-adapters-js/blob/9c9a8e875166dd6b6614c910ab8d6c1a37ee8286/packages/sources/generic-api/src/index.ts#L8).

But if the name has multiple hyphens, only the first one gets replaced by an underscore and we need to fix this manually, which sometimes is forgotten. For example ["bitgo-reserves-test" became "BITGO_RESERVES-TEST"](https://github.com/smartcontractkit/external-adapters-js/blob/9c9a8e875166dd6b6614c910ab8d6c1a37ee8286/packages/sources/bitgo-reserves-test/src/index.ts#L8).

# Changes

Fix the template code to call `replaceAll` instead of `replace`.

# Testing

In `external-adapters-js`:

1.  Use [these instructions](https://github.com/smartcontractkit/external-adapters-js/blob/main/CONTRIBUTING.md#framework-development) to point `packages/scripts/package.json` to the local framework repo with the fix.
2. Run `yarn new` and follow the instructions.
3. Create an adapter with name `aa-bb-cc-dd`.
4. Inspect the contents of `packages/sources/aa-bb-cc-dd/src/index.ts`
