### PR TITLE
Add runAllUntilSettled test util

### DIFF
--- a/src/util/testing-utils.ts
+++ b/src/util/testing-utils.ts
@@ -107,6 +107,21 @@ export async function runAllUntilTime(clock: InstalledClock, time: number): Prom
   }
 }
 
+export async function runAllUntilSettled<T>(
+  clock: InstalledClock,
+  promise: Promise<T>,
+): Promise<T> {
+  let settled = false
+  try {
+    // Return the derived promise to avoid unhandled promise rejections.
+    return promise.finally(() => {
+      settled = true
+    })
+  } finally {
+    await runAllUntil(clock, () => settled)
+  }
+}
+
 export class RedisMock {
   store = new LocalCache<string>(10000)
   keys: { [key: string]: string } = {}

--- a/test/util/testing-utils.test.ts
+++ b/test/util/testing-utils.test.ts
@@ -1,5 +1,12 @@
 import test from 'ava'
-import { allowedUndefinedStubProps, makeStub } from '../../src/util/testing-utils'
+import {
+  allowedUndefinedStubProps,
+  makeStub,
+  runAllUntil,
+  runAllUntilSettled,
+  runAllUntilTime,
+} from '../../src/util/testing-utils'
+import { installTimers } from '../helper'
 
 test('make a stub', async (t) => {
   const stub = makeStub('stub', {
@@ -118,3 +125,98 @@ test('allowedUndefinedStubProps can be extended and restored', async (t) => {
     },
   )
 })
+
+test.serial('runAllUntil returns immediately when isComplete is initially true', async (t) => {
+  const clock = installTimers()
+  try {
+    const startTime = clock.now
+    let callCount = 0
+
+    await runAllUntil(clock, () => {
+      callCount++
+      return true
+    })
+
+    t.is(callCount, 1)
+    t.is(clock.now, startTime)
+  } finally {
+    clock.uninstall()
+  }
+})
+
+test.serial(
+  'runAllUntil advances clock through timers until isComplete returns true',
+  async (t) => {
+    const clock = installTimers()
+    try {
+      let counter = 0
+      const interval = setInterval(() => {
+        counter++
+      }, 100)
+
+      await runAllUntil(clock, () => counter >= 3)
+      clearInterval(interval)
+
+      t.is(counter, 3)
+      t.is(clock.now, 300)
+    } finally {
+      clock.uninstall()
+    }
+  },
+)
+
+test.serial(
+  'runAllUntilTime advances clock by the specified amount and runs scheduled callbacks',
+  async (t) => {
+    const clock = installTimers()
+    try {
+      const fired: string[] = []
+      setTimeout(() => fired.push('100'), 100)
+      setTimeout(() => fired.push('200'), 200)
+      setTimeout(() => fired.push('400'), 400)
+
+      await runAllUntilTime(clock, 250)
+
+      t.deepEqual(fired, ['100', '200'])
+      t.is(clock.now, 250)
+    } finally {
+      clock.uninstall()
+    }
+  },
+)
+
+test.serial(
+  'runAllUntilSettled advances clock until the promise settles and returns its value',
+  async (t) => {
+    const clock = installTimers()
+    try {
+      const promise = new Promise<string>((resolve) => {
+        setTimeout(() => resolve('done'), 500)
+      })
+
+      const result = await runAllUntilSettled(clock, promise)
+
+      t.is(result, 'done')
+      t.is(clock.now, 500)
+    } finally {
+      clock.uninstall()
+    }
+  },
+)
+
+test.serial(
+  'runAllUntilSettled advances clock until the promise rejects and re-throws',
+  async (t) => {
+    const clock = installTimers()
+    try {
+      const promise = new Promise<never>((_, reject) => {
+        setTimeout(() => reject(new Error('boom')), 500)
+      })
+
+      await t.throwsAsync(() => runAllUntilSettled(clock, promise), { message: 'boom' })
+      t.is(clock.now, 500)
+    } finally {
+      clock.uninstall()
+    }
+  },
+)


### PR DESCRIPTION
# Description

The`runAllUntilSettled` is useful in websocket unit tests, such as [the one for lo-tech](https://github.com/smartcontractkit/external-adapters-js/blob/main/packages/sources/lo-tech/test/unit/stock_quotes.test.ts).

I plan to use this in a template to generate a unit test for generated websocket transports.

# Changes

1. Add `runAllUntilSettled`, slightly different than in `lo-tech` to make sure it won't leave an unhandled rejection.
2. Add unit tests.
3. Add missing test coverage for `runAllUntil` and `runAllUntilTime`.