### PR TITLE
Remove unused registry-url/always-auth from setup action

### DIFF
--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -6,8 +6,6 @@ runs:
     - uses: actions/setup-node@v6
       with:
         node-version: 24.18
-        registry-url: https://registry.npmjs.org
-        always-auth: true
         cache: yarn
     - run: corepack enable
       shell: bash


### PR DESCRIPTION
🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary
- Removes the unused `registry-url` and `always-auth` inputs from `actions/setup-node` in the shared setup action. Auth was never needed: installs use the public yarn registry, and publishing uses OIDC trusted publishing (npm publish), not `NODE_AUTH_TOKEN`.
- These inputs are also what breaks `actions/setup-node@v7` (#856): setting `registry-url` makes setup-node write a `${NODE_AUTH_TOKEN}` placeholder to `.npmrc`, which `yarn cache dir` then fails to resolve since the token is never set. Removing them unblocks the v7 bump without needing any v7-specific change.
- Verified on a temporary draft PR (#858) with `actions/setup-node@v7` + this fix — CI passed.

## Test plan
- [x] CI passes on this PR (v6 + fix)
- [x] Verified v7 + fix passes on temporary draft PR #858

