### PR TITLE
Add "noUncheckedIndexedAccess": true to compilerOptions

### DIFF
--- a/scripts/generator-adapter/generators/app/templates/src/transport/http.ts.ejs
+++ b/scripts/generator-adapter/generators/app/templates/src/transport/http.ts.ejs
@@ -60,10 +60,14 @@ export const httpTransport = new HttpTransport<HttpTransportTypes>({
 <% } -%>
   parseResponse: (params, response) => {
 <% if (includeComments) { -%>
-    // In case error was received, it's a good practice to return meaningful information to user
+    // For each 'param' a new response object is created and returned as an array
 <% } -%>
-    if (!response.data) {
-      return params.map((param) => {
+    return params.map((param) => {
+<% if (includeComments) { -%>
+      // In case error was received, it's a good practice to return meaningful information to user
+<% } -%>
+      const baseSymbol = param.base.toUpperCase()
+      if (!response.data || !response.data[baseSymbol]) {
         return {
           params: param,
           response: {
@@ -71,14 +75,9 @@ export const httpTransport = new HttpTransport<HttpTransportTypes>({
             statusCode: 502,
           },
         }
-      })
-    }
+      }
 
-<% if (includeComments) { -%>
-    // For successful responses for each 'param' a new response object is created and returned as an array
-<% } -%>
-    return params.map((param) => {
-      const result = response.data[param.base.toUpperCase()].price
+      const result = response.data[baseSymbol].price
 <% if (includeComments) { -%>
       // Response objects, whether successful or errors, contain two properties, 'params' and 'response'. 'response' is what will be
       // stored in the cache and returned as adapter response and 'params' determines the identifier so that the next request with same 'params'

--- a/scripts/generator-adapter/generators/app/templates/tsconfig.json
+++ b/scripts/generator-adapter/generators/app/templates/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "<%- standalone ? "./tsconfig.base.json" : "../../tsconfig.base.json" %>",
   "compilerOptions": {
     "outDir": "dist",
-    "rootDir": "src"
+    "rootDir": "src",
+    "noUncheckedIndexedAccess": true
   },
   "include": ["src/**/*", "src/**/*.json"],
   "exclude": ["dist", "**/*.spec.ts", "**/*.test.ts"]


### PR DESCRIPTION
# Description

There was a bug in the iTick EA that could have been caught by the compiler if the compiler had realized that `someArray[0]` is `undefined` if the array is empty. But the compiler doesn't do that unless `noUncheckedIndexedAccess` is enabled.

If we change the generator template, we can make sure this option is enabled by default in future EAs.

# Changes

1. Add `"noUncheckedIndexedAccess": true` to `"compilerOptions": {` in `scripts/generator-adapter/generators/app/templates/tsconfig.json`.
2. Update the generated code to satisfy the new compiler check.

# Tested

In external-adapters-js:

1. Use [these instructions](https://github.com/smartcontractkit/external-adapters-js/blob/main/CONTRIBUTING.md#framework-development) to point packages/scripts/package.json to the local framework repo with the change.
3. Run `yarn new` and follow the instructions.
4. Create an adapter with name `abcd`.
5. Inspect the contents of `packages/sources/abcd/tsconfig.json`.
6. Build the generated adapter.