### PR TITLE
Support customInputValidation for MarketStatusEndpoint

### DIFF
--- a/src/adapter/market-status.ts
+++ b/src/adapter/market-status.ts
@@ -73,7 +73,8 @@ export class MarketStatusEndpoint<
   T extends MarketStatusEndpointGenerics,
 > extends AdapterEndpoint<T> {
   constructor(params: AdapterEndpointParams<T>) {
-    params.customInputValidation = (req, _adapterSettings) => {
+    const originalCustomInputValidation = params.customInputValidation
+    params.customInputValidation = (req, adapterSettings) => {
       const data = req.requestContext.data as Record<string, string>
       if (data['type'] === '24/5') {
         parseWeekendString(data['weekend'])
@@ -84,7 +85,7 @@ export class MarketStatusEndpoint<
           message: '[Param: weekend] must be empty when [Param: type] is regular',
         })
       }
-      return undefined
+      return originalCustomInputValidation?.(req, adapterSettings)
     }
     super(params)
   }

--- a/test/adapter/market-status.test.ts
+++ b/test/adapter/market-status.test.ts
@@ -186,7 +186,11 @@ test('MarketStatusEndpoint - with custom input validation', async (t) => {
   })
   t.is(response4.statusCode, 200, 'Should succeed with valid weekend when type is 24/5')
 
-  t.is(customValidationCallCount, 2, 'Custom validation is only called when built-in validation passes')
+  t.is(
+    customValidationCallCount,
+    2,
+    'Custom validation is only called when built-in validation passes',
+  )
 
   await testAdapter.api.close()
 })

--- a/test/adapter/market-status.test.ts
+++ b/test/adapter/market-status.test.ts
@@ -186,7 +186,7 @@ test('MarketStatusEndpoint - with custom input validation', async (t) => {
   })
   t.is(response4.statusCode, 200, 'Should succeed with valid weekend when type is 24/5')
 
-  t.is(customValidationCallCount, 4, 'Custom validation should be called for each request')
+  t.is(customValidationCallCount, 2, 'Custom validation is only called when built-in validation passes')
 
   await testAdapter.api.close()
 })

--- a/test/adapter/market-status.test.ts
+++ b/test/adapter/market-status.test.ts
@@ -93,3 +93,100 @@ test('MarketStatusEndpoint - validates weekend', async (t) => {
 
   await testAdapter.api.close()
 })
+
+test('MarketStatusEndpoint - with custom input validation', async (t) => {
+  class MarketStatusTestTransport implements Transport<MarketStatusEndpointGenerics> {
+    name!: string
+    responseCache!: ResponseCache<MarketStatusEndpointGenerics>
+
+    async initialize() {}
+
+    async foregroundExecute() {
+      return {
+        data: {
+          result: 2,
+          statusString: 'OPEN',
+        },
+        result: 2,
+        statusCode: 200,
+        timestamps: {
+          providerDataRequestedUnixMs: 0,
+          providerDataReceivedUnixMs: 0,
+          providerIndicatedTimeUnixMs: 0,
+        },
+      }
+    }
+  }
+
+  let customValidationCallCount = 0
+
+  const adapter = new Adapter({
+    name: 'TEST',
+    endpoints: [
+      new MarketStatusEndpoint({
+        name: 'test',
+        inputParameters: new InputParameters(marketStatusEndpointInputParametersDefinition),
+        transport: new MarketStatusTestTransport(),
+        customInputValidation: (request, settings) => {
+          const params = request.requestContext.data
+          // Check that the arguments have the expected shape.
+          t.is(['regular', '24/5'].includes(params.type), true)
+          t.is(settings.BACKGROUND_EXECUTE_TIMEOUT, 90000)
+          customValidationCallCount += 1
+          return undefined
+        },
+      }),
+    ],
+  })
+
+  const testAdapter = await TestAdapter.start(
+    adapter,
+    {} as {
+      testAdapter: TestAdapter
+    },
+  )
+
+  // When we specify customInputValidation, the built-in validation should
+  // still be applied as well.
+
+  const response1 = await testAdapter.request({
+    market: 'BTC',
+    type: 'regular',
+    endpoint: 'test',
+  })
+  t.is(response1.statusCode, 200, 'Should succeed with empty weekend when type is regular')
+
+  const response2 = await testAdapter.request({
+    market: 'BTC',
+    type: 'regular',
+    weekend: '520-020',
+    endpoint: 'test',
+  })
+  t.is(response2.statusCode, 400, 'Should fail with weekend when type is regular')
+  t.true(
+    response2
+      .json()
+      .error.message.includes('[Param: weekend] must be empty when [Param: type] is regular'),
+  )
+
+  const response3 = await testAdapter.request({
+    market: 'BTC',
+    type: '24/5',
+    weekend: '520-020',
+    endpoint: 'test',
+  })
+  t.is(response3.statusCode, 400, 'Should fail with invalid weekend format when type is 24/5')
+  t.true(response3.json().error.message.includes('[Param: weekend] does not match format'))
+
+  const response4 = await testAdapter.request({
+    market: 'BTC',
+    type: '24/5',
+    weekend: '520-020:America/New_York',
+    endpoint: 'test',
+  })
+  t.is(response4.statusCode, 200, 'Should succeed with valid weekend when type is 24/5')
+
+  t.is(customValidationCallCount, 4, 'Custom validation should be called for each request')
+
+  await testAdapter.api.close()
+})


### PR DESCRIPTION
https://smartcontract-it.atlassian.net/browse/OPDATA-8204

# Description

`MarketStatusEndpoin` overrides `customInputValidation` with its own validation.
This means that if the user also specified `customInputValidation`, this is silently discarded.

# Changes

1. Apply the original `customeInputValidation` after the overriding `customInputValidation`, if present.
2. Add a test with additional `customInputValidation`.