### PR TITLE
[TEMP] Test: setup-node v7 + remove registry-url

### DIFF
--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -3,7 +3,7 @@ description: 'Sets up the project, installs dependencies, caches results'
 runs:
   using: 'composite'
   steps:
-    - uses: actions/setup-node@v6
+    - uses: actions/setup-node@v7
       with:
         node-version: 24.18
         registry-url: https://registry.npmjs.org

--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -6,8 +6,6 @@ runs:
     - uses: actions/setup-node@v7
       with:
         node-version: 24.18
-        registry-url: https://registry.npmjs.org
-        always-auth: true
         cache: yarn
     - run: corepack enable
       shell: bash


### PR DESCRIPTION
Temporary draft to validate that setup-node@v7 + removing the unused `registry-url`/`always-auth` inputs makes CI green. Will be closed; the fix will land as a standalone PR against v6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)