### PR TITLE
OPDATA-6579: Make Settings type stricter

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -532,14 +532,22 @@ export type SettingDefinition =
 type HasDefault = { default: SettingValueType }
 type IsRequired = { required: true }
 
-type OptionalSettingKeys<T extends SettingsDefinitionMap> = {
-  [K in keyof T]: T[K] extends HasDefault | IsRequired ? never : K
+type IsOptional = {
+  default?: never
+  required?: false
+  // With just `default` and `required` both optional, the type matches `{}`,
+  // which means it's a weak type which gets treated differently by TypeScript.
+  // So we add `description`, which is anyway guaranteed to be present.
+  description: string
+}
+
+type NonOptionalSettingKeys<T extends SettingsDefinitionMap> = {
+  [K in keyof T]: T[K] extends HasDefault | IsRequired ? K : never
 }[keyof T]
 
-type NonOptionalSettingKeys<T extends SettingsDefinitionMap> = Exclude<
-  keyof T,
-  OptionalSettingKeys<T>
->
+type OptionalSettingKeys<T extends SettingsDefinitionMap> = {
+  [K in keyof T]: T[K] extends IsOptional ? K : never
+}[keyof T]
 
 export type Settings<T extends SettingsDefinitionMap> = {
   -readonly [K in OptionalSettingKeys<T>]?: SettingType<T[K]>

--- a/test/config.types.test.ts
+++ b/test/config.types.test.ts
@@ -1,5 +1,5 @@
 import test from 'ava'
-import { SettingsDefinitionMap, SettingDefinition, Settings } from '../src/config'
+import { AdapterConfig, SettingDefinition, Settings } from '../src/config'
 
 // This file has type declarations that test the types of the config system at
 // compile time.
@@ -158,7 +158,7 @@ const _settingsType: ExpectEqual<
 void _settingsType
 
 // Reproduces the bug from `packages/sources/liveart/src/config/index.ts`.
-// Annotating the variable with the default `SettingsDefinitionMap` (no
+// Annotating the variable with the default `AdapterConfig` (no
 // inferred generic) widens the settings map to `Record<string,
 // SettingDefinition>`. Any custom setting then resolves via an index
 // signature whose value type is the full `SettingType<SettingDefinition>`
@@ -168,20 +168,19 @@ void _settingsType
 // distributive over `SettingDefinition`), which silently allowed values
 // like `adapterSettings.API_BASE_URL` to be passed into stricter types
 // such as Axios's `baseURL: string | undefined`.
-const wideConfig: SettingsDefinitionMap = {
+const wideConfig: AdapterConfig = new AdapterConfig({
   API_BASE_URL: {
     type: 'string',
     description: 'API base URL',
     required: true,
     default: 'https://example.com',
   },
-}
-void wideConfig
+})
 
-const _wideConfigAccess: ExpectEqual<
-  Settings<typeof wideConfig>['API_BASE_URL'],
-  string | number | boolean | undefined
-> = true
+wideConfig.initialize()
+
+// @ts-expect-error TS2339: Property 'API_BASE_URL' does not exist on type 'AdapterConfig<SettingsDefinitionMap>'.
+const _wideConfigAccess = wideConfig.settings.API_BASE_URL
 void _wideConfigAccess
 
 // The tests below are not directly a test of the config types, but it


### PR DESCRIPTION
# Context

When `OptionalSettingKeys` are defined as the negation of `extends HasDefault | IsRequired`,
```
type OptionalSettingKeys<T extends SettingsDefinitionMap> = {
  [K in keyof T]: T[K] extends HasDefault | IsRequired ? never : K
}[keyof T]
```
this also includes hypothetical keys where `required` isn't `true` or `false` but just `boolean`.
In particular, this happens when we don't specify a specific config but declare the default config, as was the case with the `liveart` EA before it got fixed in https://github.com/smartcontractkit/external-adapters-js/pull/4891

These keys then appear in the `OptionalSettingKeys` which is surprising because `required` could still be true at runtime.

This results in these keys getting a broad type like `string | number | boolean | undefined` which results in a compiler error in most cases but isn't the best way to accomplish this.

Stricter is to declare both `OptionalSettingKeys` and `NonOptionalSettingKeys` directly as a specific literal type. Then, if `required` is neither specifically `true` nor specifically `false` (or absent), those keys will be completely excluded.

The result is that in case of `liveart`, instead of getting this error for the incorrect use of `adapterSettings.API_BASE_URL`:
```
$ yarn tsc -b --noEmit packages/tsconfig.json 
packages/sources/liveart/src/transport/nav.ts:38:3 - error TS2322: Type '(params: ({ assetId: string; } & {})[], adapterSettings: AdapterSettings<SettingsDefinitionMap>) => { params: ({ assetId: string; } & {})[]; request: { baseURL: string | number | boolean | undefined; url: string; }; }[]' is not assignable to type '(params: ({ assetId: string; } & {})[], adapterSettings: AdapterSettings<SettingsDefinitionMap>) => ProviderRequestConfig<HttpTransportTypes> | ProviderRequestConfig<HttpTransportTypes>[]'.
  Type '{ params: ({ assetId: string; } & {})[]; request: { baseURL: string | number | boolean | undefined; url: string; }; }[]' is not assignable to type 'ProviderRequestConfig<HttpTransportTypes> | ProviderRequestConfig<HttpTransportTypes>[]'.
    Type '{ params: ({ assetId: string; } & {})[]; request: { baseURL: string | number | boolean | undefined; url: string; }; }[]' is not assignable to type 'ProviderRequestConfig<HttpTransportTypes>[]'.
      Type '{ params: ({ assetId: string; } & {})[]; request: { baseURL: string | number | boolean | undefined; url: string; }; }' is not assignable to type 'ProviderRequestConfig<HttpTransportTypes>'.
        The types of 'request.baseURL' are incompatible between these types.
          Type 'string | number | boolean | undefined' is not assignable to type 'string | undefined'.
            Type 'number' is not assignable to type 'string'.

38   prepareRequests: (params, adapterSettings) => {
     ~~~~~~~~~~~~~~~

  ../../ea-framework-js/tree3/dist/src/transports/http.d.ts:57:5
    57     prepareRequests: (params: TypeFromDefinition<T['Parameters']>[], adapterSettings: T['Settings']) => ProviderRequestConfig<T> | ProviderRequestConfig<T>[];
           ~~~~~~~~~~~~~~~
    The expected type comes from property 'prepareRequests' which is declared here on type 'HttpTransportConfig<HttpTransportTypes>'


Found 1 error.
```
we get this much clearer error:
```
$ yarn tsc -b --noEmit packages/tsconfig.json 
packages/sources/liveart/src/transport/nav.ts:43:36 - error TS2551: Property 'API_BASE_URL' does not exist on type 'AdapterSettings<SettingsDefinitionMap>'. Did you mean 'BASE_URL'?

43           baseURL: adapterSettings.API_BASE_URL,
                                      ~~~~~~~~~~~~


Found 1 error.
```

The only problem is that when we define `IsOptional` as `{ default?: never; required?: false }` this makes it a [weak type](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-4.html#weak-type-detection), which is treated differently by TypeScript. So we add `{ description: string }` because it's guaranteed to be present anyway.

# Changes

Make the `Settings` type stricter as described above.

# Testing

I used [these instruction](https://github.com/smartcontractkit/external-adapters-js/blob/main/CONTRIBUTING.md#framework-development) to test these changes with every existing EA. There were no additional compilation errors.