### PR TITLE
DF-25178: Adds custom subscription handling for EA specific implementations

### DIFF
--- a/docs/components/transport-types/websocket-transport.md
+++ b/docs/components/transport-types/websocket-transport.md
@@ -107,7 +107,7 @@ In the example above, after the connection is established a custom authenticatio
 
 ### Sending messages
 
-The **builders** object prepares subscribe and unsubscribe messages sent to the Data Provider. Configure **either** the per-subscription builders or the batch builders, not both. When `batchSubscribeMessage` is present, the batch path is used.
+The **builders** object prepares subscribe and unsubscribe messages sent to the Data Provider. Configure **either** the per-subscription builders or a custom subscription builder, not both.
 
 #### Per-subscription builders
 
@@ -123,26 +123,32 @@ builders: {
 }
 ```
 
-#### Batch builders
+#### Custom subscription builder
 
-Some providers accept a single message that subscribes or unsubscribes from multiple feeds at once. Use **batchSubscribeMessage** and **batchUnsubscribeMessage** instead of the per-subscription methods above.
+Some EAs need custom subscription handling—for example, batching multiple feeds into a single message. Use **customSubscriptionMessages** instead of the per-subscription methods above.
 
-Each batch builder receives the full list of new or stale subscriptions for the current background execute cycle and returns **one** message. The transport sends that message as a single WebSocket frame.
+The custom builder receives subscription deltas for the current background execute cycle (`subscriptions.new`, `subscriptions.stale`, and `subscriptions.desired`) and returns an array of messages to send. Return an empty array when there is nothing to send.
 
 ```typescript
 builders: {
-  batchSubscribeMessage: (params) => ({
-    action: 'subscribe',
-    pairs: params.map((p) => `${p.base}/${p.quote}`),
-  }),
-  batchUnsubscribeMessage: (params) => ({
-    action: 'unsubscribe',
-    pairs: params.map((p) => `${p.base}/${p.quote}`),
-  }),
+  customSubscriptionMessages: (_context, subscriptions) => {
+    const messages = []
+    if (subscriptions.new.length > 0) {
+      messages.push({
+        action: 'subscribe',
+        pairs: subscriptions.new.map((p) => `${p.base}/${p.quote}`),
+      })
+    }
+    if (subscriptions.stale.length > 0) {
+      messages.push({
+        action: 'unsubscribe',
+        pairs: subscriptions.stale.map((p) => `${p.base}/${p.quote}`),
+      })
+    }
+    return messages
+  },
 }
 ```
-
-When a feed is added or removed, only the delta (`subscriptions.new` or `subscriptions.stale`) is passed to the batch builder, so each cycle may produce a message covering one or more feeds depending on what changed.
 
 ### Heartbeat messages
 

--- a/src/transports/websocket.ts
+++ b/src/transports/websocket.ts
@@ -69,6 +69,20 @@ type WebSocketIndividualBuilders<T extends WebsocketTransportGenerics> = {
   ) => unknown
 }
 
+type WebSocketCustomBuilders<T extends WebsocketTransportGenerics> = {
+  /**
+   * Builds a WS message that will be sent to subscribe to a specific feed
+   *
+   * @param context - the background context for the Adapter
+   * @param subscriptions - the body of the adapter request
+   * @returns the WS message (can be any type as long as the [[WebSocket]] doesn't complain)
+   */
+  customSubscriptionMessages: (
+    context: EndpointContext<T>,
+    subscriptions: SubscriptionDeltas<TypeFromDefinition<T['Parameters']>>,
+  ) => unknown[] | void
+}
+
 /**
  * Config object that is provided to the WebSocketTransport constructor.
  */
@@ -149,19 +163,14 @@ export type WebSocketTransportConfig<T extends WebsocketTransportGenerics> = {
       context: EndpointContext<T>,
     ) => ProviderResult<T>[] | undefined
   }
-} & (
-  {
-    /**
-     * Map of "builders", functions that will be used to prepare specific WS messages.
-     * Provide either per-subscription builders (`subscribeMessage` / `unsubscribeMessage`)
-     * or batch builders (`batchSubscribeMessage` / `batchUnsubscribeMessage`), not both.
-     * When `batchSubscribeMessage` is present, the batch path is used.
-     */
-    builders?: WebSocketIndividualBuilders<T>
-  } | {
-    subscriptionHandler?: (context: EndpointContext<T>, subscriptions: SubscriptionDeltas<TypeFromDefinition<T['Parameters']>>) => unknown[]
-  }
-)
+  /**
+   * Map of "builders", functions that will be used to prepare specific WS messages.
+   * Provide either per-subscription builders (`subscribeMessage` / `unsubscribeMessage`)
+   * or batch builders (`batchSubscribeMessage` / `batchUnsubscribeMessage`), not both.
+   * When `batchSubscribeMessage` is present, the batch path is used.
+   */
+  builders?: WebSocketIndividualBuilders<T> | WebSocketCustomBuilders<T>
+}
 
 /**
  * Helper struct type that will be used to pass types to the generic parameters of a Transport.
@@ -179,7 +188,7 @@ export type WebsocketTransportGenerics = TransportGenerics & {
   }
 }
 
-const defaultHandleSubscriptions = <T extends WebsocketTransportGenerics,> (builders: WebSocketIndividualBuilders<T>) => (context: EndpointContext<T>, subscriptions: SubscriptionDeltas<TypeFromDefinition<T['Parameters']>>) => {
+const defaultSubscriptionMessageBuilder = <T extends WebsocketTransportGenerics,> (builders: WebSocketIndividualBuilders<T>) => (context: EndpointContext<T>, subscriptions: SubscriptionDeltas<TypeFromDefinition<T['Parameters']>>) => {
   const { subscribeMessage, unsubscribeMessage } = builders as WebSocketIndividualBuilders<T>
   const subscribeMessages = subscribeMessage
     ? subscriptions.new
@@ -191,7 +200,7 @@ const defaultHandleSubscriptions = <T extends WebsocketTransportGenerics,> (buil
       .map((sub) => unsubscribeMessage(sub, context))
       .filter((m) => m !== undefined)
     : subscriptions.stale
-  return [...subscribeMessages, ...unsubscribeMessages]
+  return [...unsubscribeMessages, ...subscribeMessages]
 }
 
 /**
@@ -209,14 +218,16 @@ export class WebSocketTransport<
   connectionOpenedAt = 0
   streamHandlerInvocationsWithNoConnection = 0
   heartbeatInterval?: NodeJS.Timeout
-  handleSubscriptions?: (context: EndpointContext<T>, subscriptions: SubscriptionDeltas<TypeFromDefinition<T['Parameters']>>) => unknown[]
+  subscriptionMessageBuilder?: (context: EndpointContext<T>, subscriptions: SubscriptionDeltas<TypeFromDefinition<T['Parameters']>>) => unknown[] | void
 
   constructor(private config: WebSocketTransportConfig<T>) {
     super()
-    if ("builders" in config && config.builders) {
-      this.handleSubscriptions = defaultHandleSubscriptions(config.builders)
-    } else if ("subscriptionHandler" in config) {
-      this.handleSubscriptions = config.subscriptionHandler
+    if (config.builders) {
+      if ('customSubscriptionMessages' in config.builders) {
+        this.subscriptionMessageBuilder = config.builders.customSubscriptionMessages
+      } else {
+        this.subscriptionMessageBuilder = defaultSubscriptionMessageBuilder(config.builders)
+      }
     }
   }
 
@@ -555,10 +566,14 @@ export class WebSocketTransport<
     if (!this.connectionClosed()) {
       logger.debug('Connection is open, sending subs/unsubs if there are any')
 
-      if (this.handleSubscriptions) {
-        const messages = this.handleSubscriptions(context, subscriptions)
-        await this.sendMessages(context, messages)
-        recordWsMessageSentMetrics(context, subscriptions.new, subscriptions.stale)
+      if (this.subscriptionMessageBuilder) {
+        const messages = this.subscriptionMessageBuilder(context, subscriptions)
+        if (messages && messages.length > 0) {
+          await this.sendMessages(context, messages)
+          recordWsMessageSentMetrics(context, subscriptions.new, subscriptions.stale)
+        } else {
+          logger.trace("No messages to send")
+        }
       } else {
         logger.trace(
           "This ws transport has no builders configured, so we're not sending any messages",

--- a/src/transports/websocket.ts
+++ b/src/transports/websocket.ts
@@ -69,36 +69,10 @@ type WebSocketIndividualBuilders<T extends WebsocketTransportGenerics> = {
   ) => unknown
 }
 
-type WebSocketBatchBuilders<T extends WebsocketTransportGenerics> = {
-  /**
-   * Builds a single WS message that will be sent to subscribe to multiple feeds at once
-   *
-   * @param params - the list of adapter requests to subscribe to in this batch
-   * @param context - the background context for the Adapter
-   * @returns the WS message (can be any type as long as the [[WebSocket]] doesn't complain)
-   */
-  batchSubscribeMessage?: (
-    params: TypeFromDefinition<T['Parameters']>[],
-    context: EndpointContext<T>,
-  ) => unknown
-
-  /**
-   * Builds a single WS message that will be sent to unsubscribe from multiple feeds at once
-   *
-   * @param params - the list of adapter requests to unsubscribe from in this batch
-   * @param context - the background context for the Adapter
-   * @returns the WS message (can be any type as long as the [[WebSocket]] doesn't complain)
-   */
-  batchUnsubscribeMessage?: (
-    params: TypeFromDefinition<T['Parameters']>[],
-    context: EndpointContext<T>,
-  ) => unknown
-}
-
 /**
  * Config object that is provided to the WebSocketTransport constructor.
  */
-export interface WebSocketTransportConfig<T extends WebsocketTransportGenerics> {
+export type WebSocketTransportConfig<T extends WebsocketTransportGenerics> = {
   /** Endpoint to which to open the WS connection*/
   url: (
     context: EndpointContext<T>,
@@ -175,15 +149,19 @@ export interface WebSocketTransportConfig<T extends WebsocketTransportGenerics> 
       context: EndpointContext<T>,
     ) => ProviderResult<T>[] | undefined
   }
-
-  /**
-   * Map of "builders", functions that will be used to prepare specific WS messages.
-   * Provide either per-subscription builders (`subscribeMessage` / `unsubscribeMessage`)
-   * or batch builders (`batchSubscribeMessage` / `batchUnsubscribeMessage`), not both.
-   * When `batchSubscribeMessage` is present, the batch path is used.
-   */
-  builders?: WebSocketIndividualBuilders<T> | WebSocketBatchBuilders<T>
-}
+} & (
+  {
+    /**
+     * Map of "builders", functions that will be used to prepare specific WS messages.
+     * Provide either per-subscription builders (`subscribeMessage` / `unsubscribeMessage`)
+     * or batch builders (`batchSubscribeMessage` / `batchUnsubscribeMessage`), not both.
+     * When `batchSubscribeMessage` is present, the batch path is used.
+     */
+    builders?: WebSocketIndividualBuilders<T>
+  } | {
+    subscriptionHandler?: (context: EndpointContext<T>, subscriptions: SubscriptionDeltas<TypeFromDefinition<T['Parameters']>>) => unknown[]
+  }
+)
 
 /**
  * Helper struct type that will be used to pass types to the generic parameters of a Transport.
@@ -201,6 +179,21 @@ export type WebsocketTransportGenerics = TransportGenerics & {
   }
 }
 
+const defaultHandleSubscriptions = <T extends WebsocketTransportGenerics,> (builders: WebSocketIndividualBuilders<T>) => (context: EndpointContext<T>, subscriptions: SubscriptionDeltas<TypeFromDefinition<T['Parameters']>>) => {
+  const { subscribeMessage, unsubscribeMessage } = builders as WebSocketIndividualBuilders<T>
+  const subscribeMessages = subscribeMessage
+    ? subscriptions.new
+      .map((sub) => subscribeMessage(sub, context))
+      .filter((m) => m !== undefined)
+    : subscriptions.new
+  const unsubscribeMessages = unsubscribeMessage
+    ? subscriptions.stale
+      .map((sub) => unsubscribeMessage(sub, context))
+      .filter((m) => m !== undefined)
+    : subscriptions.stale
+  return [...subscribeMessages, ...unsubscribeMessages]
+}
+
 /**
  * Transport implementation that takes incoming requests, adds them to an [[subscriptionSet]] and,
  * through a WebSocket connection, subscribes to the relevant feeds to populate the cache.
@@ -216,9 +209,15 @@ export class WebSocketTransport<
   connectionOpenedAt = 0
   streamHandlerInvocationsWithNoConnection = 0
   heartbeatInterval?: NodeJS.Timeout
+  handleSubscriptions?: (context: EndpointContext<T>, subscriptions: SubscriptionDeltas<TypeFromDefinition<T['Parameters']>>) => unknown[]
 
   constructor(private config: WebSocketTransportConfig<T>) {
     super()
+    if ("builders" in config && config.builders) {
+      this.handleSubscriptions = defaultHandleSubscriptions(config.builders)
+    } else if ("subscriptionHandler" in config) {
+      this.handleSubscriptions = config.subscriptionHandler
+    }
   }
 
   getSubscriptionTtlFromConfig(adapterSettings: T['Settings']): number {
@@ -420,18 +419,15 @@ export class WebSocketTransport<
     return connection
   }
 
-  async sendMessages(context: EndpointContext<T>, subscribes: unknown[], unsubscribes: unknown[]) {
-    const serializedSubscribes = subscribes.map(this.serializeMessage)
-    const serializedUnsubscribes = unsubscribes.map(this.serializeMessage)
+  async sendMessages(context: EndpointContext<T>, messages: unknown[]) {
+    const serializedMessages = messages.map(this.serializeMessage)
 
-    const messages = serializedSubscribes.concat(serializedUnsubscribes)
-
-    if (messages.length > 0) {
+    if (serializedMessages.length > 0) {
       logger.debug(`There are ${messages.length} messages to send`)
     }
 
-    for (const message of messages) {
-      this.wsConnection?.send(message)
+    for (const serializedMessage of serializedMessages) {
+      this.wsConnection?.send(serializedMessage)
     }
   }
 
@@ -558,38 +554,10 @@ export class WebSocketTransport<
     // but without this check we'd attempt to send out all the unsubscribe messages
     if (!this.connectionClosed()) {
       logger.debug('Connection is open, sending subs/unsubs if there are any')
-      const builders = this.config.builders
-      if (builders) {
-        if ('batchSubscribeMessage' in builders) {
-          const { batchSubscribeMessage, batchUnsubscribeMessage } = builders
-          await this.sendMessages(
-            context,
-            batchSubscribeMessage
-              ? [batchSubscribeMessage(subscriptions.new, context)].filter((m) => m !== undefined)
-              : subscriptions.new,
-            batchUnsubscribeMessage
-              ? [batchUnsubscribeMessage(subscriptions.stale, context)].filter(
-                  (m) => m !== undefined,
-                )
-              : subscriptions.stale,
-          )
-        } else {
-          const { subscribeMessage, unsubscribeMessage } =
-            builders as WebSocketIndividualBuilders<T>
-          await this.sendMessages(
-            context,
-            subscribeMessage
-              ? subscriptions.new
-                  .map((sub) => subscribeMessage(sub, context))
-                  .filter((m) => m !== undefined)
-              : subscriptions.new,
-            unsubscribeMessage
-              ? subscriptions.stale
-                  .map((sub) => unsubscribeMessage(sub, context))
-                  .filter((m) => m !== undefined)
-              : subscriptions.stale,
-          )
-        }
+
+      if (this.handleSubscriptions) {
+        const messages = this.handleSubscriptions(context, subscriptions)
+        await this.sendMessages(context, messages)
         recordWsMessageSentMetrics(context, subscriptions.new, subscriptions.stale)
       } else {
         logger.trace(

--- a/src/transports/websocket.ts
+++ b/src/transports/websocket.ts
@@ -188,20 +188,25 @@ export type WebsocketTransportGenerics = TransportGenerics & {
   }
 }
 
-const defaultSubscriptionMessageBuilder = <T extends WebsocketTransportGenerics,> (builders: WebSocketIndividualBuilders<T>) => (context: EndpointContext<T>, subscriptions: SubscriptionDeltas<TypeFromDefinition<T['Parameters']>>) => {
-  const { subscribeMessage, unsubscribeMessage } = builders as WebSocketIndividualBuilders<T>
-  const subscribeMessages = subscribeMessage
-    ? subscriptions.new
-      .map((sub) => subscribeMessage(sub, context))
-      .filter((m) => m !== undefined)
-    : subscriptions.new
-  const unsubscribeMessages = unsubscribeMessage
-    ? subscriptions.stale
-      .map((sub) => unsubscribeMessage(sub, context))
-      .filter((m) => m !== undefined)
-    : subscriptions.stale
-  return [...unsubscribeMessages, ...subscribeMessages]
-}
+const defaultSubscriptionMessageBuilder =
+  <T extends WebsocketTransportGenerics>(builders: WebSocketIndividualBuilders<T>) =>
+  (
+    context: EndpointContext<T>,
+    subscriptions: SubscriptionDeltas<TypeFromDefinition<T['Parameters']>>,
+  ) => {
+    const { subscribeMessage, unsubscribeMessage } = builders as WebSocketIndividualBuilders<T>
+    const subscribeMessages = subscribeMessage
+      ? subscriptions.new
+          .map((sub) => subscribeMessage(sub, context))
+          .filter((m) => m !== undefined)
+      : subscriptions.new
+    const unsubscribeMessages = unsubscribeMessage
+      ? subscriptions.stale
+          .map((sub) => unsubscribeMessage(sub, context))
+          .filter((m) => m !== undefined)
+      : subscriptions.stale
+    return [...unsubscribeMessages, ...subscribeMessages]
+  }
 
 /**
  * Transport implementation that takes incoming requests, adds them to an [[subscriptionSet]] and,
@@ -218,7 +223,10 @@ export class WebSocketTransport<
   connectionOpenedAt = 0
   streamHandlerInvocationsWithNoConnection = 0
   heartbeatInterval?: NodeJS.Timeout
-  subscriptionMessageBuilder?: (context: EndpointContext<T>, subscriptions: SubscriptionDeltas<TypeFromDefinition<T['Parameters']>>) => unknown[] | void
+  subscriptionMessageBuilder?: (
+    context: EndpointContext<T>,
+    subscriptions: SubscriptionDeltas<TypeFromDefinition<T['Parameters']>>,
+  ) => unknown[] | void
 
   constructor(private config: WebSocketTransportConfig<T>) {
     super()
@@ -572,7 +580,7 @@ export class WebSocketTransport<
           await this.sendMessages(context, messages)
           recordWsMessageSentMetrics(context, subscriptions.new, subscriptions.stale)
         } else {
-          logger.trace("No messages to send")
+          logger.trace('No messages to send')
         }
       } else {
         logger.trace(

--- a/src/transports/websocket.ts
+++ b/src/transports/websocket.ts
@@ -71,16 +71,18 @@ type WebSocketIndividualBuilders<T extends WebsocketTransportGenerics> = {
 
 type WebSocketCustomBuilders<T extends WebsocketTransportGenerics> = {
   /**
-   * Builds a WS message that will be sent to subscribe to a specific feed
+   * Builds WS messages to subscribe and/or unsubscribe from feeds.
+   * Use this instead of per-subscription builders when an EA needs custom
+   * subscription handling (e.g. batching multiple feeds into one message).
    *
    * @param context - the background context for the Adapter
-   * @param subscriptions - the body of the adapter request
-   * @returns the WS message (can be any type as long as the [[WebSocket]] doesn't complain)
+   * @param subscriptions - new, stale, and desired subscription deltas for this cycle
+   * @returns WS messages to send; an empty array means nothing to send
    */
   customSubscriptionMessages: (
     context: EndpointContext<T>,
     subscriptions: SubscriptionDeltas<TypeFromDefinition<T['Parameters']>>,
-  ) => unknown[] | void
+  ) => unknown[]
 }
 
 /**
@@ -166,8 +168,7 @@ export type WebSocketTransportConfig<T extends WebsocketTransportGenerics> = {
   /**
    * Map of "builders", functions that will be used to prepare specific WS messages.
    * Provide either per-subscription builders (`subscribeMessage` / `unsubscribeMessage`)
-   * or batch builders (`batchSubscribeMessage` / `batchUnsubscribeMessage`), not both.
-   * When `batchSubscribeMessage` is present, the batch path is used.
+   * or a custom builder (`customSubscriptionMessages`), not both.
    */
   builders?: WebSocketIndividualBuilders<T> | WebSocketCustomBuilders<T>
 }
@@ -226,7 +227,7 @@ export class WebSocketTransport<
   subscriptionMessageBuilder?: (
     context: EndpointContext<T>,
     subscriptions: SubscriptionDeltas<TypeFromDefinition<T['Parameters']>>,
-  ) => unknown[] | void
+  ) => unknown[]
 
   constructor(private config: WebSocketTransportConfig<T>) {
     super()
@@ -576,7 +577,7 @@ export class WebSocketTransport<
 
       if (this.subscriptionMessageBuilder) {
         const messages = this.subscriptionMessageBuilder(context, subscriptions)
-        if (messages && messages.length > 0) {
+        if (messages?.length > 0) {
           await this.sendMessages(context, messages)
           recordWsMessageSentMetrics(context, subscriptions.new, subscriptions.stale)
         } else {

--- a/test/transports/websocket.test.ts
+++ b/test/transports/websocket.test.ts
@@ -1946,7 +1946,9 @@ test.serial(
   },
 )
 
-const createBatchAdapter = (): Adapter => {
+const createBatchAdapter = (
+  envDefaultOverrides?: Record<string, string | number | symbol>,
+): Adapter => {
   const websocketTransport = new WebSocketTransport<WebSocketTypes>({
     url: () => ENDPOINT_URL,
     handlers: {
@@ -2004,6 +2006,7 @@ const createBatchAdapter = (): Adapter => {
         BACKGROUND_EXECUTE_MS_WS,
         WS_SUBSCRIPTION_UNRESPONSIVE_TTL: 180_000,
         WS_SUBSCRIPTION_TTL: 10_000,
+        ...envDefaultOverrides,
       },
     },
   )
@@ -2083,13 +2086,14 @@ test.serial('batch builders send one unsubscribe message when feeds go stale', a
     })
   })
 
-  const adapter = createBatchAdapter()
-  t.is(adapter.config.settings.WS_SUBSCRIPTION_TTL, 10_000)
+  const adapter = createBatchAdapter({ WS_SUBSCRIPTION_TTL: 60_000 })
+  t.is(adapter.config.settings.WS_SUBSCRIPTION_TTL, 60_000)
 
   const testAdapter = await TestAdapter.startWithMockedCache(adapter, t.context)
 
   await testAdapter.startBackgroundExecuteThenGetResponse(t, {
     requestData: { base: 'ETH', quote: 'USD' },
+    expectedCacheSize: 1,
     expectedResponse: {
       data: { result: price },
       result: price,
@@ -2099,6 +2103,7 @@ test.serial('batch builders send one unsubscribe message when feeds go stale', a
 
   await testAdapter.startBackgroundExecuteThenGetResponse(t, {
     requestData: { base: 'BTC', quote: 'USD' },
+    expectedCacheSize: 2,
     expectedResponse: {
       data: { result: price },
       result: price,
@@ -2109,11 +2114,7 @@ test.serial('batch builders send one unsubscribe message when feeds go stale', a
   // Refresh BTC only; ETH subscription TTL is not extended.
   await testAdapter.request({ base: 'BTC', quote: 'USD' })
 
-  // Same pattern as the per-subscription stale-unsub test above.
-  await runAllUntilTime(
-    t.context.clock,
-    adapter.config.settings.WS_SUBSCRIPTION_TTL + BACKGROUND_EXECUTE_MS_WS * 3 + 100,
-  )
+  await runAllUntil(t.context.clock, () => unsubscribeMessages.length >= 1)
 
   testAdapter.api.close()
   mockWsServer.close()

--- a/test/transports/websocket.test.ts
+++ b/test/transports/websocket.test.ts
@@ -1946,10 +1946,7 @@ test.serial(
   },
 )
 
-const createBatchAdapter = (
-  envDefaultOverrides: Record<string, string | number | symbol>,
-  buildersOverride?: WebSocketTransportConfig<WebSocketTypes>['builders'],
-): Adapter => {
+const createBatchAdapter = (): Adapter => {
   const websocketTransport = new WebSocketTransport<WebSocketTypes>({
     url: () => ENDPOINT_URL,
     handlers: {
@@ -1974,17 +1971,23 @@ const createBatchAdapter = (
         ]
       },
     },
-    builders: buildersOverride ?? {
-      customSubscriptionMessages: (context, subscriptions) => {
+    builders: {
+      customSubscriptionMessages: (_context, subscriptions) => {
         const messages = []
         if (subscriptions.new.length > 0) {
-          messages.push({ pairs: subscriptions.desired.map((s) => `${s.base}/${s.quote}`), request: 'subscribe' })
+          messages.push({
+            pairs: subscriptions.desired.map((s) => `${s.base}/${s.quote}`),
+            request: 'subscribe',
+          })
         }
         if (subscriptions.stale.length > 0) {
-          messages.push({ pairs: subscriptions.stale.map((s) => `${s.base}/${s.quote}`), request: 'unsubscribe' })
+          messages.push({
+            pairs: subscriptions.stale.map((s) => `${s.base}/${s.quote}`),
+            request: 'unsubscribe',
+          })
         }
         return messages
-      }
+      },
     },
   })
 
@@ -1999,7 +2002,8 @@ const createBatchAdapter = (
     {
       envDefaultOverrides: {
         BACKGROUND_EXECUTE_MS_WS,
-        ...envDefaultOverrides,
+        WS_SUBSCRIPTION_UNRESPONSIVE_TTL: 180_000,
+        WS_SUBSCRIPTION_TTL: 10_000,
       },
     },
   )
@@ -2029,7 +2033,7 @@ test.serial('batch builders send one subscribe message for multiple feeds', asyn
     })
   })
 
-  const adapter = createBatchAdapter({})
+  const adapter = createBatchAdapter()
   const testAdapter = await TestAdapter.startWithMockedCache(adapter, t.context)
 
   await testAdapter.startBackgroundExecuteThenGetResponse(t, {
@@ -2061,7 +2065,7 @@ test.serial('batch builders send one subscribe message for multiple feeds', asyn
   t.deepEqual(subscribeMessages[1].pairs, ['ETH/USD', 'BTC/USD'])
 })
 
-test.only('batch builders send one unsubscribe message when feeds go stale', async (t) => {
+test.serial('batch builders send one unsubscribe message when feeds go stale', async (t) => {
   mockWebSocketProvider(WebSocketClassProvider)
   const mockWsServer = new Server(ENDPOINT_URL, { mock: false })
   const unsubscribeMessages: Array<{ request: string; pairs: string[] }> = []
@@ -2079,10 +2083,9 @@ test.only('batch builders send one unsubscribe message when feeds go stale', asy
     })
   })
 
-  const adapter = createBatchAdapter({
-      WS_SUBSCRIPTION_UNRESPONSIVE_TTL: 180_000,
-      WS_SUBSCRIPTION_TTL: 10_000,
-  })
+  const adapter = createBatchAdapter()
+  t.is(adapter.config.settings.WS_SUBSCRIPTION_TTL, 10_000)
+
   const testAdapter = await TestAdapter.startWithMockedCache(adapter, t.context)
 
   await testAdapter.startBackgroundExecuteThenGetResponse(t, {
@@ -2103,21 +2106,14 @@ test.only('batch builders send one unsubscribe message when feeds go stale', asy
     },
   })
 
-  await runAllUntilTime(t.context.clock, 3_000)
+  // Refresh BTC only; ETH subscription TTL is not extended.
+  await testAdapter.request({ base: 'BTC', quote: 'USD' })
 
-  await testAdapter.startBackgroundExecuteThenGetResponse(t, {
-    requestData: { base: 'BTC', quote: 'USD' },
-    expectedResponse: {
-      data: { result: price },
-      result: price,
-      statusCode: 200,
-    },
-  })
-
-  await runAllUntilTime(t.context.clock, 8_000)
-
-  const error = await testAdapter.request({ base: 'ETH', quote: 'USD' })
-  t.is(error.statusCode, 504)
+  // Same pattern as the per-subscription stale-unsub test above.
+  await runAllUntilTime(
+    t.context.clock,
+    adapter.config.settings.WS_SUBSCRIPTION_TTL + BACKGROUND_EXECUTE_MS_WS * 3 + 100,
+  )
 
   testAdapter.api.close()
   mockWsServer.close()

--- a/test/transports/websocket.test.ts
+++ b/test/transports/websocket.test.ts
@@ -2022,110 +2022,110 @@ const createCustomSubscriptionsAdapter = (
 test.serial(
   'custom subscription builder sends one subscribe message for multiple feeds',
   async (t) => {
-  mockWebSocketProvider(WebSocketClassProvider)
-  const mockWsServer = new Server(ENDPOINT_URL, { mock: false })
-  const subscribeMessages: Array<{ request: string; pairs: string[] }> = []
+    mockWebSocketProvider(WebSocketClassProvider)
+    const mockWsServer = new Server(ENDPOINT_URL, { mock: false })
+    const subscribeMessages: Array<{ request: string; pairs: string[] }> = []
 
-  mockWsServer.on('connection', (socket) => {
-    socket.on('message', (rawMsg) => {
-      const parsed = JSON.parse(rawMsg.toString())
-      if (parsed.request === 'subscribe') {
-        subscribeMessages.push(parsed)
-        for (const pair of parsed.pairs) {
-          socket.send(JSON.stringify({ pair, value: price }))
+    mockWsServer.on('connection', (socket) => {
+      socket.on('message', (rawMsg) => {
+        const parsed = JSON.parse(rawMsg.toString())
+        if (parsed.request === 'subscribe') {
+          subscribeMessages.push(parsed)
+          for (const pair of parsed.pairs) {
+            socket.send(JSON.stringify({ pair, value: price }))
+          }
         }
-      }
+      })
     })
-  })
 
-  const adapter = createCustomSubscriptionsAdapter()
-  const testAdapter = await TestAdapter.startWithMockedCache(adapter, t.context)
+    const adapter = createCustomSubscriptionsAdapter()
+    const testAdapter = await TestAdapter.startWithMockedCache(adapter, t.context)
 
-  await testAdapter.startBackgroundExecuteThenGetResponse(t, {
-    requestData: { base: 'ETH', quote: 'USD' },
-    expectedCacheSize: 1,
-    expectedResponse: {
-      data: { result: price },
-      result: price,
-      statusCode: 200,
-    },
-  })
+    await testAdapter.startBackgroundExecuteThenGetResponse(t, {
+      requestData: { base: 'ETH', quote: 'USD' },
+      expectedCacheSize: 1,
+      expectedResponse: {
+        data: { result: price },
+        result: price,
+        statusCode: 200,
+      },
+    })
 
-  await testAdapter.startBackgroundExecuteThenGetResponse(t, {
-    requestData: { base: 'BTC', quote: 'USD' },
-    expectedCacheSize: 2,
-    expectedResponse: {
-      data: { result: price },
-      result: price,
-      statusCode: 200,
-    },
-  })
+    await testAdapter.startBackgroundExecuteThenGetResponse(t, {
+      requestData: { base: 'BTC', quote: 'USD' },
+      expectedCacheSize: 2,
+      expectedResponse: {
+        data: { result: price },
+        result: price,
+        statusCode: 200,
+      },
+    })
 
-  testAdapter.api.close()
-  mockWsServer.close()
-  await t.context.clock.runToLastAsync()
+    testAdapter.api.close()
+    mockWsServer.close()
+    await t.context.clock.runToLastAsync()
 
-  t.is(subscribeMessages.length, 2)
-  t.deepEqual(subscribeMessages[0].pairs, ['ETH/USD'])
-  t.deepEqual(subscribeMessages[1].pairs, ['ETH/USD', 'BTC/USD'])
+    t.is(subscribeMessages.length, 2)
+    t.deepEqual(subscribeMessages[0].pairs, ['ETH/USD'])
+    t.deepEqual(subscribeMessages[1].pairs, ['ETH/USD', 'BTC/USD'])
   },
 )
 
 test.serial(
   'custom subscription builder sends one unsubscribe message when feeds go stale',
   async (t) => {
-  mockWebSocketProvider(WebSocketClassProvider)
-  const mockWsServer = new Server(ENDPOINT_URL, { mock: false })
-  const unsubscribeMessages: Array<{ request: string; pairs: string[] }> = []
+    mockWebSocketProvider(WebSocketClassProvider)
+    const mockWsServer = new Server(ENDPOINT_URL, { mock: false })
+    const unsubscribeMessages: Array<{ request: string; pairs: string[] }> = []
 
-  mockWsServer.on('connection', (socket) => {
-    socket.on('message', (rawMsg) => {
-      const parsed = JSON.parse(rawMsg.toString())
-      if (parsed.request === 'subscribe') {
-        for (const pair of parsed.pairs) {
-          socket.send(JSON.stringify({ pair, value: price }))
+    mockWsServer.on('connection', (socket) => {
+      socket.on('message', (rawMsg) => {
+        const parsed = JSON.parse(rawMsg.toString())
+        if (parsed.request === 'subscribe') {
+          for (const pair of parsed.pairs) {
+            socket.send(JSON.stringify({ pair, value: price }))
+          }
+        } else if (parsed.request === 'unsubscribe') {
+          unsubscribeMessages.push(parsed)
         }
-      } else if (parsed.request === 'unsubscribe') {
-        unsubscribeMessages.push(parsed)
-      }
+      })
     })
-  })
 
-  const adapter = createCustomSubscriptionsAdapter({ WS_SUBSCRIPTION_TTL: 60_000 })
-  t.is(adapter.config.settings.WS_SUBSCRIPTION_TTL, 60_000)
+    const adapter = createCustomSubscriptionsAdapter({ WS_SUBSCRIPTION_TTL: 60_000 })
+    t.is(adapter.config.settings.WS_SUBSCRIPTION_TTL, 60_000)
 
-  const testAdapter = await TestAdapter.startWithMockedCache(adapter, t.context)
+    const testAdapter = await TestAdapter.startWithMockedCache(adapter, t.context)
 
-  await testAdapter.startBackgroundExecuteThenGetResponse(t, {
-    requestData: { base: 'ETH', quote: 'USD' },
-    expectedCacheSize: 1,
-    expectedResponse: {
-      data: { result: price },
-      result: price,
-      statusCode: 200,
-    },
-  })
+    await testAdapter.startBackgroundExecuteThenGetResponse(t, {
+      requestData: { base: 'ETH', quote: 'USD' },
+      expectedCacheSize: 1,
+      expectedResponse: {
+        data: { result: price },
+        result: price,
+        statusCode: 200,
+      },
+    })
 
-  await testAdapter.startBackgroundExecuteThenGetResponse(t, {
-    requestData: { base: 'BTC', quote: 'USD' },
-    expectedCacheSize: 2,
-    expectedResponse: {
-      data: { result: price },
-      result: price,
-      statusCode: 200,
-    },
-  })
+    await testAdapter.startBackgroundExecuteThenGetResponse(t, {
+      requestData: { base: 'BTC', quote: 'USD' },
+      expectedCacheSize: 2,
+      expectedResponse: {
+        data: { result: price },
+        result: price,
+        statusCode: 200,
+      },
+    })
 
-  // Refresh BTC only; ETH subscription TTL is not extended.
-  await testAdapter.request({ base: 'BTC', quote: 'USD' })
+    // Refresh BTC only; ETH subscription TTL is not extended.
+    await testAdapter.request({ base: 'BTC', quote: 'USD' })
 
-  await runAllUntil(t.context.clock, () => unsubscribeMessages.length >= 1)
+    await runAllUntil(t.context.clock, () => unsubscribeMessages.length >= 1)
 
-  testAdapter.api.close()
-  mockWsServer.close()
-  await t.context.clock.runToLastAsync()
+    testAdapter.api.close()
+    mockWsServer.close()
+    await t.context.clock.runToLastAsync()
 
-  t.is(unsubscribeMessages.length, 1)
-  t.deepEqual(unsubscribeMessages[0].pairs, ['ETH/USD'])
+    t.is(unsubscribeMessages.length, 1)
+    t.deepEqual(unsubscribeMessages[0].pairs, ['ETH/USD'])
   },
 )

--- a/test/transports/websocket.test.ts
+++ b/test/transports/websocket.test.ts
@@ -1946,7 +1946,10 @@ test.serial(
   },
 )
 
-const createBatchAdapter = (): Adapter => {
+const createBatchAdapter = (
+  envDefaultOverrides: Record<string, string | number | symbol>,
+  buildersOverride?: WebSocketTransportConfig<WebSocketTypes>['builders'],
+): Adapter => {
   const websocketTransport = new WebSocketTransport<WebSocketTypes>({
     url: () => ENDPOINT_URL,
     handlers: {
@@ -1971,15 +1974,17 @@ const createBatchAdapter = (): Adapter => {
         ]
       },
     },
-    builders: {
-      batchSubscribeMessage: (params) => ({
-        request: 'subscribe',
-        pairs: params.map((p) => `${p.base}/${p.quote}`),
-      }),
-      batchUnsubscribeMessage: (params) => ({
-        request: 'unsubscribe',
-        pairs: params.map((p) => `${p.base}/${p.quote}`),
-      }),
+    builders: buildersOverride ?? {
+      customSubscriptionMessages: (context, subscriptions) => {
+        const messages = []
+        if (subscriptions.new.length > 0) {
+          messages.push({ pairs: subscriptions.desired.map((s) => `${s.base}/${s.quote}`), request: 'subscribe' })
+        }
+        if (subscriptions.stale.length > 0) {
+          messages.push({ pairs: subscriptions.stale.map((s) => `${s.base}/${s.quote}`), request: 'unsubscribe' })
+        }
+        return messages
+      }
     },
   })
 
@@ -1994,7 +1999,7 @@ const createBatchAdapter = (): Adapter => {
     {
       envDefaultOverrides: {
         BACKGROUND_EXECUTE_MS_WS,
-        WS_SUBSCRIPTION_UNRESPONSIVE_TTL: 180_000,
+        ...envDefaultOverrides,
       },
     },
   )
@@ -2024,7 +2029,7 @@ test.serial('batch builders send one subscribe message for multiple feeds', asyn
     })
   })
 
-  const adapter = createBatchAdapter()
+  const adapter = createBatchAdapter({})
   const testAdapter = await TestAdapter.startWithMockedCache(adapter, t.context)
 
   await testAdapter.startBackgroundExecuteThenGetResponse(t, {
@@ -2053,12 +2058,13 @@ test.serial('batch builders send one subscribe message for multiple feeds', asyn
 
   t.is(subscribeMessages.length, 2)
   t.deepEqual(subscribeMessages[0].pairs, ['ETH/USD'])
-  t.deepEqual(subscribeMessages[1].pairs, ['BTC/USD'])
+  t.deepEqual(subscribeMessages[1].pairs, ['ETH/USD', 'BTC/USD'])
 })
 
-test.serial('batch builders send one unsubscribe message when feeds go stale', async (t) => {
+test.only('batch builders send one unsubscribe message when feeds go stale', async (t) => {
   mockWebSocketProvider(WebSocketClassProvider)
   const mockWsServer = new Server(ENDPOINT_URL, { mock: false })
+  const unsubscribeMessages: Array<{ request: string; pairs: string[] }> = []
 
   mockWsServer.on('connection', (socket) => {
     socket.on('message', (rawMsg) => {
@@ -2067,11 +2073,16 @@ test.serial('batch builders send one unsubscribe message when feeds go stale', a
         for (const pair of parsed.pairs) {
           socket.send(JSON.stringify({ pair, value: price }))
         }
+      } else if (parsed.request === 'unsubscribe') {
+        unsubscribeMessages.push(parsed)
       }
     })
   })
 
-  const adapter = createBatchAdapter()
+  const adapter = createBatchAdapter({
+      WS_SUBSCRIPTION_UNRESPONSIVE_TTL: 180_000,
+      WS_SUBSCRIPTION_TTL: 10_000,
+  })
   const testAdapter = await TestAdapter.startWithMockedCache(adapter, t.context)
 
   await testAdapter.startBackgroundExecuteThenGetResponse(t, {
@@ -2083,11 +2094,27 @@ test.serial('batch builders send one unsubscribe message when feeds go stale', a
     },
   })
 
-  const duration =
-    Math.ceil(CACHE_MAX_AGE / adapter.config.settings.WS_SUBSCRIPTION_TTL) *
-      adapter.config.settings.WS_SUBSCRIPTION_TTL +
-    1
-  await runAllUntilTime(t.context.clock, duration)
+  await testAdapter.startBackgroundExecuteThenGetResponse(t, {
+    requestData: { base: 'BTC', quote: 'USD' },
+    expectedResponse: {
+      data: { result: price },
+      result: price,
+      statusCode: 200,
+    },
+  })
+
+  await runAllUntilTime(t.context.clock, 3_000)
+
+  await testAdapter.startBackgroundExecuteThenGetResponse(t, {
+    requestData: { base: 'BTC', quote: 'USD' },
+    expectedResponse: {
+      data: { result: price },
+      result: price,
+      statusCode: 200,
+    },
+  })
+
+  await runAllUntilTime(t.context.clock, 8_000)
 
   const error = await testAdapter.request({ base: 'ETH', quote: 'USD' })
   t.is(error.statusCode, 504)
@@ -2095,4 +2122,7 @@ test.serial('batch builders send one unsubscribe message when feeds go stale', a
   testAdapter.api.close()
   mockWsServer.close()
   await t.context.clock.runToLastAsync()
+
+  t.is(unsubscribeMessages.length, 1)
+  t.deepEqual(unsubscribeMessages[0].pairs, ['ETH/USD'])
 })

--- a/test/transports/websocket.test.ts
+++ b/test/transports/websocket.test.ts
@@ -1946,7 +1946,7 @@ test.serial(
   },
 )
 
-const createBatchAdapter = (
+const createCustomSubscriptionsAdapter = (
   envDefaultOverrides?: Record<string, string | number | symbol>,
 ): Adapter => {
   const websocketTransport = new WebSocketTransport<WebSocketTypes>({
@@ -2019,7 +2019,9 @@ const createBatchAdapter = (
   })
 }
 
-test.serial('batch builders send one subscribe message for multiple feeds', async (t) => {
+test.serial(
+  'custom subscription builder sends one subscribe message for multiple feeds',
+  async (t) => {
   mockWebSocketProvider(WebSocketClassProvider)
   const mockWsServer = new Server(ENDPOINT_URL, { mock: false })
   const subscribeMessages: Array<{ request: string; pairs: string[] }> = []
@@ -2036,7 +2038,7 @@ test.serial('batch builders send one subscribe message for multiple feeds', asyn
     })
   })
 
-  const adapter = createBatchAdapter()
+  const adapter = createCustomSubscriptionsAdapter()
   const testAdapter = await TestAdapter.startWithMockedCache(adapter, t.context)
 
   await testAdapter.startBackgroundExecuteThenGetResponse(t, {
@@ -2066,9 +2068,12 @@ test.serial('batch builders send one subscribe message for multiple feeds', asyn
   t.is(subscribeMessages.length, 2)
   t.deepEqual(subscribeMessages[0].pairs, ['ETH/USD'])
   t.deepEqual(subscribeMessages[1].pairs, ['ETH/USD', 'BTC/USD'])
-})
+  },
+)
 
-test.serial('batch builders send one unsubscribe message when feeds go stale', async (t) => {
+test.serial(
+  'custom subscription builder sends one unsubscribe message when feeds go stale',
+  async (t) => {
   mockWebSocketProvider(WebSocketClassProvider)
   const mockWsServer = new Server(ENDPOINT_URL, { mock: false })
   const unsubscribeMessages: Array<{ request: string; pairs: string[] }> = []
@@ -2086,7 +2091,7 @@ test.serial('batch builders send one unsubscribe message when feeds go stale', a
     })
   })
 
-  const adapter = createBatchAdapter({ WS_SUBSCRIPTION_TTL: 60_000 })
+  const adapter = createCustomSubscriptionsAdapter({ WS_SUBSCRIPTION_TTL: 60_000 })
   t.is(adapter.config.settings.WS_SUBSCRIPTION_TTL, 60_000)
 
   const testAdapter = await TestAdapter.startWithMockedCache(adapter, t.context)
@@ -2122,4 +2127,5 @@ test.serial('batch builders send one unsubscribe message when feeds go stale', a
 
   t.is(unsubscribeMessages.length, 1)
   t.deepEqual(unsubscribeMessages[0].pairs, ['ETH/USD'])
-})
+  },
+)


### PR DESCRIPTION
## Summary

Adds a `customSubscriptionMessages` builder to `WebSocketTransport` so EAs can fully control how subscribe/unsubscribe WebSocket messages are built each background-execute cycle. This replaces the earlier `batchSubscribeMessage` / `batchUnsubscribeMessage` API with a more flexible hook that receives full subscription deltas (`new`, `stale`, and `desired`).

- Introduces `WebSocketCustomBuilders` with `customSubscriptionMessages(context, subscriptions) => unknown[]`
- Unifies outbound message construction behind an internal `subscriptionMessageBuilder`; per-subscription `subscribeMessage` / `unsubscribeMessage` builders continue to work via a default adapter
- Simplifies `sendMessages` to accept a single ordered message array
- Updates docs and tests for the new API

**Motivation (DF-25178):** Some providers need EA-specific subscription logic—e.g. batching multiple feeds into one message, custom ordering, or provider-specific payload shapes—that the fixed per-feed and batch-builder APIs could not express cleanly.

**Backward compatibility:** Existing adapters using `subscribeMessage` / `unsubscribeMessage` are unchanged. Only adapters that adopt `customSubscriptionMessages` need updates.

## API

Configure **either** per-subscription builders **or** the custom builder, not both:

```typescript
builders: {
  customSubscriptionMessages: (_context, subscriptions) => {
    const messages = []
    if (subscriptions.new.length > 0) {
      messages.push({
        request: 'subscribe',
        pairs: subscriptions.new.map((s) => `${s.base}/${s.quote}`),
      })
    }
    if (subscriptions.stale.length > 0) {
      messages.push({
        request: 'unsubscribe',
        pairs: subscriptions.stale.map((s) => `${s.base}/${s.quote}`),
      })
    }
    return messages
  },
}