### PR TITLE
Stop sending undefine ws message + pass through raw endpoint name

### DIFF
--- a/src/transports/websocket.ts
+++ b/src/transports/websocket.ts
@@ -533,10 +533,14 @@ export class WebSocketTransport<
         await this.sendMessages(
           context,
           subscribeMessage
-            ? subscriptions.new.map((sub) => subscribeMessage(sub, context))
+            ? subscriptions.new
+                .map((sub) => subscribeMessage(sub, context))
+                .filter((m) => m !== undefined)
             : subscriptions.new,
           unsubscribeMessage
-            ? subscriptions.stale.map((sub) => unsubscribeMessage(sub, context))
+            ? subscriptions.stale
+                .map((sub) => unsubscribeMessage(sub, context))
+                .filter((m) => m !== undefined)
             : subscriptions.stale,
         )
         recordWsMessageSentMetrics(context, subscriptions.new, subscriptions.stale)

--- a/src/util/types.ts
+++ b/src/util/types.ts
@@ -33,7 +33,7 @@ export type AdapterRequestContext<T> = {
   endpointName: string
 
   /** Name of the endpoint from input before aliasing */
-  rawEndpointName: string
+  requestEndpointName: string
 
   /** Name of the transport this payload should be directed to */
   transportName: string

--- a/src/util/types.ts
+++ b/src/util/types.ts
@@ -32,6 +32,9 @@ export type AdapterRequestContext<T> = {
   /** Name of the endpoint this payload should be directed to */
   endpointName: string
 
+  /** Name of the endpoint from input before aliasing */
+  rawEndpointName: string
+
   /** Name of the transport this payload should be directed to */
   transportName: string
 

--- a/src/validation/index.ts
+++ b/src/validation/index.ts
@@ -70,7 +70,7 @@ export const validatorMiddleware: AdapterMiddlewareBuilder =
       cacheKey: '',
       data: validatedData,
       endpointName: endpoint.name,
-      rawEndpointName: endpointParam,
+      requestEndpointName: endpointParam,
     } as AdapterRequestContext<TypeFromDefinition<InputParametersDefinition>>
 
     // We do it afterwards so the custom routers can have a request with a requestContext fulfilled (sans transportName, ofc)
@@ -151,7 +151,7 @@ export const errorCatchingMiddleware = (err: Error, req: FastifyRequest, res: Fa
       cacheKey: errorLabel,
       data: undefined,
       endpointName: errorLabel,
-      rawEndpointName: errorLabel,
+      requestEndpointName: errorLabel,
       transportName: errorLabel,
       meta: { error: err },
     }

--- a/src/validation/index.ts
+++ b/src/validation/index.ts
@@ -70,6 +70,7 @@ export const validatorMiddleware: AdapterMiddlewareBuilder =
       cacheKey: '',
       data: validatedData,
       endpointName: endpoint.name,
+      rawEndpointName: endpointParam,
     } as AdapterRequestContext<TypeFromDefinition<InputParametersDefinition>>
 
     // We do it afterwards so the custom routers can have a request with a requestContext fulfilled (sans transportName, ofc)
@@ -150,6 +151,7 @@ export const errorCatchingMiddleware = (err: Error, req: FastifyRequest, res: Fa
       cacheKey: errorLabel,
       data: undefined,
       endpointName: errorLabel,
+      rawEndpointName: errorLabel,
       transportName: errorLabel,
       meta: { error: err },
     }

--- a/test/transports/websocket.test.ts
+++ b/test/transports/websocket.test.ts
@@ -10,6 +10,7 @@ import {
   WebSocketClassProvider,
   WebsocketReverseMappingTransport,
   WebSocketTransport,
+  type WebSocketTransportConfig,
 } from '../../src/transports'
 import { SingleNumberResultResponse, sleep } from '../../src/util'
 import { mockWebSocketProvider, runAllUntilTime, TestAdapter } from '../../src/util/testing-utils'
@@ -65,6 +66,7 @@ const createAdapter = (
     context: EndpointContext<WebSocketTypes>,
   ) => Promise<void> | void,
   pongHandler?: (connection: WebSocket, data: Buffer) => void,
+  buildersOverride?: WebSocketTransportConfig<WebSocketTypes>['builders'],
 ): Adapter => {
   const websocketTransport = new WebSocketTransport<WebSocketTypes>({
     url: () => ENDPOINT_URL,
@@ -99,7 +101,7 @@ const createAdapter = (
       heartbeat: heartbeatHandler,
       pong: pongHandler,
     },
-    builders: {
+    builders: buildersOverride ?? {
       subscribeMessage: (params) => `S:${params.base}/${params.quote}`,
       unsubscribeMessage: (params) => ({
         request: 'unsubscribe',
@@ -194,6 +196,81 @@ test.serial('connects to websocket, subscribes, gets message, unsubscribes', asy
     quote,
   })
   t.is(error2.statusCode, 504)
+
+  testAdapter.api.close()
+  mockWsServer.close()
+  await t.context.clock.runToLastAsync()
+})
+
+test.serial('filters out undefined subscribe and unsubscribe messages from builders', async (t) => {
+  mockWebSocketProvider(WebSocketClassProvider)
+  const mockWsServer = new Server(ENDPOINT_URL, { mock: false })
+  const messagesReceived: string[] = []
+
+  mockWsServer.on('connection', (socket) => {
+    socket.on('message', (data) => {
+      messagesReceived.push(typeof data === 'string' ? data : data.toString())
+      socket.send(
+        JSON.stringify({
+          pair: `ETH/DOGE`,
+          value: price,
+        }),
+      )
+    })
+  })
+
+  const adapter = createAdapter(
+    {
+      WS_SUBSCRIPTION_UNRESPONSIVE_TTL: 180_000,
+      WS_SUBSCRIPTION_TTL: 60_000,
+    },
+    undefined,
+    undefined,
+    {
+      subscribeMessage: (params) => {
+        return params.base === 'SKIP' ? undefined : `S:${params.base}/${params.quote}`
+      },
+      unsubscribeMessage: (params) => {
+        return params.quote === 'SKIPUNSUB' ? undefined : `U:${params.base}/${params.quote}`
+      },
+    },
+  )
+
+  const testAdapter = await TestAdapter.startWithMockedCache(adapter, t.context)
+
+  // ETH first so the socket gets a subscribe + provider message before SKIP (no subscribe payload).
+  await testAdapter.request({ base: 'ETH', quote: 'DOGE' })
+  await runAllUntilTime(t.context.clock, BACKGROUND_EXECUTE_MS_WS + 200)
+  await testAdapter.request({ base: 'SKIP', quote: 'DOGE' })
+  await runAllUntilTime(t.context.clock, BACKGROUND_EXECUTE_MS_WS + 200)
+  await testAdapter.request({ base: 'ETH', quote: 'SKIPUNSUB' })
+  await runAllUntilTime(t.context.clock, BACKGROUND_EXECUTE_MS_WS + 200)
+
+  t.false(
+    messagesReceived.includes('S:SKIP/DOGE'),
+    'no subscribe payload for feeds where subscribeMessage returns undefined',
+  )
+  t.false(
+    messagesReceived.some((m) => m === 'undefined'),
+    'undefined must not be serialized and sent',
+  )
+  t.true(messagesReceived.includes('S:ETH/DOGE'))
+  t.true(messagesReceived.includes('S:ETH/SKIPUNSUB'))
+
+  await runAllUntilTime(
+    t.context.clock,
+    adapter.config.settings.WS_SUBSCRIPTION_TTL + BACKGROUND_EXECUTE_MS_WS * 3 + 100,
+  )
+
+  const unsubscribePayloads = messagesReceived.filter((m) => m.startsWith('U:'))
+  t.false(
+    unsubscribePayloads.some((m) => m === 'U:ETH/SKIPUNSUB'),
+    'unsubscribe builder returned undefined for SKIPUNSUB quote — must not send that payload',
+  )
+  t.true(
+    unsubscribePayloads.includes('U:ETH/DOGE'),
+    'defined unsubscribe payloads are still sent for stale subs that map to a message',
+  )
 
   testAdapter.api.close()
   mockWsServer.close()

--- a/test/transports/websocket.test.ts
+++ b/test/transports/websocket.test.ts
@@ -246,30 +246,21 @@ test.serial('filters out undefined subscribe and unsubscribe messages from build
   await testAdapter.request({ base: 'ETH', quote: 'SKIPUNSUB' })
   await runAllUntilTime(t.context.clock, BACKGROUND_EXECUTE_MS_WS + 200)
 
-  t.false(
-    messagesReceived.includes('S:SKIP/DOGE'),
-    'no subscribe payload for feeds where subscribeMessage returns undefined',
+  t.deepEqual(
+    messagesReceived,
+    ['S:ETH/DOGE', 'S:ETH/SKIPUNSUB'],
+    'after three requests: SKIP yields no subscribe payload; only defined subscribe strings are sent',
   )
-  t.false(
-    messagesReceived.some((m) => m === 'undefined'),
-    'undefined must not be serialized and sent',
-  )
-  t.true(messagesReceived.includes('S:ETH/DOGE'))
-  t.true(messagesReceived.includes('S:ETH/SKIPUNSUB'))
 
   await runAllUntilTime(
     t.context.clock,
     adapter.config.settings.WS_SUBSCRIPTION_TTL + BACKGROUND_EXECUTE_MS_WS * 3 + 100,
   )
 
-  const unsubscribePayloads = messagesReceived.filter((m) => m.startsWith('U:'))
-  t.false(
-    unsubscribePayloads.some((m) => m === 'U:ETH/SKIPUNSUB'),
-    'unsubscribe builder returned undefined for SKIPUNSUB quote — must not send that payload',
-  )
-  t.true(
-    unsubscribePayloads.includes('U:ETH/DOGE'),
-    'defined unsubscribe payloads are still sent for stale subs that map to a message',
+  t.deepEqual(
+    messagesReceived,
+    ['S:ETH/DOGE', 'S:ETH/SKIPUNSUB', 'U:ETH/DOGE', 'U:SKIP/DOGE'],
+    'full outbound WS payload sequence: subscribes in order, then per-TTL stale unsubs (no U for SKIPUNSUB quote)',
   )
 
   testAdapter.api.close()

--- a/test/validation.test.ts
+++ b/test/validation.test.ts
@@ -837,6 +837,40 @@ test.serial('examples in input parameters', async (t) => {
   ])
 })
 
+test.serial('requestContext has correct endpointName and rawEndpointName', async (t) => {
+  let capturedContext: { endpointName: string; rawEndpointName: string } | undefined
+
+  const adapter = new Adapter({
+    name: 'TEST',
+    endpoints: [
+      new AdapterEndpoint({
+        name: 'test',
+        aliases: ['test-alias'],
+        transport: new (class extends NopTransport {
+          override async foregroundExecute(req: AdapterRequest<EmptyInputParameters>) {
+            capturedContext = {
+              endpointName: req.requestContext.endpointName,
+              rawEndpointName: req.requestContext.rawEndpointName,
+            }
+          }
+        })(),
+      }),
+    ],
+  })
+
+  const testAdapter = await TestAdapter.start(adapter, t.context)
+
+  // When using the canonical name, both fields should match
+  await testAdapter.request({ endpoint: 'test' })
+  t.is(capturedContext?.endpointName, 'test')
+  t.is(capturedContext?.rawEndpointName, 'test')
+
+  // When using an alias, endpointName is the canonical name and rawEndpointName is the alias
+  await testAdapter.request({ endpoint: 'test-alias' })
+  t.is(capturedContext?.endpointName, 'test')
+  t.is(capturedContext?.rawEndpointName, 'test-alias')
+})
+
 test.serial('limit size of input parameters', async (t) => {
   process.env['MAX_PAYLOAD_SIZE_LIMIT'] = '1048576'
 

--- a/test/validation.test.ts
+++ b/test/validation.test.ts
@@ -837,8 +837,8 @@ test.serial('examples in input parameters', async (t) => {
   ])
 })
 
-test.serial('requestContext has correct endpointName and rawEndpointName', async (t) => {
-  let capturedContext: { endpointName: string; rawEndpointName: string } | undefined
+test.serial('requestContext has correct endpointName and requestEndpointName', async (t) => {
+  let capturedContext: { endpointName: string; requestEndpointName: string } | undefined
 
   const adapter = new Adapter({
     name: 'TEST',
@@ -850,7 +850,7 @@ test.serial('requestContext has correct endpointName and rawEndpointName', async
           override async foregroundExecute(req: AdapterRequest<EmptyInputParameters>) {
             capturedContext = {
               endpointName: req.requestContext.endpointName,
-              rawEndpointName: req.requestContext.rawEndpointName,
+              requestEndpointName: req.requestContext.requestEndpointName,
             }
           }
         })(),
@@ -863,12 +863,12 @@ test.serial('requestContext has correct endpointName and rawEndpointName', async
   // When using the canonical name, both fields should match
   await testAdapter.request({ endpoint: 'test' })
   t.is(capturedContext?.endpointName, 'test')
-  t.is(capturedContext?.rawEndpointName, 'test')
+  t.is(capturedContext?.requestEndpointName, 'test')
 
-  // When using an alias, endpointName is the canonical name and rawEndpointName is the alias
+  // When using an alias, endpointName is the canonical name and requestEndpointName is the alias
   await testAdapter.request({ endpoint: 'test-alias' })
   t.is(capturedContext?.endpointName, 'test')
-  t.is(capturedContext?.rawEndpointName, 'test-alias')
+  t.is(capturedContext?.requestEndpointName, 'test-alias')
 })
 
 test.serial('limit size of input parameters', async (t) => {


### PR DESCRIPTION
## Summary
- **`requestContext.rawEndpointName`** — Stores the normalized endpoint string from the request (the same value used to resolve the endpoint in `endpointsMap`). **`requestContext.endpointName`** remains the canonical endpoint name. When the client uses an **alias**, `endpointName` is the canonical name and `rawEndpointName` is the alias. Adapters can distinguish client-facing endpoint identifiers while keeping a single endpoint definition, transport, and WebSocket connection when multiple names map to the same `AdapterEndpoint`.
- **WebSocket transport** — After `subscribeMessage` / `unsubscribeMessage` run, **`undefined` results are filtered out** before serialize/send, so the provider does not receive spurious payloads (e.g. the string `"undefined"`).
## Motivation
Some adapters expose several request-facing names (aliases) on one endpoint that shares one streaming connection. Previously only the canonical name was available on `requestContext`, so transports could not tell whether the caller used e.g. `stock` vs `stock_quotes` when both resolve to the same endpoint. Exposing the lookup string as `rawEndpointName` fixes that for any code path that has the full **`AdapterRequest`**.

Subscribe/unsubscribe builders may intentionally return **`undefined`** when no wire message is required; those must not be sent to the WebSocket server.
