### PR TITLE
Fix compile issues in generated EA

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -89,6 +89,7 @@ jobs:
           DEBUG=* yo "$path_to_generator" examples
           cd examples/example-adapter
           yarn build
+          yarn tsc -b --noEmit tsconfig.test.json
           yarn test
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/scripts/generator-adapter/generators/app/templates/test/integration/adapter-ws.test.ts.ejs
+++ b/scripts/generator-adapter/generators/app/templates/test/integration/adapter-ws.test.ts.ejs
@@ -1,3 +1,4 @@
+import { SettingsDefinitionFromConfig } from '@chainlink/external-adapter-framework/config'
 import { WebSocketClassProvider } from '@chainlink/external-adapter-framework/transports'
 import {
   TestAdapter,
@@ -5,13 +6,15 @@ import {
   mockWebSocketProvider,
   MockWebsocketServer,
 } from '@chainlink/external-adapter-framework/util/testing-utils'
-import FakeTimers from '@sinonjs/fake-timers'
+import FakeTimers, { InstalledClock } from '@sinonjs/fake-timers'
+import { config } from '../../src/config'
 import { mockWebsocketServer } from './fixtures'
 
+type SettingsDefinition = SettingsDefinitionFromConfig<typeof config>
 
 describe('websocket', () => {
   let mockWsServer: MockWebsocketServer | undefined
-  let testAdapter: TestAdapter
+  let testAdapter: TestAdapter<SettingsDefinition>
   const wsEndpoint = 'ws://localhost:9090'
   let oldEnv: NodeJS.ProcessEnv
 <% for(let i=0; i<endpoints.length; i++) {%>
@@ -32,7 +35,7 @@ describe('websocket', () => {
     const adapter = (await import('./../../src')).adapter
     testAdapter = await TestAdapter.startWithMockedCache(adapter, {
       clock: FakeTimers.install(),
-      testAdapter: {} as TestAdapter<never>,
+      testAdapter: {} as TestAdapter<SettingsDefinition>,
     })
 
     // Send initial request to start background execute and wait for cache to be filled with results
@@ -44,7 +47,7 @@ describe('websocket', () => {
   afterAll(async () => {
     setEnvVariables(oldEnv)
     mockWsServer?.close()
-    testAdapter.clock?.uninstall()
+    ;(testAdapter.clock as InstalledClock | undefined)?.uninstall()
     await testAdapter.api.close()
   })
 <% for(var i=0; i<endpoints.length; i++) {%>

--- a/scripts/generator-adapter/generators/app/templates/test/integration/adapter.test.ts.ejs
+++ b/scripts/generator-adapter/generators/app/templates/test/integration/adapter.test.ts.ejs
@@ -1,13 +1,17 @@
+import { SettingsDefinitionFromConfig } from '@chainlink/external-adapter-framework/config'
 import {
   TestAdapter,
   setEnvVariables,
 } from '@chainlink/external-adapter-framework/util/testing-utils'
 import * as nock from 'nock'
+import { config } from '../../src/config'
 import { <% if (mockPostResponse) { %>mockPostResponseSuccess<% } else { %>mockResponseSuccess<% } %> } from './fixtures'
+
+type SettingsDefinition = SettingsDefinitionFromConfig<typeof config>
 
 describe('execute', () => {
   let spy: jest.SpyInstance
-  let testAdapter: TestAdapter
+  let testAdapter: TestAdapter<SettingsDefinition>
   let oldEnv: NodeJS.ProcessEnv
 
   beforeAll(async () => {
@@ -20,7 +24,7 @@ describe('execute', () => {
     const adapter = (await import('./../../src')).adapter
     adapter.rateLimiting = undefined
     testAdapter = await TestAdapter.startWithMockedCache(adapter, {
-      testAdapter: {} as TestAdapter<never>,
+      testAdapter: {} as TestAdapter<SettingsDefinition>,
     })
   })
 

--- a/scripts/generator-adapter/generators/app/templates/test/integration/fixtures.ts.ejs
+++ b/scripts/generator-adapter/generators/app/templates/test/integration/fixtures.ts.ejs
@@ -47,7 +47,7 @@ export const mockPostResponseSuccess = (): nock.Scope =>
 export const mockWebsocketServer = (URL: string): MockWebsocketServer => {
     const mockWsServer = new MockWebsocketServer(URL, { mock: false })
     mockWsServer.on('connection', (socket) => {
-      socket.on('message', (message) => {
+      socket.on('message', (_message) => {
           return socket.send(
             JSON.stringify({
               success: true,

--- a/scripts/generator-adapter/generators/app/templates/test/unit/ws.test.ts.ejs
+++ b/scripts/generator-adapter/generators/app/templates/test/unit/ws.test.ts.ejs
@@ -9,7 +9,6 @@ import {
   makeStub,
   mockWebSocketProvider,
   MockWebsocketServer,
-  runAllUntil,
   runAllUntilSettled,
 } from '@chainlink/external-adapter-framework/util/testing-utils'
 import FakeTimers from '@sinonjs/fake-timers'


### PR DESCRIPTION
# Description

When I added the new generated unit tests, some earlier version didn't compile but this wasn't caught in CI.
I didn't fix that originally because the existing tests also didn't compile.

# Changes

1. Fix compilation issues in generated tests.
2. Compile generated tests in CI.