### PR TITLE
Fix flaky Redis test

### DIFF
--- a/test/cache/helper.ts
+++ b/test/cache/helper.ts
@@ -56,7 +56,11 @@ export class BasicCacheSetterTransport extends NopTransport<CacheTestTransportTy
   }
 }
 
+// Transport that gives a different result each time, even across different
+// instances.
 export class DifferentResultTransport extends NopTransport<CacheTestTransportTypes> {
+  static nextResult = Date.now()
+
   override async foregroundExecute(
     req: AdapterRequest<TypeFromDefinition<typeof cacheTestInputParameters.definition>>,
   ): Promise<void> {
@@ -65,7 +69,7 @@ export class DifferentResultTransport extends NopTransport<CacheTestTransportTyp
         params: req.requestContext.data,
         response: {
           data: null,
-          result: Date.now(),
+          result: DifferentResultTransport.nextResult++,
           timestamps: {
             providerDataRequestedUnixMs: 0,
             providerDataReceivedUnixMs: 0,


### PR DESCRIPTION
# Description

I've noticed `test/cache/redis.test.ts` being very flaky.
The test `'Test cache key collision across adapters'` relies on `DifferentResultTransport` giving a different result each time.
But the actual result is created with `Date.now()` and in practice it often runs within the same millisecond, giving the same result.

# Changes

Make `DifferentResultTransport` actually return a different result each time.