### PR TITLE
OPDATA-6579: Improve config type declarations

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -486,7 +486,7 @@ export const getEnv = (
 }
 
 type SettingValueType = string | number | boolean
-type ConcreteSettingType<C extends SettingDefinition> = C['type'] extends 'string'
+type SettingTypeWhenPresent<C extends SettingDefinition> = C['type'] extends 'string'
   ? string
   : C['type'] extends 'number'
     ? number
@@ -498,36 +498,29 @@ type ConcreteSettingType<C extends SettingDefinition> = C['type'] extends 'strin
           : never
         : never
 type SettingType<C extends SettingDefinition> = C extends HasDefault | IsRequired
-  ? ConcreteSettingType<C>
-  : ConcreteSettingType<C> | undefined
+  ? SettingTypeWhenPresent<C>
+  : SettingTypeWhenPresent<C> | undefined
 
 export type BaseSettingsDefinitionType = typeof BaseSettingsDefinition
-
-export type MaybeRequiredSettingDefinition =
-  | {
-      required?: false
-    }
-  | {
-      required: true
-    }
 
 export type SettingDefinitionBase = {
   description: string
   sensitive?: boolean
-} & MaybeRequiredSettingDefinition
+  required?: boolean
+}
 
 export type NonEnumSettingDefinition<TypeString, Type> = SettingDefinitionBase & {
   type: TypeString
-  options?: never
   default?: Type
   validate?: Validator<Type>
+  options?: never
 }
 
 export type EnumSettingDefinition = SettingDefinitionBase & {
   type: 'enum'
-  options: readonly string[]
   default?: string
   validate?: Validator<string>
+  options: readonly string[]
 }
 
 export type SettingDefinition =

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -486,7 +486,7 @@ export const getEnv = (
 }
 
 type SettingValueType = string | number | boolean
-type SettingType<C extends SettingDefinition> = C['type'] extends 'string'
+type ConcreteSettingType<C extends SettingDefinition> = C['type'] extends 'string'
   ? string
   : C['type'] extends 'number'
     ? number
@@ -497,6 +497,8 @@ type SettingType<C extends SettingDefinition> = C['type'] extends 'string'
           ? C['options'][number]
           : never
         : never
+type SettingType<C extends SettingDefinition> = C extends HasDefault | IsRequired ? ConcreteSettingType<C> : ConcreteSettingType<C> | undefined
+
 export type BaseSettingsDefinitionType = typeof BaseSettingsDefinition
 
 export type MaybeRequiredSettingDefinition =
@@ -545,7 +547,7 @@ type NonOptionalSettingKeys<T extends SettingsDefinitionMap> = Exclude<
 >
 
 export type Settings<T extends SettingsDefinitionMap> = {
-  -readonly [K in OptionalSettingKeys<T>]?: SettingType<T[K]> | undefined
+  -readonly [K in OptionalSettingKeys<T>]?: SettingType<T[K]>
 } & {
   -readonly [K in NonOptionalSettingKeys<T>]: SettingType<T[K]>
 }

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -497,7 +497,9 @@ type ConcreteSettingType<C extends SettingDefinition> = C['type'] extends 'strin
           ? C['options'][number]
           : never
         : never
-type SettingType<C extends SettingDefinition> = C extends HasDefault | IsRequired ? ConcreteSettingType<C> : ConcreteSettingType<C> | undefined
+type SettingType<C extends SettingDefinition> = C extends HasDefault | IsRequired
+  ? ConcreteSettingType<C>
+  : ConcreteSettingType<C> | undefined
 
 export type BaseSettingsDefinitionType = typeof BaseSettingsDefinition
 

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -498,90 +498,56 @@ type SettingType<C extends SettingDefinition> = C['type'] extends 'string'
           : never
         : never
 export type BaseSettingsDefinitionType = typeof BaseSettingsDefinition
-export type SettingDefinition =
+
+export type MaybeRequiredSettingDefinition =
   | {
-      type: 'string'
-      description: string
-      options?: never
-      default?: string
-      validate?: Validator<string>
-      required?: false
-      sensitive?: boolean
-    }
-  | {
-      type: 'string'
-      description: string
-      options?: never
-      default?: string
-      validate?: Validator<string>
-      required: true
-      sensitive?: boolean
-    }
-  | {
-      type: 'number'
-      description: string
-      options?: never
-      default?: number
-      validate?: Validator<number>
       required?: false
     }
   | {
-      type: 'number'
-      description: string
-      options?: never
-      default?: number
-      validate?: Validator<number>
-      required: true
-    }
-  | {
-      type: 'boolean'
-      description: string
-      options?: never
-      default?: boolean
-      validate?: Validator<boolean>
-      required?: false
-    }
-  | {
-      type: 'boolean'
-      description: string
-      options?: never
-      default?: boolean
-      validate?: Validator<boolean>
-      required: true
-    }
-  | {
-      type: 'enum'
-      description: string
-      default?: string
-      options: readonly string[]
-      validate?: Validator<string>
-      required?: false
-    }
-  | {
-      type: 'enum'
-      description: string
-      default?: string
-      options: readonly string[]
-      validate?: Validator<string>
       required: true
     }
 
+export type SettingDefinitionBase = {
+  description: string
+  sensitive?: boolean
+} & MaybeRequiredSettingDefinition
+
+export type NonEnumSettingDefinition<TypeString, Type> = SettingDefinitionBase & {
+  type: TypeString
+  options?: never
+  default?: Type
+  validate?: Validator<Type>
+}
+
+export type EnumSettingDefinition = SettingDefinitionBase & {
+  type: 'enum'
+  options: readonly string[]
+  default?: string
+  validate?: Validator<string>
+}
+
+export type SettingDefinition =
+  | NonEnumSettingDefinition<'string', string>
+  | NonEnumSettingDefinition<'number', number>
+  | NonEnumSettingDefinition<'boolean', boolean>
+  | EnumSettingDefinition
+
+type HasDefault = { default: SettingValueType }
+type IsRequired = { required: true }
+
+type OptionalSettingKeys<T extends SettingsDefinitionMap> = {
+  [K in keyof T]: T[K] extends HasDefault | IsRequired ? never : K
+}[keyof T]
+
+type NonOptionalSettingKeys<T extends SettingsDefinitionMap> = Exclude<
+  keyof T,
+  OptionalSettingKeys<T>
+>
+
 export type Settings<T extends SettingsDefinitionMap> = {
-  -readonly [K in keyof T as T[K] extends {
-    default: SettingValueType
-  }
-    ? K
-    : T[K]['required'] extends true
-      ? K
-      : never]: SettingType<T[K]>
+  -readonly [K in OptionalSettingKeys<T>]?: SettingType<T[K]> | undefined
 } & {
-  -readonly [K in keyof T as T[K] extends {
-    default: SettingValueType
-  }
-    ? never
-    : T[K]['required'] extends true
-      ? never
-      : K]?: SettingType<T[K]> | undefined
+  -readonly [K in NonOptionalSettingKeys<T>]: SettingType<T[K]>
 }
 
 export type BaseAdapterSettings = Settings<BaseSettingsDefinitionType>

--- a/test/config.types.test.ts
+++ b/test/config.types.test.ts
@@ -1,5 +1,5 @@
 import test from 'ava'
-import { SettingDefinition, Settings } from '../src/config'
+import { SettingsDefinitionMap, SettingDefinition, Settings } from '../src/config'
 
 // This file has type declarations that test the types of the config system at
 // compile time.
@@ -156,6 +156,61 @@ const _settingsType: ExpectEqual<
   ExpectedSettingsType
 > = true
 void _settingsType
+
+// Reproduces the bug from `packages/sources/liveart/src/config/index.ts`.
+// Annotating the variable with the default `SettingsDefinitionMap` (no
+// inferred generic) widens the settings map to `Record<string,
+// SettingDefinition>`. Any custom setting then resolves via an index
+// signature whose value type is the full `SettingType<SettingDefinition>`
+// union.
+//
+// Previously this collapsed to `undefined` (because `SettingType` was not
+// distributive over `SettingDefinition`), which silently allowed values
+// like `adapterSettings.API_BASE_URL` to be passed into stricter types
+// such as Axios's `baseURL: string | undefined`.
+const wideConfig: SettingsDefinitionMap = {
+  API_BASE_URL: {
+    type: 'string',
+    description: 'API base URL',
+    required: true,
+    default: 'https://example.com',
+  },
+}
+void wideConfig
+
+const _wideConfigAccess: ExpectEqual<
+  Settings<typeof wideConfig>['API_BASE_URL'],
+  string | number | boolean | undefined
+> = true
+void _wideConfigAccess
+
+// The tests below are not directly a test of the config types, but it
+// demonstrates an important principle used in SettingType.
+
+type MyType = { foo: number } | { foo: string }
+
+type TypeOfFoo<T extends { foo: unknown }> = T['foo'] extends string
+  ? string
+  : T['foo'] extends number
+    ? number
+    : never
+
+type DistributeTypeOfFoo<T extends { foo: unknown }> = T extends never ? never : TypeOfFoo<T>
+
+// If TypeOfFoo is applied directly to MyType, it will evaluate T['foo'] as
+// `string | number`, which does not satisfy either condition and results in
+// `never`.
+const _testTypeOfFooDirectly: ExpectEqual<TypeOfFoo<MyType>, never> = true
+void _testTypeOfFooDirectly
+
+// But if you do the same inside a seemingly useless conditional, it will apply
+// `TypeOfFoo` to each member of the union separately (first to
+// `{ foo: number }` and then to `{ foo: string }`), and then combine the
+// results together. So it will evaluate to `number` for the first member and
+// `string` for the second member, and the result will be `number | string`.
+// then unions the results together.
+const _testTypeOfFooDistributed: ExpectEqual<DistributeTypeOfFoo<MyType>, string | number> = true
+void _testTypeOfFooDistributed
 
 test('add one actual test so the test framework does not complain', (t) => {
   t.pass()

--- a/test/config.types.test.ts
+++ b/test/config.types.test.ts
@@ -1,3 +1,4 @@
+import test from 'ava'
 import { SettingDefinition, Settings } from '../src/config'
 
 // This file has type declarations that test the types of the config system at
@@ -155,3 +156,7 @@ const _settingsType: ExpectEqual<
   ExpectedSettingsType
 > = true
 void _settingsType
+
+test('add one actual test so the test framework does not complain', (t) => {
+  t.pass()
+})


### PR DESCRIPTION
# [OPDATA-6579](https://smartcontract-it.atlassian.net/browse/OPDATA-6579)

# Context

`src/config/index.ts` has a really long fully expanded type declaration for `SettingDefinition`.
This makes it hard to see the structure:
* There are 4 types: string, number, boolean and enum
* string, number and boolean are treated similarly but enum is special
* Each member of the union has a version with `required: true` and a version with `required?: false`

Also, it turns out that having separate union members for `required: true` and `required?: false` is not actually necessary. I realized this because otherwise we would also need separately members for `default?: never` and `default: string`.

Lastly, the definition of `Settings` is quite hard to read. What it actually does, is it splits the fields into ones that are guaranteed to be present (because they are required or have a default specified) and ones that aren't. Then it declares the guaranteed ones as plain types and the others as optional.

# Changes

1. Rename `SettingType` to `SettingTypeWhenPresent` to indicate that it doesn't take into account that optional variables can be `undefined`.
2. Introduce a new `SettingType` which does evaluate to `T | undefined` if the variable is optional.
3. Refactor `SettingDefinition` to clearly demonstrate its structure.
4. Refactor `Settings` to make it more readable.

# Tested

I used [these instruction](https://github.com/smartcontractkit/external-adapters-js/blob/main/CONTRIBUTING.md#framework-development) to test these changes with every existing EA.

There were 2 EAs with compilation errors but they have the same errors without my changes, because they are just not compatible with the newest framework version: `ncfx` and `deutsche-boerse`.

And there was 1 EA with compilation errors that were not there before: `liveart`. This exposed a bug in `liveart` which is fixed in https://github.com/smartcontractkit/external-adapters-js/pull/4891.

[OPDATA-6579]: https://smartcontract-it.atlassian.net/browse/OPDATA-6579?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ