### PR TITLE
DF-24268 Cover bigint conversion in log censoring

### DIFF
--- a/src/util/logger.ts
+++ b/src/util/logger.ts
@@ -221,18 +221,18 @@ export function censor(obj: any, censorList: CensorKeyValue[], throwOnError = fa
   try {
     // JSON.stringify(obj) will fail if obj contains a circular reference or a bigint.
     stringified = JSON.stringify(obj)
-  } catch (e) {
+  } catch {
     try {
       // Retry with a bigint-safe replacer in case the failure was due to a bigint value.
       // JSON.stringify with a replacer function is slower, so we only pay that cost when
       // the fast path above actually fails, rather than on every call.
-      stringified = JSON.stringify(obj, (_key, value) =>
-        typeof value === 'bigint' ? value.toString() : value,
-      )
-    } catch (e2) {
+      stringified = JSON.stringify(obj, (_key, value) => {
+        return typeof value === 'bigint' ? value.toString() : value
+      })
+    } catch (e) {
       // Still fails (e.g. a genuine circular reference) - fall back to "[Unknown]".
       if (throwOnError) {
-        throw e2
+        throw e
       }
       return '[Unknown]'
     }

--- a/src/util/logger.ts
+++ b/src/util/logger.ts
@@ -219,14 +219,23 @@ export const loggingContextMiddleware = (
 export function censor(obj: any, censorList: CensorKeyValue[], throwOnError = false) {
   let stringified: string | undefined
   try {
-    // JSON.stringify(obj) will fail if obj contains a circular reference.
-    // If it fails, we fall back to replacing it with "[Unknown]".
+    // JSON.stringify(obj) will fail if obj contains a circular reference or a bigint.
     stringified = JSON.stringify(obj)
   } catch (e) {
-    if (throwOnError) {
-      throw e
+    try {
+      // Retry with a bigint-safe replacer in case the failure was due to a bigint value.
+      // JSON.stringify with a replacer function is slower, so we only pay that cost when
+      // the fast path above actually fails, rather than on every call.
+      stringified = JSON.stringify(obj, (_key, value) =>
+        typeof value === 'bigint' ? value.toString() : value,
+      )
+    } catch (e2) {
+      // Still fails (e.g. a genuine circular reference) - fall back to "[Unknown]".
+      if (throwOnError) {
+        throw e2
+      }
+      return '[Unknown]'
     }
-    return '[Unknown]'
   }
 
   if (typeof stringified !== 'string') {

--- a/test/logger.test.ts
+++ b/test/logger.test.ts
@@ -119,3 +119,13 @@ test('properly handle circular references', async (t) => {
   const log = censor(a, CensorList.getAll())
   t.is(log, '[Unknown]')
 })
+
+test('properly handle bigint values', async (t) => {
+  const log = censor({ value: 123n }, CensorList.getAll())
+  t.deepEqual(log, { value: '123' })
+})
+
+test('properly handle nested bigint values', async (t) => {
+  const log = censor({ apiKey: 'mock-api-key', tx: { gasLimit: 21000n } }, CensorList.getAll())
+  t.deepEqual(log, { apiKey: '[API_KEY REDACTED]', tx: { gasLimit: '21000' } })
+})


### PR DESCRIPTION
Some EAs currently see [Unknown] issues from trying to log objects with bigints, and JSON serialization fails. Since logs pass through the censoring method here, we can apply handling for this case in particular in there. We default to trying to serialize normally first, since that path will drop to the native JSON serializer impl which is much faster than the JS level one.