### PR TITLE
OPDATA-6579: Add getEnvVarName to variable env vars

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -532,6 +532,7 @@ type VariableEnvVarEntry<T extends ValidSettingValue> = {
 
 export interface Getter<T extends SettingValueType | undefined> {
   get(variable: string): T
+  getEnvVarName(variable: string): string
   entries(): VariableEnvVarEntry<Exclude<T, undefined>>[]
 }
 
@@ -593,8 +594,12 @@ export class EnvGetter<
     )
   }
 
+  private getCanonicalVariable(variable: string): string {
+    return variable.replace(/\W/g, '_').toUpperCase()
+  }
+
   get(variable: string): SettingType<T> {
-    const canonicalVariable = variable.replace(/\W/g, '_').toUpperCase()
+    const canonicalVariable = this.getCanonicalVariable(variable)
     if (canonicalVariable in this.variableMap) {
       return this.variableMap[canonicalVariable].value as SettingType<T>
     }
@@ -604,14 +609,21 @@ export class EnvGetter<
     if (!this.settingsDefinition.required) {
       return undefined as SettingType<T>
     }
-    const envName = getEnvName(
-      this.name.replace(this.settingsDefinition.variablePlaceholder, canonicalVariable),
-      this.prefix,
-    )
+    const envName = this.getEnvVarName(variable)
     throw new AdapterError({
       statusCode: 500,
       message: `Missing required environment variable: ${envName}`,
     })
+  }
+
+  getEnvVarName(variable: string): string {
+    return getEnvName(
+      this.name.replace(
+        this.settingsDefinition.variablePlaceholder,
+        this.getCanonicalVariable(variable),
+      ),
+      this.prefix,
+    )
   }
 
   entries(): VariableEnvVarEntry<SettingTypeWhenPresent<T>>[] {

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -526,6 +526,27 @@ test.serial('Get variable env var entries', async (t) => {
   ])
 })
 
+test.serial('Get variable env var name', async (t) => {
+  const envVarsPrefix = 'PREFIX'
+  const customSettings = {
+    NETWORK_NETWORK_TYPE: {
+      description: 'Network type for the given blockchain',
+      type: 'enum',
+      options: ['mainnet', 'testnet'],
+      variablePlaceholder: 'NETWORK',
+    },
+  } as const
+
+  const config = new AdapterConfig(customSettings, { envVarsPrefix })
+  config.initialize()
+  config.validate()
+  t.is(
+    config.settings.NETWORK_NETWORK_TYPE.getEnvVarName('ethereum'),
+    'PREFIX_ETHEREUM_NETWORK_TYPE',
+  )
+  t.is(config.settings.NETWORK_NETWORK_TYPE.getEnvVarName('a.b$c'), 'PREFIX_A_B_C_NETWORK_TYPE')
+})
+
 test.serial('Setting name must not have invalid characters', async (t) => {
   const customSettings = {
     'NETWORK-RPC-URL': {


### PR DESCRIPTION
https://smartcontract-it.atlassian.net/browse/OPDATA-6579

# Description

The framework has support for variable environment variables, such as `${NETWORK}_RPC_URL` where `${NETWORK}` can be determined at runtime.

Sometimes we do additional checks on the value of the variable in the EA and we want to give an error message. But in order to mention the correct env var name in the error message, we have to reconstruct it in the EA. For example [in generic-api](https://github.com/smartcontractkit/external-adapters-js/blob/d06be5efc359cea36bc5841880cba3daaaef887e/packages/sources/generic-api/src/config/index.ts#L50) or [in view-function-multi-chain](https://github.com/smartcontractkit/external-adapters-js/blob/d06be5efc359cea36bc5841880cba3daaaef887e/packages/sources/view-function-multi-chain/src/endpoint/function.ts#L63).

To make this more convenient, we should provide a way to get the variable name from the framework.

# Change

Add `getEnvVarName()` which returns the name of an environment variable for a given config variable and placeholder variable.

# Testing

1. Unit test added.
2. Tested locally with `nav-generic` in `external-adapters-js`.