### PR TITLE
Throw AdapterError instead of Error when variable env var is missing

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,4 +1,5 @@
 import CensorList, { CensorKeyValue } from '../util/censor/censor-list'
+import { AdapterError } from '../validation/error'
 import { Validator, validator } from '../validation/utils'
 
 export const BaseSettingsDefinition = {
@@ -597,7 +598,10 @@ export class EnvGetter<
       this.name.replace(this.settingsDefinition.variablePlaceholder, canonicalVariable),
       this.prefix,
     )
-    throw new Error(`Missing required environment variable: ${envName}`)
+    throw new AdapterError({
+      statusCode: 500,
+      message: `Missing required environment variable: ${envName}`,
+    })
   }
 
   entries(): VariableEnvVarEntry<SettingTypeWhenPresent<T>>[] {

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -6,6 +6,7 @@ import {
   SettingDefinition,
   SettingsDefinitionMap,
 } from '../src/config'
+import { AdapterError } from '../src/validation/error'
 import { validator } from '../src/validation/utils'
 import { Adapter } from '../src/adapter'
 import { buildSettingsList } from '../src/util/settings'
@@ -317,7 +318,8 @@ test.serial('Get required variable env var', async (t) => {
     config.settings.NETWORK_RPC_URL.get('arbitrum')
     t.fail()
   } catch (error) {
-    t.is((error as Error).message, 'Missing required environment variable: ARBITRUM_RPC_URL')
+    t.is((error as AdapterError).message, 'Missing required environment variable: ARBITRUM_RPC_URL')
+    t.is((error as AdapterError).statusCode, 500)
   }
 })
 


### PR DESCRIPTION
# Description

Most errors thrown in `src/config/index.ts` are thrown during adapter initialization.
But the error that's thrown when a required variable env var is missing, is likely to be thrown during request validation.
By making it an `AdapterError` instead of `Error`, the adapter will returns a proper json response with `statusCode` instead of just a string.

# Changes

Throw `AdapterError` instead of `Error` when a required variable env var is missing when requested.

# Testing

Used with `proof-of-reserves-v2` in the EA repo.