### PR TITLE
Optional sleep in http transport

### DIFF
--- a/src/transports/http.ts
+++ b/src/transports/http.ts
@@ -93,6 +93,9 @@ export interface HttpTransportConfig<T extends HttpTransportGenerics> {
     res: AxiosResponse<T['Provider']['ResponseBody']>,
     adapterSettings: T['Settings'],
   ) => ProviderResult<T>[]
+
+  // Optional custom sleep time for the background execute loop
+  backgroundSleepMs?: number
 }
 
 /**
@@ -189,6 +192,11 @@ export class HttpTransport<T extends HttpTransportGenerics> extends Subscription
     // We're not sleeping here on purpose. We sleep when there are no entries in the subscription set to avoid polling too
     // frequently, but if we have entries we want the background execute to be re-run ASAP so we can prepare the next batch
     // of requests, and the sleep to rate-limit will be performed by the rate-limiter in the Requester.
+    // Unless config.backgroundSleepMs is set
+    if (this.config.backgroundSleepMs) {
+      logger.trace(`Sleep ${this.config.backgroundSleepMs}ms - config.backgroundSleepMs`)
+      await sleep(this.config.backgroundSleepMs)
+    }
     return
   }
 

--- a/test/transports/http.test.ts
+++ b/test/transports/http.test.ts
@@ -93,8 +93,12 @@ const BACKGROUND_EXECUTE_MS_HTTP = 1000
 class MockHttpTransport extends HttpTransport<HttpTransportTypes> {
   backgroundExecuteCalls = 0
 
-  constructor(private callSuper = false) {
+  constructor(
+    private callSuper = false,
+    backgroundSleepMs?: number,
+  ) {
     super({
+      backgroundSleepMs,
       prepareRequests: (params) => ({
         params,
         request: {
@@ -202,6 +206,45 @@ test.serial('sends request to DP and returns response', async (t) => {
     },
   })
 })
+
+test.serial(
+  'backgroundSleepMs delays data provider requests until the configured sleep has elapsed on the fake clock',
+  async (t) => {
+    const bgSleepMs = 2_000
+    const fromSymbol = 'BGSLEEPCHK'
+    let dataProviderRequests = 0
+
+    axiosMock
+      .onPost(URL + endpoint, {
+        pairs: [{ base: fromSymbol, quote: to }],
+      })
+      .reply(() => {
+        dataProviderRequests++
+        return [200, {}]
+      })
+
+    const adapter = new Adapter({
+      name: 'TEST',
+      defaultEndpoint: 'test',
+      endpoints: [
+        new AdapterEndpoint({
+          name: 'test',
+          inputParameters,
+          transport: new MockHttpTransport(true, bgSleepMs),
+        }),
+      ],
+    })
+
+    const testAdapter = await TestAdapter.startWithMockedCache(adapter, t.context)
+    await testAdapter.request({ from: fromSymbol, to })
+
+    t.is(dataProviderRequests, 0)
+    await runAllUntilTime(t.context.clock, bgSleepMs / 2)
+    t.is(dataProviderRequests, 0)
+    await runAllUntilTime(t.context.clock, bgSleepMs)
+    t.is(dataProviderRequests, 1)
+  },
+)
 
 test.serial(
   'per minute rate limit of 4 with one batch transport results in a call every 15s',


### PR DESCRIPTION
Add ability to sleep between http background execute cycles.

One of the use case is fallback transport, we may not want the fallback transport to go full speed on fetching values.