### PR TITLE
Add generated unit test for generated ws transport

### DIFF
--- a/scripts/generator-adapter/generators/app/index.ts
+++ b/scripts/generator-adapter/generators/app/index.ts
@@ -246,6 +246,16 @@ export default class extends Generator.default {
         this.destinationPath(`${this.args[0]}/${this.props.adapterName}/test/integration/${fileName}`),
         { endpoints: wsEndpoints },
       )
+
+      // Create ws unit test files
+      for (const { inputEndpointName, normalizedEndpointNameCap, inputTransports } of wsEndpoints) {
+        const transportFileBaseName = inputTransports.length > 1 ? `${inputEndpointName}-ws` : inputEndpointName
+        this.fs.copyTpl(
+          this.templatePath(`test/unit/ws.test.ts.ejs`),
+          this.destinationPath(`${this.args[0]}/${this.props.adapterName}/test/unit/${transportFileBaseName}.test.ts`),
+          { inputEndpointName, normalizedEndpointNameCap, transportFileBaseName },
+        )
+      }
     }
 
     // Create adapter.test.ts or adapter-custom.test.ts if there is at least one endpoint with customTransport.

--- a/scripts/generator-adapter/generators/app/templates/src/transport/http.ts.ejs
+++ b/scripts/generator-adapter/generators/app/templates/src/transport/http.ts.ejs
@@ -30,17 +30,17 @@ export class <%= normalizedEndpointNameCap %>HttpTransport extends HttpTransport
       // `prepareRequests` method receives request payloads sent to associated endpoint alongside adapter config(environment variables)
       // and should return 'request information' to the Data Provider. Use this method to construct one or many requests, and the framework
       // will send them to Data Provider
-    <% } -%>
+<% } -%>
       prepareRequests: (params, config) => {
         return params.map((param) => {
           return {
-    <% if (includeComments) { -%>
+<% if (includeComments) { -%>
             // `params` are parameters associated to this single request and will also be available in the 'parseResponse' method.
-    <% } -%>
+<% } -%>
             params: [param],
-    <% if (includeComments) { -%>
+<% if (includeComments) { -%>
             // `request` contains any valid axios request configuration
-    <% } -%>
+<% } -%>
             request: {
               baseURL: config.API_ENDPOINT,
               url: '/cryptocurrency/price',
@@ -55,19 +55,19 @@ export class <%= normalizedEndpointNameCap %>HttpTransport extends HttpTransport
           }
         })
       },
-    <% if (includeComments) { -%>
+<% if (includeComments) { -%>
       // `parseResponse` takes the 'params' specified in the `prepareRequests` and the 'response' from Data Provider and should return
       // an array of response objects to be stored in cache. Use this method to construct a list of response objects for every parameter in 'params'
       // and the framework will save them in cache and return to user
-    <% } -%>
+<% } -%>
       parseResponse: (params, response) => {
-    <% if (includeComments) { -%>
+<% if (includeComments) { -%>
         // For each 'param' a new response object is created and returned as an array
-    <% } -%>
+<% } -%>
         return params.map((param) => {
-    <% if (includeComments) { -%>
+<% if (includeComments) { -%>
           // In case error was received, it's a good practice to return meaningful information to user
-    <% } -%>
+<% } -%>
           const baseSymbol = param.base.toUpperCase()
           if (!response.data || !response.data[baseSymbol]) {
             return {
@@ -80,11 +80,11 @@ export class <%= normalizedEndpointNameCap %>HttpTransport extends HttpTransport
           }
 
           const result = response.data[baseSymbol].price
-    <% if (includeComments) { -%>
+<% if (includeComments) { -%>
           // Response objects, whether successful or errors, contain two properties, 'params' and 'response'. 'response' is what will be
           // stored in the cache and returned as adapter response and 'params' determines the identifier so that the next request with same 'params'
           // will immediately return the response from the cache
-    <% } -%>
+<% } -%>
           return {
             params: param,
             response: {

--- a/scripts/generator-adapter/generators/app/templates/src/transport/ws.ts.ejs
+++ b/scripts/generator-adapter/generators/app/templates/src/transport/ws.ts.ejs
@@ -21,74 +21,80 @@ export type WsTransportTypes = BaseEndpointTypes & {
 <% if (includeComments) { -%>
 // WebSocketTransport is used to fetch and process data from a Provider using Websocket protocol.
 <% } -%>
-export const wsTransport = new WebSocketTransport<WsTransportTypes>({
+export class <%= normalizedEndpointNameCap %>WebSocketTransport extends WebSocketTransport<WsTransportTypes> {
+  constructor() {
+    super({
 <% if (includeComments) { -%>
-  // use `url` method to provide connection url. It accepts adapter context, so you have access to adapter config(environment variables) and
-  // request payload if needed
+      // use `url` method to provide connection url. It accepts adapter context, so you have access to adapter config(environment variables) and
+      // request payload if needed
 <% } -%>
-  url: (context) => context.adapterSettings.WS_API_ENDPOINT,
+      url: (context) => context.adapterSettings.WS_API_ENDPOINT,
 <% if (includeComments) { -%>
-  // 'handler' contains two helpful methods. one of them is `message`. This method is called when there is a new websocket message.
-  // The other one is 'open' method. It is called when the websocket connection is successfully opened. Use this method to execute some logic
-  // when the connection is established (custom authentication, logging, ...)
+      // 'handler' contains two helpful methods. one of them is `message`. This method is called when there is a new websocket message.
+      // The other one is 'open' method. It is called when the websocket connection is successfully opened. Use this method to execute some logic
+      // when the connection is established (custom authentication, logging, ...)
 <% } -%>
-  handlers: {
+      handlers: {
 <% if (includeComments) { -%>
-    // 'message' handler receives a raw websocket message as first argument and adapter context as second and should return an array of
-    // response objects. Use this method to construct a list of response objects, and the framework will save them in cache and return to user
+        // 'message' handler receives a raw websocket message as first argument and adapter context as second and should return an array of
+        // response objects. Use this method to construct a list of response objects, and the framework will save them in cache and return to user
 <% } -%>
-    message(message) {
+        message(message) {
 <% if (includeComments) { -%>
-      // in cases when error or unknown message is received, use 'return' to skip the iteration.
+          // in cases when error or unknown message is received, use 'return' to skip the iteration.
 <% } -%>
-      if (message.success === false) {
-        return
-      }
+          if (message.success === false) {
+            return
+          }
 
 <% if (includeComments) { -%>
-    // Response objects, whether successful or errors (if not skipped), contain two properties, 'params' and 'response'. 'response' is what
-    // will be stored in the cache and returned as adapter response and 'params' determines the identifier so that the next request with
-    // same 'params' will immediately return the response from the cache
+        // Response objects, whether successful or errors (if not skipped), contain two properties, 'params' and 'response'. 'response' is what
+        // will be stored in the cache and returned as adapter response and 'params' determines the identifier so that the next request with
+        // same 'params' will immediately return the response from the cache
 <% } -%>
-      return [
-        {
-          params: { base: message.base, quote: message.quote },
-          response: {
-            result: message.price,
-            data: {
-             result: message.price
+          return [
+            {
+              params: { base: message.base, quote: message.quote },
+              response: {
+                result: message.price,
+                data: {
+                 result: message.price
+                },
+                timestamps: {
+                  providerIndicatedTimeUnixMs: message.time,
+                },
+              },
             },
-            timestamps: {
-              providerIndicatedTimeUnixMs: message.time,
-            },
-          },
+          ]
         },
-      ]
-    },
-  },
+      },
 <% if (includeComments) { -%>
-  // `builders` are builder methods, that will be used to prepare specific WS messages to be sent to Data Provider
+      // `builders` are builder methods, that will be used to prepare specific WS messages to be sent to Data Provider
 <% } -%>
-  builders: {
+      builders: {
 <% if (includeComments) { -%>
-    // `subscribeMessage` accepts request parameters and should construct and return a payload that will be sent to Data Provider
-    // Use this method to subscribe to live feeds
+        // `subscribeMessage` accepts request parameters and should construct and return a payload that will be sent to Data Provider
+        // Use this method to subscribe to live feeds
 <% } -%>
-    subscribeMessage: (params) => {
-      return {
-        type: 'subscribe',
-        symbols: `${params.base}/${params.quote}`.toUpperCase()
-      }
-    },
+        subscribeMessage: (params) => {
+          return {
+            type: 'subscribe',
+            symbols: `${params.base}/${params.quote}`.toUpperCase()
+          }
+        },
 <% if (includeComments) { -%>
-    // `unsubscribeMessage` accepts request parameters and should construct and return a payload that will be sent to Data Provider
-    // Use this method to unsubscribe from live feeds
+        // `unsubscribeMessage` accepts request parameters and should construct and return a payload that will be sent to Data Provider
+        // Use this method to unsubscribe from live feeds
 <% } -%>
-    unsubscribeMessage: (params) => {
-      return {
-        type: 'unsubscribe',
-        symbols: `${params.base}/${params.quote}`.toUpperCase()
-      }
-    },
-  },
-})
+        unsubscribeMessage: (params) => {
+          return {
+            type: 'unsubscribe',
+            symbols: `${params.base}/${params.quote}`.toUpperCase()
+          }
+        },
+      },
+    })
+  }
+}
+
+export const wsTransport = new <%= normalizedEndpointNameCap %>WebSocketTransport()

--- a/scripts/generator-adapter/generators/app/templates/test/unit/ws.test.ts.ejs
+++ b/scripts/generator-adapter/generators/app/templates/test/unit/ws.test.ts.ejs
@@ -1,0 +1,211 @@
+import { EndpointContext } from '@chainlink/external-adapter-framework/adapter'
+import { metrics } from '@chainlink/external-adapter-framework/metrics'
+import {
+  TransportDependencies,
+  WebSocketClassProvider,
+} from '@chainlink/external-adapter-framework/transports'
+import { LoggerFactoryProvider } from '@chainlink/external-adapter-framework/util'
+import {
+  makeStub,
+  mockWebSocketProvider,
+  MockWebsocketServer,
+  runAllUntil,
+  runAllUntilSettled,
+} from '@chainlink/external-adapter-framework/util/testing-utils'
+import FakeTimers from '@sinonjs/fake-timers'
+import { BaseEndpointTypes } from '../../src/endpoint/<%= inputEndpointName %>'
+import { <%= normalizedEndpointNameCap %>WebSocketTransport, WsTransportTypes } from '../../src/transport/<%= transportFileBaseName %>'
+
+const log = jest.fn()
+const debugLog = jest.fn()
+const logger = {
+  fatal: log,
+  error: log,
+  warn: log,
+  info: log,
+  debug: debugLog,
+  trace: debugLog,
+  msgPrefix: 'mock-logger',
+}
+
+LoggerFactoryProvider.set({ child: () => logger })
+metrics.initialize()
+
+describe('<%= normalizedEndpointNameCap %>WebSocketTransport', () => {
+  const transportName = 'default_single_transport'
+  const endpointName = '<%= inputEndpointName %>'
+
+  const adapterSettings = makeStub('adapterSettings', {
+    WS_API_ENDPOINT: 'ws://api.example.com',
+    WS_SUBSCRIPTION_TTL: 30_000,
+    WS_SUBSCRIPTION_UNRESPONSIVE_TTL: 120_000,
+    STREAM_HANDLER_RETRY_MIN_MS: 100,
+    STREAM_HANDLER_RETRY_EXP_FACTOR: 3,
+    STREAM_HANDLER_RETRY_MAX_MS: 1_200_000,
+    MAX_COMMON_KEY_SIZE: 300,
+    WS_CONNECTION_OPEN_TIMEOUT: 10_000,
+    BACKGROUND_EXECUTE_MS_WS: 1_000,
+    WS_HEARTBEAT_INTERVAL_MS: 30_000,
+  } as unknown as BaseEndpointTypes['Settings'])
+
+  const subscriptionSet = makeStub('subscriptionSet', {
+    getAll: jest.fn(),
+  })
+
+  const subscriptionSetFactory = makeStub('subscriptionSetFactory', {
+    buildSet() {
+      return subscriptionSet
+    },
+  })
+
+  const responseCache = {
+    write: jest.fn(),
+  }
+  const dependencies = makeStub('dependencies', {
+    responseCache,
+    subscriptionSetFactory,
+  } as unknown as TransportDependencies<WsTransportTypes>)
+
+  let transport: <%= normalizedEndpointNameCap %>WebSocketTransport
+
+  let clock: FakeTimers.Clock
+  let mockWsServer: MockWebsocketServer
+  let socket: WebSocket
+  const receivedMessages: string[] = []
+
+  beforeAll(() => {
+    clock = FakeTimers.install()
+  })
+
+  beforeEach(async () => {
+    jest.resetAllMocks()
+
+    mockWebSocketProvider(WebSocketClassProvider)
+    receivedMessages.length = 0
+    mockWsServer?.close()
+    mockWsServer = new MockWebsocketServer(adapterSettings.WS_API_ENDPOINT, {
+      mock: false,
+    })
+
+    mockWsServer.on('connection', (sock) => {
+      socket = sock as WebSocket
+      sock.on('message', (message) => {
+        receivedMessages.push(String(message))
+      })
+    })
+
+    transport = new <%= normalizedEndpointNameCap %>WebSocketTransport()
+    await transport.initialize(dependencies, adapterSettings, endpointName, transportName)
+  })
+
+  afterEach(() => {
+    expect(log).not.toHaveBeenCalled()
+  })
+
+  it('should subscribe to the currency pair', async () => {
+    const from = 'ETH'
+    const to = 'USD'
+
+    const params = makeStub('params', {
+      base: from,
+      quote: to,
+    })
+    subscriptionSet.getAll.mockReturnValue([params])
+
+    const context = makeStub('context', {
+      adapterSettings,
+      endpointName,
+    } as EndpointContext<WsTransportTypes>)
+
+    await runAllUntilSettled(clock, transport.backgroundExecute(context))
+    expect(receivedMessages.length).toBe(1)
+
+    await expect(receivedMessages[0]).toBe(
+      JSON.stringify({
+        type: 'subscribe',
+        symbols: `${from}/${to}`,
+      }),
+    )
+  })
+
+  it('should write response to cache', async () => {
+    const from = 'ETH'
+    const to = 'USD'
+
+    const params = makeStub('params', {
+      base: from,
+      quote: to,
+    })
+    subscriptionSet.getAll.mockReturnValue([params])
+
+    const context = makeStub('context', {
+      adapterSettings,
+      endpointName,
+    } as EndpointContext<WsTransportTypes>)
+
+    const t0 = Date.now()
+    await runAllUntilSettled(clock, transport.backgroundExecute(context))
+    const t1 = Date.now()
+
+    const price = 123
+    const providerIndicatedTimeUnixMs = 123456789
+
+    socket.send(
+      JSON.stringify({
+        base: from,
+        quote: to,
+        price,
+        time: providerIndicatedTimeUnixMs,
+      }),
+    )
+
+    expect(responseCache.write).toHaveBeenCalledWith(transportName, [
+      {
+        params,
+        response: {
+          result: price,
+          data: {
+            result: price,
+          },
+          timestamps: {
+            providerDataStreamEstablishedUnixMs: t0,
+            providerDataReceivedUnixMs: t1,
+            providerIndicatedTimeUnixMs,
+          },
+        },
+      },
+    ])
+    expect(responseCache.write).toHaveBeenCalledTimes(1)
+  })
+
+  it('should unsubscribe', async () => {
+    const from = 'ETH'
+    const to = 'USD'
+
+    const params = makeStub('params', {
+      base: from,
+      quote: to,
+    })
+
+    const context = makeStub('context', {
+      adapterSettings,
+      endpointName,
+    } as EndpointContext<WsTransportTypes>)
+
+    subscriptionSet.getAll.mockReturnValue([params])
+    await runAllUntilSettled(clock, transport.backgroundExecute(context))
+    expect(receivedMessages.length).toBe(1)
+
+    subscriptionSet.getAll.mockReturnValue([])
+    await runAllUntilSettled(clock, transport.backgroundExecute(context))
+    expect(receivedMessages.length).toBe(2)
+
+    await expect(receivedMessages[1]).toBe(
+      JSON.stringify({
+        type: 'unsubscribe',
+        symbols: `${from}/${to}`,
+      }),
+    )
+  })
+})
+


### PR DESCRIPTION
Follow-up to https://github.com/smartcontractkit/ea-framework-js/pull/784

# Description

When generating a new EA with `yarn new`, it includes an integration test but only unit tests for `http` transports.
This PR adds a unit test for `ws` transports.
I hope to add a unit test for subscription transports in the future.

# Changes

1. In the generated WS transport file, create a transport class which can be instantiated by the unit test.
2. Add a ws unit test template.
3. Use the template to generate the unit test.
4. Drive-by fix: Unindent the template directives in `scripts/generator-adapter/generators/app/templates/src/transport/http.ts.ejs`. They got indented in https://github.com/smartcontractkit/ea-framework-js/pull/784 together with the code that got indented.

# Testing

1. We have a [workflow](https://github.com/smartcontractkit/ea-framework-js/blob/225d0063ac1979f2f1ba150e1e3b29e30c7139fb/.github/workflows/main.yaml#L77) that generates an adapter that still passes.
2. I manually tested it in `external-adapters-js` to create an adapter with a single endpoint called `abc-def` with a single `ws` transport. The generated unit test passed.