### PR TITLE
refactor(adapter): remove read-path LWBA validation from LwbaEndpoint

### DIFF
--- a/src/adapter/lwba.ts
+++ b/src/adapter/lwba.ts
@@ -1,6 +1,5 @@
 import { TransportGenerics } from '../transports'
 import { TimestampedProviderResult } from '../util'
-import { AdapterLWBAError } from '../validation/error'
 import { AdapterEndpoint } from './endpoint'
 import { AdapterEndpointParams, PriceEndpointInputParametersDefinition } from './index'
 
@@ -69,30 +68,6 @@ export class LwbaEndpoint<T extends LwbaEndpointGenerics> extends AdapterEndpoin
       if (params.name !== alias && !params.aliases.includes(alias)) {
         params.aliases.push(alias)
       }
-    }
-
-    // Also validate on the response path for backwards compatibility with custom transports
-    // that return responses directly from foregroundExecute.
-    const existingValidation = params.customOutputValidation
-    params.customOutputValidation = (output) => {
-      if (existingValidation) {
-        const result = existingValidation(output)
-        if (result !== undefined) {
-          return result
-        }
-      }
-
-      if (output.statusCode !== 200) {
-        return undefined
-      }
-
-      const data = output.data as LwbaResponseDataFields['Data']
-      const error = validateLwbaResponse(data.bid, data.mid, data.ask)
-      if (error) {
-        throw new AdapterLWBAError({ statusCode: 500, message: error })
-      }
-
-      return undefined
     }
 
     super(params)

--- a/test/lwba.test.ts
+++ b/test/lwba.test.ts
@@ -1,106 +1,27 @@
-import { NopTransport, TestAdapter } from '../src/util/testing-utils'
-import untypedTest, { ExecutionContext, TestFn } from 'ava'
+import { NopTransport } from '../src/util/testing-utils'
+import test from 'ava'
 import { InputParameters } from '../src/validation'
 import {
   DEFAULT_LWBA_ALIASES,
-  IncludesFile,
   LwbaEndpoint,
   LwbaEndpointGenerics,
-  LwbaEndpointInputParametersDefinition,
-  LwbaResponseDataFields,
-  PriceAdapter,
-  PriceEndpoint,
-  PriceEndpointInputParametersDefinition,
   lwbaEndpointInputParametersDefinition,
-  priceEndpointInputParametersDefinition,
 } from '../src/adapter'
-import {
-  AdapterRequest,
-  AdapterResponse,
-  TimestampedProviderErrorResponse,
-  TimestampedProviderResult,
-} from '../src/util'
-import { EmptyCustomSettings } from '../src/config'
-import { TypeFromDefinition } from '../src/validation/input-params'
-import { Transport } from '../src/transports'
-import { ResponseCache } from '../src/cache/response'
+import { TimestampedProviderErrorResponse, TimestampedProviderResult } from '../src/util'
 
-type TestContext = {
-  testAdapter: TestAdapter
-}
-const test = untypedTest as TestFn<TestContext>
+type LwbaResultValidator = (
+  result: TimestampedProviderResult<LwbaEndpointGenerics>,
+) => TimestampedProviderResult<LwbaEndpointGenerics>
 
-type LWBATestTypes = {
-  Parameters: LwbaEndpointInputParametersDefinition
-  Response: LwbaResponseDataFields
-  Settings: EmptyCustomSettings
-}
+const getResultValidator = (endpoint: LwbaEndpoint<LwbaEndpointGenerics>): LwbaResultValidator =>
+  (endpoint as unknown as { resultValidator: LwbaResultValidator }).resultValidator
 
-class LWBATestTransport implements Transport<LWBATestTypes> {
-  name!: string
-  responseCache!: ResponseCache<LWBATestTypes>
-
-  constructor(
-    private mockResponse: (
-      req: AdapterRequest<TypeFromDefinition<LwbaEndpointInputParametersDefinition>>,
-    ) => AdapterResponse<LWBATestTypes['Response']>,
-  ) {}
-
-  async initialize(): Promise<void> {
-    return
-  }
-
-  async foregroundExecute(
-    req: AdapterRequest<TypeFromDefinition<LwbaEndpointInputParametersDefinition>>,
-  ): Promise<void | AdapterResponse<LWBATestTypes['Response']>> {
-    return this.mockResponse(req)
-  }
-}
-
-type PriceTestTypes = {
-  Parameters: PriceEndpointInputParametersDefinition
-  Response: {
-    Data: { result: number }
-    Result: number
-  }
-  Settings: EmptyCustomSettings
-}
-
-class PriceTestTransport implements Transport<PriceTestTypes> {
-  name!: string
-  responseCache!: ResponseCache<PriceTestTypes>
-  async initialize(): Promise<void> {
-    return
-  }
-}
-
-export const buildAdapter = async (
-  context: ExecutionContext<TestContext>['context'],
-  mockResponse: (
-    req: AdapterRequest<TypeFromDefinition<LwbaEndpointInputParametersDefinition>>,
-  ) => AdapterResponse<LWBATestTypes['Response']>,
-  includes?: IncludesFile,
-) => {
-  const adapter = new PriceAdapter({
-    name: 'TEST',
-    endpoints: [
-      new PriceEndpoint({
-        name: 'test',
-        inputParameters: new InputParameters(priceEndpointInputParametersDefinition),
-        transport: new PriceTestTransport(),
-      }),
-      new LwbaEndpoint({
-        name: 'lwba_test',
-        inputParameters: new InputParameters(lwbaEndpointInputParametersDefinition),
-        transport: new LWBATestTransport(mockResponse),
-      }),
-    ],
-    includes,
-  })
-
-  context.testAdapter = await TestAdapter.start(adapter, context)
-  return context.testAdapter
-}
+const buildLwbaEndpoint = () =>
+  new LwbaEndpoint({
+    name: 'lwba_test',
+    inputParameters: new InputParameters(lwbaEndpointInputParametersDefinition),
+    transport: new NopTransport(),
+  }) as LwbaEndpoint<LwbaEndpointGenerics>
 
 test('lwba price endpoint has common aliases', async (t) => {
   const lwbaEndpoint = new LwbaEndpoint({
@@ -112,56 +33,35 @@ test('lwba price endpoint has common aliases', async (t) => {
   t.deepEqual(lwbaEndpoint.aliases, DEFAULT_LWBA_ALIASES)
 })
 
-test('Successful response passes LWBA validation', async (t) => {
-  const mockResponse: AdapterResponse<LWBATestTypes['Response']> = {
-    result: null,
-    data: {
-      bid: 123.1,
-      mid: 123.2,
-      ask: 123.3,
-    },
-    statusCode: 200,
-    timestamps: {
-      providerDataRequestedUnixMs: 0,
-      providerDataReceivedUnixMs: 0,
-      providerIndicatedTimeUnixMs: undefined,
-    },
-  }
+test('Valid LWBA response passes validation via resultValidator', (t) => {
+  const lwbaEndpoint = buildLwbaEndpoint()
 
-  const testAdapter = await buildAdapter(t.context, (req) => {
-    t.deepEqual(req.requestContext.data, {
-      base: 'BTC',
-      quote: 'USD',
-    })
-
-    return mockResponse
+  const result = getResultValidator(lwbaEndpoint)({
+    params: { base: 'BTC', quote: 'USD' },
+    response: {
+      result: null,
+      data: {
+        bid: 123.1,
+        mid: 123.2,
+        ask: 123.3,
+      },
+      timestamps: {
+        providerDataRequestedUnixMs: 0,
+        providerDataReceivedUnixMs: 0,
+        providerIndicatedTimeUnixMs: undefined,
+      },
+    },
   })
 
-  const response = await testAdapter.request({
-    base: 'BTC',
-    quote: 'USD',
-    endpoint: 'lwba_test',
+  t.deepEqual(result.response.data, {
+    bid: 123.1,
+    mid: 123.2,
+    ask: 123.3,
   })
-
-  t.is(response.statusCode, 200)
-  t.is(response.json().data.bid, 123.1)
-  t.is(response.json().data.mid, 123.2)
-  t.is(response.json().data.ask, 123.3)
 })
 
-type LwbaResultValidator = (
-  result: TimestampedProviderResult<LwbaEndpointGenerics>,
-) => TimestampedProviderResult<LwbaEndpointGenerics>
-
-const getResultValidator = (endpoint: LwbaEndpoint<LwbaEndpointGenerics>): LwbaResultValidator =>
-  (endpoint as unknown as { resultValidator: LwbaResultValidator }).resultValidator
-
 test('Invariant violation fails LWBA validation via resultValidator (bid <= mid <= ask)', (t) => {
-  const lwbaEndpoint = new LwbaEndpoint({
-    name: 'lwba_test',
-    inputParameters: new InputParameters(lwbaEndpointInputParametersDefinition),
-    transport: new NopTransport(),
-  }) as LwbaEndpoint<LwbaEndpointGenerics>
+  const lwbaEndpoint = buildLwbaEndpoint()
 
   const result = getResultValidator(lwbaEndpoint)({
     params: { base: 'BTC', quote: 'USD' },
@@ -190,11 +90,7 @@ test('Invariant violation fails LWBA validation via resultValidator (bid <= mid 
 })
 
 test('Invariant violation fails LWBA validation via resultValidator (bid, mid or ask not found)', (t) => {
-  const lwbaEndpoint = new LwbaEndpoint({
-    name: 'lwba_test',
-    inputParameters: new InputParameters(lwbaEndpointInputParametersDefinition),
-    transport: new NopTransport(),
-  }) as LwbaEndpoint<LwbaEndpointGenerics>
+  const lwbaEndpoint = buildLwbaEndpoint()
 
   const result = getResultValidator(lwbaEndpoint)({
     params: { base: 'BTC', quote: 'USD' },


### PR DESCRIPTION
Follow-up to #876.

Removes the read-path LWBA validation that was added to LwbaEndpoint for backwards compatibility with custom transports using foregroundExecute. No production adapter uses that pattern, so the validation can live solely in the cache-level resultValidator.

Changes:
- Removed customOutputValidation wrapping from LwbaEndpoint.
- Removed AdapterLWBAError import from lwba.ts.
- Simplified test/lwba.test.ts to exercise validation through resultValidator only.

All lwba tests pass.