### PR TITLE
feat(util): add validateResultNumber helper

### DIFF
--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -1,4 +1,5 @@
 export * from './logger'
+export * from './result-number'
 export * from './subscription-set/subscription-set'
 export * from './types'
 

--- a/src/util/result-number.ts
+++ b/src/util/result-number.ts
@@ -19,13 +19,6 @@ export interface ValidateResultNumberOptions {
 }
 
 /**
- * Type guard for the error branch of ValidatedResultNumber.
- */
-export const isProviderError = (
-  v: ValidatedResultNumber,
-): v is { statusCode: 502; errorMessage: string } => 'statusCode' in v
-
-/**
  * Validates that a raw value from a data provider is a usable numeric result.
  *
  * The raw value is checked BEFORE any Number() coercion so that null/undefined
@@ -56,7 +49,7 @@ export function validateResultNumber(
     isWrongType || trimmed === '' || !Number.isFinite(num) || (!acceptZeroValue && num === 0)
 
   if (isInvalid) {
-    logger.warn(`${errorMessage} (received: ${JSON.stringify(value)})`)
+    logger.warn({ received: value }, errorMessage)
     return { statusCode: 502, errorMessage }
   }
 

--- a/src/util/result-number.ts
+++ b/src/util/result-number.ts
@@ -37,16 +37,6 @@ export const isProviderError = (
  * the response cache and reaches the Node as a 502. Throwing inside
  * HttpTransport.parseResponse would fall into a generic catch and be dropped.
  *
- * | input            | output           |
- * |------------------|------------------|
- * | null, undefined  | 502              |
- * | NaN, "NaN"       | 502              |
- * | "", "   "        | 502              |
- * | {}, [], booleans | 502              |
- * | +/-Infinity      | 502              |
- * | 12.3, "12.3"     | { result: 12.3 } |
- * | 0, "0"           | { result: 0 }    | (default; see acceptZeroValue)
- *
  * @param value - the raw, uncoerced value from the provider response
  * @param errorMessage - message returned to the caller when the value is invalid
  * @param options - see ValidateResultNumberOptions

--- a/src/util/result-number.ts
+++ b/src/util/result-number.ts
@@ -1,0 +1,74 @@
+import { makeLogger } from './logger'
+
+const logger = makeLogger('ResultNumberValidation')
+
+/**
+ * Result of validating a numeric value from a data provider.
+ * Either the coerced, validated number, or a provider error response
+ * (statusCode 502) that can be returned directly as a ProviderResult response.
+ */
+export type ValidatedResultNumber = { result: number } | { statusCode: 502; errorMessage: string }
+
+export interface ValidateResultNumberOptions {
+  /**
+   * Whether 0 should be treated as a valid result.
+   * Defaults to true (funding rates, realized volatility, yields can legitimately be 0).
+   * Set to false for feeds where 0 always indicates missing/invalid data.
+   */
+  acceptZeroValue?: boolean
+}
+
+/**
+ * Type guard for the error branch of ValidatedResultNumber.
+ */
+export const isProviderError = (
+  v: ValidatedResultNumber,
+): v is { statusCode: 502; errorMessage: string } => 'statusCode' in v
+
+/**
+ * Validates that a raw value from a data provider is a usable numeric result.
+ *
+ * The raw value is checked BEFORE any Number() coercion so that null/undefined
+ * cannot silently become 0 (Number(null) === 0). Invalid values produce a 502
+ * error response, allowing the Node to fall back to the bridge cache (last
+ * known good value).
+ *
+ * Never throws: transports must RETURN the error object so it flows through
+ * the response cache and reaches the Node as a 502. Throwing inside
+ * HttpTransport.parseResponse would fall into a generic catch and be dropped.
+ *
+ * | input            | output           |
+ * |------------------|------------------|
+ * | null, undefined  | 502              |
+ * | NaN, "NaN"       | 502              |
+ * | "", "   "        | 502              |
+ * | {}, [], booleans | 502              |
+ * | +/-Infinity      | 502              |
+ * | 12.3, "12.3"     | { result: 12.3 } |
+ * | 0, "0"           | { result: 0 }    | (default; see acceptZeroValue)
+ *
+ * @param value - the raw, uncoerced value from the provider response
+ * @param errorMessage - message returned to the caller when the value is invalid
+ * @param options - see ValidateResultNumberOptions
+ */
+export function validateResultNumber(
+  value: unknown,
+  errorMessage: string,
+  options?: ValidateResultNumberOptions,
+): ValidatedResultNumber {
+  const acceptZeroValue = options?.acceptZeroValue ?? true
+
+  const isWrongType = typeof value !== 'number' && typeof value !== 'string'
+  const trimmed = typeof value === 'string' ? value.trim() : value
+  const num = Number(trimmed)
+
+  const isInvalid =
+    isWrongType || trimmed === '' || !Number.isFinite(num) || (!acceptZeroValue && num === 0)
+
+  if (isInvalid) {
+    logger.warn(`${errorMessage} (received: ${JSON.stringify(value)})`)
+    return { statusCode: 502, errorMessage }
+  }
+
+  return { result: num }
+}

--- a/test/util/result-number.test.ts
+++ b/test/util/result-number.test.ts
@@ -1,0 +1,129 @@
+import test from 'ava'
+import { LoggerFactoryProvider } from '../../src/util/logger'
+import { isProviderError, validateResultNumber } from '../../src/util/result-number'
+
+test.before(() => {
+  LoggerFactoryProvider.set()
+})
+
+test('validateResultNumber returns a valid number for numeric input', (t) => {
+  t.deepEqual(validateResultNumber(123.45, 'error'), { result: 123.45 })
+})
+
+test('validateResultNumber coerces numeric strings to numbers', (t) => {
+  t.deepEqual(validateResultNumber('67.89', 'error'), { result: 67.89 })
+})
+
+test('validateResultNumber accepts 0 by default', (t) => {
+  t.deepEqual(validateResultNumber(0, 'error'), { result: 0 })
+  t.deepEqual(validateResultNumber('0', 'error'), { result: 0 })
+})
+
+test('validateResultNumber rejects 0 when acceptZeroValue is false', (t) => {
+  const result = validateResultNumber(0, 'error', { acceptZeroValue: false })
+  t.true(isProviderError(result))
+  if (isProviderError(result)) {
+    t.is(result.statusCode, 502)
+  }
+})
+
+test('validateResultNumber rejects null', (t) => {
+  const result = validateResultNumber(null, 'error')
+  t.true(isProviderError(result))
+  if (isProviderError(result)) {
+    t.is(result.statusCode, 502)
+  }
+})
+
+test('validateResultNumber rejects undefined', (t) => {
+  const result = validateResultNumber(undefined, 'error')
+  t.true(isProviderError(result))
+  if (isProviderError(result)) {
+    t.is(result.statusCode, 502)
+  }
+})
+
+test('validateResultNumber rejects NaN', (t) => {
+  const result = validateResultNumber(NaN, 'error')
+  t.true(isProviderError(result))
+  if (isProviderError(result)) {
+    t.is(result.statusCode, 502)
+  }
+})
+
+test('validateResultNumber rejects "NaN" string', (t) => {
+  const result = validateResultNumber('NaN', 'error')
+  t.true(isProviderError(result))
+  if (isProviderError(result)) {
+    t.is(result.statusCode, 502)
+  }
+})
+
+test('validateResultNumber rejects empty string', (t) => {
+  const result = validateResultNumber('', 'error')
+  t.true(isProviderError(result))
+  if (isProviderError(result)) {
+    t.is(result.statusCode, 502)
+  }
+})
+
+test('validateResultNumber rejects whitespace-only string', (t) => {
+  const result = validateResultNumber('   ', 'error')
+  t.true(isProviderError(result))
+  if (isProviderError(result)) {
+    t.is(result.statusCode, 502)
+  }
+})
+
+test('validateResultNumber rejects objects', (t) => {
+  const result = validateResultNumber({ value: 123 }, 'error')
+  t.true(isProviderError(result))
+  if (isProviderError(result)) {
+    t.is(result.statusCode, 502)
+  }
+})
+
+test('validateResultNumber rejects arrays', (t) => {
+  const result = validateResultNumber([123], 'error')
+  t.true(isProviderError(result))
+  if (isProviderError(result)) {
+    t.is(result.statusCode, 502)
+  }
+})
+
+test('validateResultNumber rejects booleans', (t) => {
+  const result = validateResultNumber(true, 'error')
+  t.true(isProviderError(result))
+  if (isProviderError(result)) {
+    t.is(result.statusCode, 502)
+  }
+})
+
+test('validateResultNumber rejects Infinity', (t) => {
+  const result = validateResultNumber(Infinity, 'error')
+  t.true(isProviderError(result))
+  if (isProviderError(result)) {
+    t.is(result.statusCode, 502)
+  }
+})
+
+test('validateResultNumber rejects -Infinity', (t) => {
+  const result = validateResultNumber(-Infinity, 'error')
+  t.true(isProviderError(result))
+  if (isProviderError(result)) {
+    t.is(result.statusCode, 502)
+  }
+})
+
+test('validateResultNumber preserves the provided error message', (t) => {
+  const result = validateResultNumber(null, 'custom error message')
+  t.true(isProviderError(result))
+  if (isProviderError(result)) {
+    t.is(result.errorMessage, 'custom error message')
+  }
+})
+
+test('isProviderError returns false for a valid result', (t) => {
+  const result = validateResultNumber(123, 'error')
+  t.false(isProviderError(result))
+})

--- a/test/util/result-number.test.ts
+++ b/test/util/result-number.test.ts
@@ -1,6 +1,10 @@
 import test from 'ava'
 import { LoggerFactoryProvider } from '../../src/util/logger'
-import { isProviderError, validateResultNumber } from '../../src/util/result-number'
+import { validateResultNumber, ValidatedResultNumber } from '../../src/util/result-number'
+
+const isProviderError = (
+  v: ValidatedResultNumber,
+): v is { statusCode: 502; errorMessage: string } => 'statusCode' in v
 
 test.before(() => {
   LoggerFactoryProvider.set()


### PR DESCRIPTION
Adds a reusable helper to validate numeric provider results before coercion, returning a structured 502 error for null/undefined/NaN/empty/objects/arrays/booleans/Infinity. Includes behavior-table unit tests.