### PR TITLE
OPDATA-6402 update comparison in CompositeTransport CompareResponseCache

### DIFF
--- a/src/cache/response-cache/compare.ts
+++ b/src/cache/response-cache/compare.ts
@@ -14,11 +14,6 @@ export class CompareResponseCache<
   readonly transportName: string
   // The actual cache where responses are written to
   responseCache: ResponseCache<T>
-  // A local map to keep track of the most recent entries written to the responseCache
-  // We compare with this first before comparing with value in cache
-  // so that we can reduce cache reads
-  localCache: Map<string, { value: AdapterResponse<T['Response']>; writtenAt: number }>
-  staleThreshold: number
   // True if next should replace current in cache
   shouldUpdate: (
     next: AdapterResponse<T['Response']>,
@@ -32,7 +27,6 @@ export class CompareResponseCache<
       next: AdapterResponse<T['Response']>,
       current?: AdapterResponse<T['Response']>,
     ) => boolean,
-    staleThreshold = Infinity,
   ) {
     super({
       inputParameters: responseCache.inputParameters,
@@ -43,8 +37,6 @@ export class CompareResponseCache<
     })
     this.transportName = transportName
     this.responseCache = responseCache
-    this.localCache = new Map()
-    this.staleThreshold = staleThreshold
     this.shouldUpdate = shouldUpdate
   }
 
@@ -60,23 +52,12 @@ export class CompareResponseCache<
       value: AdapterResponse<T['Response']>
     }[],
   ) {
-    const now = Date.now()
     const filteredEntries = (
       await Promise.all(
         entries.flatMap(async ({ key, value }) => {
-          const local = this.localCache.get(key)
-          const isLocalExpired = !!local && now - local.writtenAt >= this.staleThreshold
-          const localValue = local && !isLocalExpired ? local.value : undefined
-          if (!this.shouldUpdate(value, localValue)) {
+          const current = await this.get(key)
+          if (!this.shouldUpdate(value, current)) {
             return []
-          }
-          // Skip the Redis check when the local entry is expired — the incoming write
-          // should take over regardless of what Redis has at that point.
-          if (!isLocalExpired) {
-            const entryInCache = await this.get(key)
-            if (!this.shouldUpdate(value, entryInCache)) {
-              return []
-            }
           }
           return [{ key, value }]
         }),
@@ -85,10 +66,6 @@ export class CompareResponseCache<
 
     if (filteredEntries.length > 0) {
       await this.responseCache.writeEntries(filteredEntries)
-
-      filteredEntries.forEach(({ key, value }) => {
-        this.localCache.set(key, { value, writtenAt: now })
-      })
     }
   }
 

--- a/src/cache/response-cache/compare.ts
+++ b/src/cache/response-cache/compare.ts
@@ -17,7 +17,8 @@ export class CompareResponseCache<
   // A local map to keep track of the most recent entries written to the responseCache
   // We compare with this first before comparing with value in cache
   // so that we can reduce cache reads
-  localCache: Map<string, AdapterResponse<T['Response']>>
+  localCache: Map<string, { value: AdapterResponse<T['Response']>; writtenAt: number }>
+  staleThreshold: number
   // True if next should replace current in cache
   shouldUpdate: (
     next: AdapterResponse<T['Response']>,
@@ -31,6 +32,7 @@ export class CompareResponseCache<
       next: AdapterResponse<T['Response']>,
       current?: AdapterResponse<T['Response']>,
     ) => boolean,
+    staleThreshold = Infinity,
   ) {
     super({
       inputParameters: responseCache.inputParameters,
@@ -42,6 +44,7 @@ export class CompareResponseCache<
     this.transportName = transportName
     this.responseCache = responseCache
     this.localCache = new Map()
+    this.staleThreshold = staleThreshold
     this.shouldUpdate = shouldUpdate
   }
 
@@ -57,15 +60,23 @@ export class CompareResponseCache<
       value: AdapterResponse<T['Response']>
     }[],
   ) {
+    const now = Date.now()
     const filteredEntries = (
       await Promise.all(
         entries.flatMap(async ({ key, value }) => {
-          if (!this.shouldUpdate(value, this.localCache.get(key))) {
+          const local = this.localCache.get(key)
+          const isLocalExpired = !!local && now - local.writtenAt >= this.staleThreshold
+          const localValue = local && !isLocalExpired ? local.value : undefined
+          if (!this.shouldUpdate(value, localValue)) {
             return []
           }
-          const entryInCache = await this.get(key)
-          if (!this.shouldUpdate(value, entryInCache)) {
-            return []
+          // Skip the Redis check when the local entry is expired — the incoming write
+          // should take over regardless of what Redis has at that point.
+          if (!isLocalExpired) {
+            const entryInCache = await this.get(key)
+            if (!this.shouldUpdate(value, entryInCache)) {
+              return []
+            }
           }
           return [{ key, value }]
         }),
@@ -76,7 +87,7 @@ export class CompareResponseCache<
       await this.responseCache.writeEntries(filteredEntries)
 
       filteredEntries.forEach(({ key, value }) => {
-        this.localCache.set(key, value)
+        this.localCache.set(key, { value, writtenAt: now })
       })
     }
   }

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -399,12 +399,6 @@ export const BaseSettingsDefinition = {
     description: 'Whether to use enableCompositeTransport parameter in AdapterEndpoint',
     default: false,
   },
-  COMPOSITE_TRANSPORT_STALE_THRESHOLD_MS: {
-    type: 'number',
-    description:
-      'The maximum amount of time in milliseconds before a composite transport cache entry is considered stale. Defaults to CACHE_MAX_AGE / 2 if not set.',
-    validate: validator.integer({ min: 1000, max: 60 * 60 * 1000 }), // Max 1 hour
-  },
 } as const satisfies SettingsDefinitionMap
 
 export const buildAdapterSettings = <

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -399,6 +399,12 @@ export const BaseSettingsDefinition = {
     description: 'Whether to use enableCompositeTransport parameter in AdapterEndpoint',
     default: false,
   },
+  COMPOSITE_TRANSPORT_STALE_THRESHOLD_MS: {
+    type: 'number',
+    description:
+      'The maximum amount of time in milliseconds before a composite transport cache entry is considered stale. Defaults to CACHE_MAX_AGE / 2 if not set.',
+    validate: validator.integer({ min: 1000, max: 60 * 60 * 1000 }), // Max 1 hour
+  },
 } as const satisfies SettingsDefinitionMap
 
 export const buildAdapterSettings = <

--- a/src/transports/composite.ts
+++ b/src/transports/composite.ts
@@ -24,12 +24,30 @@ export class CompositeTransport<T extends TransportGenerics> implements Transpor
     this.name = transportName
     this.responseCache = dependencies.responseCache
 
+    const staleThreshold =
+      adapterSettings.COMPOSITE_TRANSPORT_STALE_THRESHOLD_MS ?? adapterSettings.CACHE_MAX_AGE / 2
+
     const compareCache = new CompareResponseCache(
       transportName,
       this.responseCache,
-      (next, current) =>
-        (next.timestamps?.providerIndicatedTimeUnixMs ?? 0) >
-        (current?.timestamps?.providerIndicatedTimeUnixMs ?? 0),
+      (next, current) => {
+        // If newer timestamp, return true.
+        // If same timestamp and value, return true to refresh TTL. This may be from another transport.
+        // If same timestamp and different value but current entry is older than staleThreshold, return true to avoid serving stale data after a transport goes silent.
+        // If same timestamp and different value and current entry is fresh, return false to avoid rubberbanding between transports.
+        const newTimestamp = next.timestamps?.providerIndicatedTimeUnixMs ?? 0
+        const currentTimestamp = current?.timestamps?.providerIndicatedTimeUnixMs ?? 0
+        const newReceivedTimestamp = next.timestamps?.providerDataReceivedUnixMs ?? 0
+        const currentReceivedTimestamp = current?.timestamps?.providerDataReceivedUnixMs ?? 0
+        const newData = JSON.stringify(next.data)
+        const currentData = JSON.stringify(current?.data)
+        return (
+          newTimestamp > currentTimestamp ||
+          (newTimestamp === currentTimestamp && newData === currentData) ||
+          (newTimestamp === currentTimestamp &&
+            newReceivedTimestamp > currentReceivedTimestamp + staleThreshold)
+        )
+      },
     )
 
     await Promise.all(
@@ -61,6 +79,10 @@ export class CompositeTransport<T extends TransportGenerics> implements Transpor
 
   async backgroundExecute(context: EndpointContext<T>): Promise<void> {
     const entries = Object.entries(this.transports)
+
+    // Note that this will wait for the slowest transport to resolve before completing
+    // this shared backgroundExecute loop and stalling the faster transport(s).
+    // Consider setting lower timeouts on the individual transports if this becomes an issue.
     const results = await Promise.allSettled(entries.map(([, t]) => t.backgroundExecute?.(context)))
 
     results.forEach((r, i) => {

--- a/src/transports/composite.ts
+++ b/src/transports/composite.ts
@@ -24,18 +24,14 @@ export class CompositeTransport<T extends TransportGenerics> implements Transpor
     this.name = transportName
     this.responseCache = dependencies.responseCache
 
-    const staleThreshold =
-      adapterSettings.COMPOSITE_TRANSPORT_STALE_THRESHOLD_MS ?? adapterSettings.CACHE_MAX_AGE / 2
-
     const compareCache = new CompareResponseCache(
       transportName,
       this.responseCache,
       (next, current) =>
         // Write if the incoming value has a newer provider timestamp
-        // Also writes if the local cache entry has gone stale in the underlying CompareResponseCache
+        // Also writes if the previous cache entry is stale/expired
         (next.timestamps?.providerIndicatedTimeUnixMs ?? 0) >
         (current?.timestamps?.providerIndicatedTimeUnixMs ?? 0),
-      staleThreshold,
     )
 
     await Promise.all(

--- a/src/transports/composite.ts
+++ b/src/transports/composite.ts
@@ -30,24 +30,12 @@ export class CompositeTransport<T extends TransportGenerics> implements Transpor
     const compareCache = new CompareResponseCache(
       transportName,
       this.responseCache,
-      (next, current) => {
-        // If newer timestamp, return true.
-        // If same timestamp and value, return true to refresh TTL. This may be from another transport.
-        // If same timestamp and different value but current entry is older than staleThreshold, return true to avoid serving stale data after a transport goes silent.
-        // If same timestamp and different value and current entry is fresh, return false to avoid rubberbanding between transports.
-        const newTimestamp = next.timestamps?.providerIndicatedTimeUnixMs ?? 0
-        const currentTimestamp = current?.timestamps?.providerIndicatedTimeUnixMs ?? 0
-        const newReceivedTimestamp = next.timestamps?.providerDataReceivedUnixMs ?? 0
-        const currentReceivedTimestamp = current?.timestamps?.providerDataReceivedUnixMs ?? 0
-        const newData = JSON.stringify(next.data)
-        const currentData = JSON.stringify(current?.data)
-        return (
-          newTimestamp > currentTimestamp ||
-          (newTimestamp === currentTimestamp && newData === currentData) ||
-          (newTimestamp === currentTimestamp &&
-            newReceivedTimestamp > currentReceivedTimestamp + staleThreshold)
-        )
-      },
+      (next, current) =>
+        // Write if the incoming value has a newer provider timestamp
+        // Also writes if the local cache entry has gone stale in the underlying CompareResponseCache
+        (next.timestamps?.providerIndicatedTimeUnixMs ?? 0) >
+        (current?.timestamps?.providerIndicatedTimeUnixMs ?? 0),
+      staleThreshold,
     )
 
     await Promise.all(

--- a/test/cache/response-cache/compare.test.ts
+++ b/test/cache/response-cache/compare.test.ts
@@ -101,4 +101,3 @@ test('shouldUpdate checks the backing cache when no prior write through compareC
   await compareCache.write('merged', [providerResult(params, 25)])
   t.is((await compareCache.get(compareCache.getCacheKey('merged', params)))?.result, 100)
 })
-

--- a/test/cache/response-cache/compare.test.ts
+++ b/test/cache/response-cache/compare.test.ts
@@ -97,7 +97,7 @@ test('shouldUpdate checks the backing cache when no prior write through compareC
   await simpleCache.write('merged', [providerResult(params, 100)])
   t.is((await compareCache.get(compareCache.getCacheKey('merged', params)))?.result, 100)
 
-  // shouldUpdate sees the backing cache value and blocks the lower write
+  // Sees the backing cache value and blocks the lower write
   await compareCache.write('merged', [providerResult(params, 25)])
   t.is((await compareCache.get(compareCache.getCacheKey('merged', params)))?.result, 100)
 })

--- a/test/cache/response-cache/compare.test.ts
+++ b/test/cache/response-cache/compare.test.ts
@@ -84,6 +84,32 @@ test('shouldUpdate can block write when new value is not fresher than cache', as
   t.is(compareCache.localCache.size, 1)
 })
 
+test('stale local entry allows write to bypass shouldUpdate result against Redis', async (t) => {
+  const simpleCache = buildSimpleCache()
+  const compareCache = new CompareResponseCache(
+    'merged',
+    simpleCache,
+    (next, current) => (next?.result || 0) > (current?.result || 0),
+    1000, // 1s staleThreshold
+  )
+
+  const params = { base: 'ETH', factor: 1 }
+
+  // Write value=100 through compareCache so the local map has an entry
+  await compareCache.write('merged', [providerResult(params, 100)])
+  t.is((await compareCache.get(compareCache.getCacheKey('merged', params)))?.result, 100)
+
+  // Manually expire the local map entry by backdating writtenAt
+  const key = compareCache.getCacheKey('merged', params)
+  const local = compareCache.localCache.get(key)!
+  compareCache.localCache.set(key, { ...local, writtenAt: local.writtenAt - 2000 })
+
+  // Value=25 would normally be blocked by shouldUpdate (25 < 100), but the local entry
+  // is stale so the Redis check is skipped and the write goes through
+  await compareCache.write('merged', [providerResult(params, 25)])
+  t.is((await compareCache.get(compareCache.getCacheKey('merged', params)))?.result, 25)
+})
+
 test('shouldUpdate can block write without old value in localCache', async (t) => {
   const simpleCache = buildSimpleCache()
 

--- a/test/cache/response-cache/compare.test.ts
+++ b/test/cache/response-cache/compare.test.ts
@@ -57,7 +57,7 @@ test('writes under CompareResponseCache transportName', async (t) => {
   t.is(entry?.meta?.transportName, 'ws')
 })
 
-test('second write override first write', async (t) => {
+test('second write overrides first write', async (t) => {
   const compareCache = new CompareResponseCache('merged', buildSimpleCache(), () => true)
 
   const params = { base: 'ETH', factor: 1 }
@@ -81,38 +81,10 @@ test('shouldUpdate can block write when new value is not fresher than cache', as
 
   await compareCache.write('merged', [providerResult(params, 25)])
   t.is((await compareCache.get(compareCache.getCacheKey('merged', params)))?.result, 50)
-  t.is(compareCache.localCache.size, 1)
 })
 
-test('stale local entry allows write to bypass shouldUpdate result against Redis', async (t) => {
+test('shouldUpdate checks the backing cache when no prior write through compareCache', async (t) => {
   const simpleCache = buildSimpleCache()
-  const compareCache = new CompareResponseCache(
-    'merged',
-    simpleCache,
-    (next, current) => (next?.result || 0) > (current?.result || 0),
-    1000, // 1s staleThreshold
-  )
-
-  const params = { base: 'ETH', factor: 1 }
-
-  // Write value=100 through compareCache so the local map has an entry
-  await compareCache.write('merged', [providerResult(params, 100)])
-  t.is((await compareCache.get(compareCache.getCacheKey('merged', params)))?.result, 100)
-
-  // Manually expire the local map entry by backdating writtenAt
-  const key = compareCache.getCacheKey('merged', params)
-  const local = compareCache.localCache.get(key)!
-  compareCache.localCache.set(key, { ...local, writtenAt: local.writtenAt - 2000 })
-
-  // Value=25 would normally be blocked by shouldUpdate (25 < 100), but the local entry
-  // is stale so the Redis check is skipped and the write goes through
-  await compareCache.write('merged', [providerResult(params, 25)])
-  t.is((await compareCache.get(compareCache.getCacheKey('merged', params)))?.result, 25)
-})
-
-test('shouldUpdate can block write without old value in localCache', async (t) => {
-  const simpleCache = buildSimpleCache()
-
   const compareCache = new CompareResponseCache(
     'merged',
     simpleCache,
@@ -121,10 +93,12 @@ test('shouldUpdate can block write without old value in localCache', async (t) =
 
   const params = { base: 'ETH', factor: 1 }
 
+  // Write directly to the backing cache, bypassing compareCache
   await simpleCache.write('merged', [providerResult(params, 100)])
   t.is((await compareCache.get(compareCache.getCacheKey('merged', params)))?.result, 100)
 
+  // shouldUpdate sees the backing cache value and blocks the lower write
   await compareCache.write('merged', [providerResult(params, 25)])
   t.is((await compareCache.get(compareCache.getCacheKey('merged', params)))?.result, 100)
-  t.is(compareCache.localCache.size, 0)
 })
+

--- a/test/transports/composite.test.ts
+++ b/test/transports/composite.test.ts
@@ -41,7 +41,7 @@ const axiosMock = new MockAdapter(axios)
 type CacheTestHttpTypes = CacheTestTransportTypes & {
   Provider: {
     RequestBody: unknown
-    ResponseBody: { result: number; ts?: number }
+    ResponseBody: { result: number; ts?: number; received?: number }
   }
 }
 
@@ -60,7 +60,10 @@ class CountingCacheHttpTransport extends HttpTransport<CacheTestHttpTypes> {
             params: { base: p.base, factor: p.factor },
           },
         })),
-      parseResponse: (params, res: AxiosResponse<{ result: number; ts?: number }>) =>
+      parseResponse: (
+        params,
+        res: AxiosResponse<{ result: number; ts?: number; received?: number }>,
+      ) =>
         params.map((p) => ({
           params: p,
           response: {
@@ -68,7 +71,7 @@ class CountingCacheHttpTransport extends HttpTransport<CacheTestHttpTypes> {
             result: res.data.result,
             timestamps: {
               providerDataRequestedUnixMs: 0,
-              providerDataReceivedUnixMs: 0,
+              providerDataReceivedUnixMs: res.data.received ?? 0,
               providerIndicatedTimeUnixMs: res.data.ts ?? 1,
             },
           },
@@ -140,7 +143,7 @@ test.serial(
 )
 
 test.serial(
-  'composite transport merges child writes by providerIndicatedTimeUnixMs when run under an adapter',
+  'composite transport merges child writes by providerIndicatedTimeUnixMs when run under an adapter, takes newest timestamped value',
   async (t) => {
     axiosMock
       .onGet(`${WS_PROVIDER}/price`, { params: { base: 'BTC', factor: 3 } })
@@ -158,6 +161,50 @@ test.serial(
     t.is(res.json().result, 100)
     t.is(t.context.ws.registerRequestCalls, 1)
     t.is(t.context.rest.registerRequestCalls, 1)
+  },
+)
+
+test.serial(
+  'composite transport refreshes TTL when both transports return same value at same timestamp',
+  async (t) => {
+    axiosMock
+      .onGet(`${WS_PROVIDER}/price`, { params: { base: 'XRP', factor: 1 } })
+      .reply(200, { result: 42, ts: 100 })
+    axiosMock
+      .onGet(`${REST_PROVIDER}/price`, { params: { base: 'XRP', factor: 1 } })
+      .reply(200, { result: 42, ts: 100 })
+
+    const res = await t.context.testAdapter.request({ base: 'XRP', factor: 1 })
+
+    // How to test whether the params were refreshed in the cache?
+    // we can check that the response is correct and then check that the ws transport was called again
+    // on a subsequent request, indicating that the cache entry was refreshed and the ws transport was used again instead of the rest transport
+
+    t.is(res.statusCode, 200)
+    t.is(res.json().result, 42)
+  },
+)
+
+test.serial(
+  'composite transport does not rubberband when transports return conflicting values at same timestamp',
+  async (t) => {
+    // Send first request
+    axiosMock
+      .onGet(`${WS_PROVIDER}/price`, { params: { base: 'ABC', factor: 1 } })
+      .reply(200, { result: 10, ts: 200 })
+
+    const res = await t.context.testAdapter.request({ base: 'ABC', factor: 1 })
+    t.is(res.statusCode, 200)
+    t.is(res.json().result, 10)
+
+    // Send second request with same timestamp but different value
+    axiosMock
+      .onGet(`${REST_PROVIDER}/price`, { params: { base: 'ABC', factor: 1 } })
+      .reply(200, { result: 99, ts: 200 })
+
+    const res2 = await t.context.testAdapter.request({ base: 'ABC', factor: 1 })
+    t.is(res2.statusCode, 200)
+    t.is(res2.json().result, 10)
   },
 )
 
@@ -261,6 +308,58 @@ test.serial(
     t.is(res.json().result, 99)
     t.is(ws.registerRequestCalls, 0)
     t.is(rest.registerRequestCalls, 1)
+
+    await localAdapter.api.close()
+  },
+)
+
+test.serial(
+  'composite transport allows overwrite when current entry is stale despite same timestamp',
+  async (t) => {
+    const ws = new CountingCacheHttpTransport('ws', WS_PROVIDER)
+    const rest = new CountingCacheHttpTransport('rest', REST_PROVIDER)
+
+    const adapter = new Adapter({
+      name: 'TEST_STALENESS',
+      defaultEndpoint: 'test',
+      endpoints: [
+        new AdapterEndpoint({
+          name: 'test',
+          inputParameters: cacheTestInputParameters,
+          enableCompositeTransport: true,
+          transportRoutes: new TransportRoutes<CacheTestHttpTypes>()
+            .register('ws', ws)
+            .register('rest', rest),
+        }),
+      ],
+      config: new AdapterConfig(
+        {},
+        {
+          envDefaultOverrides: {
+            COMPOSITE_TRANSPORT: true,
+            COMPOSITE_TRANSPORT_STALE_THRESHOLD_MS: 1000,
+          },
+        },
+      ),
+    })
+
+    const localContext = { clock: t.context.clock } as typeof t.context
+    const localAdapter = await TestAdapter.start(adapter, localContext)
+
+    // WS writes first at ts=500, received=0
+    axiosMock
+      .onGet(`${WS_PROVIDER}/price`, { params: { base: 'NEAR', factor: 1 } })
+      .reply(200, { result: 10, ts: 500, received: 0 })
+    // REST writes at the same ts=500 but received=2000 (2s later, exceeding the 1000ms threshold)
+    // and a slightly different value due to rounding — should be allowed through
+    axiosMock
+      .onGet(`${REST_PROVIDER}/price`, { params: { base: 'NEAR', factor: 1 } })
+      .reply(200, { result: 11, ts: 500, received: 2000 })
+
+    const res = await localAdapter.request({ base: 'NEAR', factor: 1 })
+
+    t.is(res.statusCode, 200)
+    t.is(res.json().result, 11)
 
     await localAdapter.api.close()
   },

--- a/test/transports/composite.test.ts
+++ b/test/transports/composite.test.ts
@@ -41,7 +41,7 @@ const axiosMock = new MockAdapter(axios)
 type CacheTestHttpTypes = CacheTestTransportTypes & {
   Provider: {
     RequestBody: unknown
-    ResponseBody: { result: number; ts?: number; received?: number }
+    ResponseBody: { result: number; ts?: number }
   }
 }
 
@@ -62,7 +62,7 @@ class CountingCacheHttpTransport extends HttpTransport<CacheTestHttpTypes> {
         })),
       parseResponse: (
         params,
-        res: AxiosResponse<{ result: number; ts?: number; received?: number }>,
+        res: AxiosResponse<{ result: number; ts?: number }>,
       ) =>
         params.map((p) => ({
           params: p,
@@ -71,7 +71,7 @@ class CountingCacheHttpTransport extends HttpTransport<CacheTestHttpTypes> {
             result: res.data.result,
             timestamps: {
               providerDataRequestedUnixMs: 0,
-              providerDataReceivedUnixMs: res.data.received ?? 0,
+              providerDataReceivedUnixMs: 0,
               providerIndicatedTimeUnixMs: res.data.ts ?? 1,
             },
           },
@@ -313,57 +313,6 @@ test.serial(
   },
 )
 
-test.serial(
-  'composite transport allows overwrite when current entry is stale despite same timestamp',
-  async (t) => {
-    const ws = new CountingCacheHttpTransport('ws', WS_PROVIDER)
-    const rest = new CountingCacheHttpTransport('rest', REST_PROVIDER)
-
-    const adapter = new Adapter({
-      name: 'TEST_STALENESS',
-      defaultEndpoint: 'test',
-      endpoints: [
-        new AdapterEndpoint({
-          name: 'test',
-          inputParameters: cacheTestInputParameters,
-          enableCompositeTransport: true,
-          transportRoutes: new TransportRoutes<CacheTestHttpTypes>()
-            .register('ws', ws)
-            .register('rest', rest),
-        }),
-      ],
-      config: new AdapterConfig(
-        {},
-        {
-          envDefaultOverrides: {
-            COMPOSITE_TRANSPORT: true,
-            COMPOSITE_TRANSPORT_STALE_THRESHOLD_MS: 1000,
-          },
-        },
-      ),
-    })
-
-    const localContext = { clock: t.context.clock } as typeof t.context
-    const localAdapter = await TestAdapter.start(adapter, localContext)
-
-    // WS writes first at ts=500, received=0
-    axiosMock
-      .onGet(`${WS_PROVIDER}/price`, { params: { base: 'NEAR', factor: 1 } })
-      .reply(200, { result: 10, ts: 500, received: 0 })
-    // REST writes at the same ts=500 but received=2000 (2s later, exceeding the 1000ms threshold)
-    // and a slightly different value due to rounding — should be allowed through
-    axiosMock
-      .onGet(`${REST_PROVIDER}/price`, { params: { base: 'NEAR', factor: 1 } })
-      .reply(200, { result: 11, ts: 500, received: 2000 })
-
-    const res = await localAdapter.request({ base: 'NEAR', factor: 1 })
-
-    t.is(res.statusCode, 200)
-    t.is(res.json().result, 11)
-
-    await localAdapter.api.close()
-  },
-)
 
 test.serial(
   'AdapterEndpoint throws when enableCompositeTransport is true with only one transport',

--- a/test/transports/composite.test.ts
+++ b/test/transports/composite.test.ts
@@ -60,10 +60,7 @@ class CountingCacheHttpTransport extends HttpTransport<CacheTestHttpTypes> {
             params: { base: p.base, factor: p.factor },
           },
         })),
-      parseResponse: (
-        params,
-        res: AxiosResponse<{ result: number; ts?: number }>,
-      ) =>
+      parseResponse: (params, res: AxiosResponse<{ result: number; ts?: number }>) =>
         params.map((p) => ({
           params: p,
           response: {
@@ -312,7 +309,6 @@ test.serial(
     await localAdapter.api.close()
   },
 )
-
 
 test.serial(
   'AdapterEndpoint throws when enableCompositeTransport is true with only one transport',


### PR DESCRIPTION
https://smartcontract-it.atlassian.net/browse/OPDATA-6402

Updates comparison in CompositeTransport beyond strict new.timestamp > old.timestamp

New rules address:

1. new.timestamp > old.timestamp
2. refreshing cache TTL
3. same timestamp but different value received after a staleness threshold

Introduces `COMPOSITE_TRANSPORT_STALE_THRESHOLD_MS` setting var defaulted to `CACHE_MAX_AGE / 2` for point 3 above.