### PR TITLE
Adjust TLS env var logic

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -43,21 +43,23 @@ export const getTLSOptions = (adapterSettings: AdapterSettings) => {
     throw new Error('TLS_ENABLED and MTLS_ENABLED cannot both be set to true.')
   }
 
-  if (
-    !adapterSettings.TLS_PRIVATE_KEY ||
-    !adapterSettings.TLS_PUBLIC_KEY ||
-    !adapterSettings.TLS_CA
-  ) {
+  if (!adapterSettings.TLS_PRIVATE_KEY || !adapterSettings.TLS_PUBLIC_KEY) {
     const TLSOption = adapterSettings.TLS_ENABLED ? 'TLS_ENABLED' : 'MTLS_ENABLED'
     throw new Error(
-      `TLS_PRIVATE_KEY, TLS_PUBLIC_KEY, and TLS_CA environment variables are required when ${TLSOption} is set to true.`,
+      `TLS_PRIVATE_KEY and TLS_PUBLIC_KEY environment variables are required when ${TLSOption} is set to true.`,
     )
+  }
+
+  if (adapterSettings.MTLS_ENABLED && !adapterSettings.TLS_CA) {
+    throw new Error('TLS_CA is required when MTLS_ENABLED is true.')
   }
 
   const httpsOptions = {
     key: adapterSettings.TLS_PRIVATE_KEY,
     cert: adapterSettings.TLS_PUBLIC_KEY,
-    ca: adapterSettings.TLS_CA,
+    ...(adapterSettings.TLS_CA && {
+      ca: adapterSettings.TLS_CA,
+    }),
     passphrase: adapterSettings.TLS_PASSPHRASE,
     requestCert: adapterSettings.MTLS_ENABLED,
   }

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -32,6 +32,35 @@ test('health endpoint returns health OK', async (t) => {
   })
 })
 
+test('TLS_ENABLED with no TLS params should error', async (t) => {
+  const config = new AdapterConfig(
+    {},
+    {
+      envDefaultOverrides: {
+        TLS_ENABLED: true,
+      },
+    },
+  )
+  const adapter = new Adapter({
+    name: 'TEST',
+    config,
+    endpoints: [
+      new AdapterEndpoint({
+        name: 'test',
+        transport: new NopTransport(),
+      }),
+    ],
+  })
+  try {
+    await start(adapter)
+  } catch (e: unknown) {
+    t.is(
+      (e as Error).message,
+      'TLS_PRIVATE_KEY and TLS_PUBLIC_KEY environment variables are required when TLS_ENABLED is set to true.',
+    )
+  }
+})
+
 test('MTLS_ENABLED with no TLS params should error', async (t) => {
   const config = new AdapterConfig(
     {},
@@ -56,8 +85,36 @@ test('MTLS_ENABLED with no TLS params should error', async (t) => {
   } catch (e: unknown) {
     t.is(
       (e as Error).message,
-      'TLS_PRIVATE_KEY, TLS_PUBLIC_KEY, and TLS_CA environment variables are required when MTLS_ENABLED is set to true.',
+      'TLS_PRIVATE_KEY and TLS_PUBLIC_KEY environment variables are required when MTLS_ENABLED is set to true.',
     )
+  }
+})
+
+test('MTLS_ENABLED with no TLS_CA should error', async (t) => {
+  const config = new AdapterConfig(
+    {},
+    {
+      envDefaultOverrides: {
+        MTLS_ENABLED: true,
+        TLS_PRIVATE_KEY: 'dGVzdA==',
+        TLS_PUBLIC_KEY: 'dGVzdA==',
+      },
+    },
+  )
+  const adapter = new Adapter({
+    name: 'TEST',
+    config,
+    endpoints: [
+      new AdapterEndpoint({
+        name: 'test',
+        transport: new NopTransport(),
+      }),
+    ],
+  })
+  try {
+    await start(adapter)
+  } catch (e: unknown) {
+    t.is((e as Error).message, 'TLS_CA is required when MTLS_ENABLED is true.')
   }
 })
 
@@ -127,12 +184,10 @@ test('requestCert should be false when TLS_ENABLED is set to true', async (t) =>
   adapterSettings.TLS_ENABLED = true
   adapterSettings.TLS_PRIVATE_KEY = 'dGVzdA=='
   adapterSettings.TLS_PUBLIC_KEY = 'dGVzdA=='
-  adapterSettings.TLS_CA = 'dGVzdA=='
   t.deepEqual(getTLSOptions(adapterSettings), {
     https: {
       key: 'dGVzdA==',
       cert: 'dGVzdA==',
-      ca: 'dGVzdA==',
       passphrase: '',
       requestCert: false,
     },


### PR DESCRIPTION
The previous TLS logic is wrong

TLS_CA is only required for MTLS_ENABLED
TLS_PRIVATE_KEY and TLS_PUBLIC_KEY are required for both TLS_ENABLED and MTLS_ENABLED


Looks like these options are not used by anything yet

https://github.com/search?q=repo%3Asmartcontractkit%2Finfra-k8s+path%3A%2F%5Eprojects%5C%2Fadapters%5C%2F%2F+MTLS_ENABLED&type=code

https://github.com/search?q=repo%3Asmartcontractkit%2Finfra-k8s%20path%3A%2F%5Eprojects%5C%2Fadapters%5C%2F%2F%20TLS_ENABLED&type=code